### PR TITLE
tunnel labels

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -265,8 +265,12 @@ class TunnelClient:
         self,
         tunnel_ids: Optional[list[str]] = None,
         labels: Optional[list[str]] = None,
+        team_id: Optional[str] = None,
     ) -> dict:
         """Bulk delete multiple tunnels by IDs or labels."""
+        if not tunnel_ids and not labels:
+            raise ValueError("Must specify either tunnel_ids or labels")
+
         self._check_auth_required()
 
         url = f"{self.base_url}/api/v1/tunnel"
@@ -275,6 +279,8 @@ class TunnelClient:
             payload["tunnel_ids"] = tunnel_ids
         if labels:
             payload["labels"] = labels
+        if team_id:
+            payload["teamId"] = team_id
 
         try:
             response = await self._idempotent_request_with_retry("DELETE", url, json=payload)

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -96,7 +96,7 @@ class TunnelClient:
         method: str,
         url: str,
         json: Optional[Dict[str, Any]] = None,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
         """Make async HTTP request with retry on transient connection errors.
 
@@ -117,7 +117,7 @@ class TunnelClient:
         method: str,
         url: str,
         json: Optional[Dict[str, Any]] = None,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
         """Make async HTTP request with retry on transient errors including timeouts.
 
@@ -270,6 +270,8 @@ class TunnelClient:
         """Bulk delete multiple tunnels by IDs or labels."""
         if not tunnel_ids and not labels:
             raise ValueError("Must specify either tunnel_ids or labels")
+        if tunnel_ids and labels:
+            raise ValueError("Cannot specify both tunnel_ids and labels")
 
         self._check_auth_required()
 

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -152,6 +152,7 @@ class TunnelClient:
         local_port: int,
         name: Optional[str] = None,
         team_id: Optional[str] = None,
+        labels: Optional[list[str]] = None,
     ) -> TunnelInfo:
         """
         Register a new tunnel with the backend.
@@ -160,6 +161,7 @@ class TunnelClient:
             local_port: Local port the tunnel will forward to
             name: Optional friendly name for the tunnel
             team_id: Optional team ID for team tunnels
+            labels: Optional labels for the tunnel
 
         Returns:
             TunnelInfo with connection details
@@ -179,6 +181,8 @@ class TunnelClient:
             payload["name"] = name
         if team_id:
             payload["teamId"] = team_id
+        if labels:
+            payload["labels"] = labels
 
         try:
             response = await self._request_with_retry("POST", url, json=payload)
@@ -226,6 +230,7 @@ class TunnelClient:
             server_host="",
             server_port=7000,
             expires_at=data["expires_at"],
+            labels=data.get("labels", []),
             user_id=data.get("user_id"),
         )
 
@@ -256,12 +261,20 @@ class TunnelClient:
         await self._handle_response(response, "delete tunnel")
         return True
 
-    async def bulk_delete_tunnels(self, tunnel_ids: list[str]) -> dict:
-        """Bulk delete multiple tunnels."""
+    async def bulk_delete_tunnels(
+        self,
+        tunnel_ids: Optional[list[str]] = None,
+        labels: Optional[list[str]] = None,
+    ) -> dict:
+        """Bulk delete multiple tunnels by IDs or labels."""
         self._check_auth_required()
 
         url = f"{self.base_url}/api/v1/tunnel"
-        payload = {"tunnel_ids": tunnel_ids}
+        payload: Dict[str, Any] = {}
+        if tunnel_ids:
+            payload["tunnel_ids"] = tunnel_ids
+        if labels:
+            payload["labels"] = labels
 
         try:
             response = await self._idempotent_request_with_retry("DELETE", url, json=payload)
@@ -272,12 +285,17 @@ class TunnelClient:
 
         return await self._handle_response(response, "bulk delete tunnels")
 
-    async def list_tunnels(self, team_id: Optional[str] = None) -> list[TunnelInfo]:
+    async def list_tunnels(
+        self,
+        team_id: Optional[str] = None,
+        labels: Optional[list[str]] = None,
+    ) -> list[TunnelInfo]:
         """
         List all tunnels for the current user.
 
         Args:
             team_id: Optional team ID to include team tunnels
+            labels: Optional labels to filter by (tunnels must have ALL specified labels)
 
         Returns:
             List of TunnelInfo objects
@@ -288,10 +306,14 @@ class TunnelClient:
             team_id = self.config.team_id
 
         url = f"{self.base_url}/api/v1/tunnel"
-        params = {"teamId": team_id} if team_id else None
+        params: Dict[str, Any] = {}
+        if team_id:
+            params["teamId"] = team_id
+        if labels:
+            params["labels"] = labels
 
         try:
-            response = await self._idempotent_request_with_retry("GET", url, params=params)
+            response = await self._idempotent_request_with_retry("GET", url, params=params or None)
         except httpx.TimeoutException as e:
             raise TunnelTimeoutError(f"Request timed out: {e}") from e
         except httpx.RequestError as e:
@@ -309,6 +331,7 @@ class TunnelClient:
                     server_host="",
                     server_port=7000,
                     expires_at=t["expires_at"],
+                    labels=t.get("labels", []),
                     user_id=t.get("user_id"),
                 )
             )

--- a/packages/prime-tunnel/src/prime_tunnel/core/client.py
+++ b/packages/prime-tunnel/src/prime_tunnel/core/client.py
@@ -273,6 +273,9 @@ class TunnelClient:
 
         self._check_auth_required()
 
+        if team_id is None:
+            team_id = self.config.team_id
+
         url = f"{self.base_url}/api/v1/tunnel"
         payload: Dict[str, Any] = {}
         if tunnel_ids:

--- a/packages/prime-tunnel/src/prime_tunnel/models.py
+++ b/packages/prime-tunnel/src/prime_tunnel/models.py
@@ -15,6 +15,7 @@ class TunnelInfo(BaseModel):
     server_host: str = Field(..., description="frps server hostname")
     server_port: int = Field(7000, description="frps server port")
     expires_at: datetime = Field(..., description="Token expiration time")
+    labels: list[str] = Field(default_factory=list, description="Tunnel labels")
     # Optional because create_tunnel response doesn't include user_id
     user_id: Optional[str] = Field(None, description="Owner user ID")
 

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -26,6 +26,7 @@ class Tunnel:
         connection_timeout: float = 30.0,
         log_level: str = "info",
         team_id: Optional[str] = None,
+        labels: Optional[list[str]] = None,
     ):
         """
         Initialize a tunnel.
@@ -37,11 +38,13 @@ class Tunnel:
             team_id: Optional team ID for team tunnels
             connection_timeout: Timeout for establishing connection (seconds)
             log_level: frpc log level (trace, debug, info, warn, error)
+            labels: Optional labels for the tunnel
         """
         self.local_port = local_port
         self.local_addr = local_addr
         self.name = name
         self.team_id = team_id
+        self.labels = labels
         self.connection_timeout = connection_timeout
         self.log_level = log_level
 
@@ -98,6 +101,7 @@ class Tunnel:
                 local_port=self.local_port,
                 name=self.name,
                 team_id=self.team_id,
+                labels=self.labels,
             )
         except BaseException as e:
             await self._cleanup()

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -184,7 +184,7 @@ def stop_tunnel(
     # Handle --label: delete by labels directly via API
     if label:
         confirmation_msg = (
-            f"Are you sure you want to stop all tunnels with labels {label}? "
+            f"Are you sure you want to stop all tunnels with labels {', '.join(label)}? "
             "This action cannot be undone."
         )
         if not confirm_or_skip(confirmation_msg, yes):
@@ -194,7 +194,7 @@ def stop_tunnel(
         async def delete_by_labels():
             client = TunnelClient()
             try:
-                return await client.bulk_delete_tunnels(labels=label)
+                return await client.bulk_delete_tunnels(labels=label, team_id=team_id)
             finally:
                 await client.close()
 
@@ -206,13 +206,30 @@ def stop_tunnel(
             raise typer.Exit(1)
 
         succeeded = result.get("succeeded", [])
-        message = result.get("message", "")
+        failed = result.get("failed", [])
+
+        if not succeeded and not failed:
+            console.print(
+                f"[yellow]No tunnels found matching labels {', '.join(label)}[/yellow]"
+            )
+            return
+
         if succeeded:
-            console.print(f"[green]{message}[/green]")
+            console.print(
+                f"[bold green]Successfully deleted {len(succeeded)} tunnel(s):[/bold green]"
+            )
             for tid in succeeded:
                 console.print(f"  ✓ {tid}")
-        else:
-            console.print(f"[yellow]No tunnels found matching labels {label}[/yellow]")
+
+        if failed:
+            console.print(
+                f"\n[bold red]Failed to delete {len(failed)} tunnel(s):[/bold red]"
+            )
+            for failure in failed:
+                tid = failure.get("tunnel_id", "unknown")
+                error = failure.get("error", "Unknown error")
+                console.print(f"  ✗ {tid}: {error}")
+            raise typer.Exit(1)
         return
 
     parsed_ids: List[str] = []

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -164,13 +164,13 @@ def stop_tunnel(
         True,
         "--only-mine/--all-users",
         "-m/-A",
-        help="Restrict '--all' deletes to only your tunnels",
+        help="Restrict '--all' and '--label' deletes to only your tunnels",
         show_default=True,
     ),
 ) -> None:
     """Stop and delete one or more tunnels.
 
-    --only-mine controls whether '--all' will restrict to your tunnels or delete for all users.
+    --only-mine controls whether '--all' and '--label' will restrict to your tunnels or delete for all users.
     """
     modes = sum([bool(tunnel_ids), all, bool(label)])
     if modes > 1:
@@ -181,59 +181,47 @@ def stop_tunnel(
         console.print("[red]Error:[/red] Must specify tunnel IDs, --all, or --label")
         raise typer.Exit(1)
 
-    # Handle --label: delete by labels directly via API
+    # Handle --label: list matching tunnels, apply only_mine filter, then bulk delete by IDs
     if label:
-        confirmation_msg = (
-            f"Are you sure you want to stop all tunnels with labels {', '.join(label)}? "
-            "This action cannot be undone."
-        )
-        if not confirm_or_skip(confirmation_msg, yes):
-            console.print("Stop cancelled")
-            return
 
-        async def delete_by_labels():
+        async def fetch_labeled_tunnels() -> List[str]:
             client = TunnelClient()
             try:
-                return await client.bulk_delete_tunnels(labels=label, team_id=team_id)
+                tunnels = await client.list_tunnels(team_id=team_id, labels=label)
+                if only_mine:
+                    current_user_id = client.config.user_id
+                    if not current_user_id:
+                        console.print(
+                            "[red]Error:[/red] Cannot filter by user - no user_id configured. "
+                            "Use --all-users to delete all tunnels, or configure your user_id."
+                        )
+                        raise typer.Exit(1)
+                    tunnels = [t for t in tunnels if t.user_id == current_user_id]
+                return [t.tunnel_id for t in tunnels]
             finally:
                 await client.close()
 
         try:
-            with console.status("[bold blue]Stopping tunnel(s)...", spinner="dots"):
-                result = asyncio.run(delete_by_labels())
+            parsed_ids = asyncio.run(fetch_labeled_tunnels())
+        except typer.Exit:
+            raise
         except Exception as e:
             console.print(f"[red]Error:[/red] {e}", style="bold")
             raise typer.Exit(1)
 
-        succeeded = result.get("succeeded", [])
-        failed = result.get("failed", [])
-
-        if not succeeded and not failed:
+        if not parsed_ids:
             console.print(
                 f"[yellow]No tunnels found matching labels {', '.join(label)}[/yellow]"
             )
+            if only_mine:
+                console.print(
+                    "\n[dim]Note: --label only deletes your own tunnels by default. "
+                    "Use --all-users to delete tunnels from all team members.[/dim]"
+                )
             return
 
-        if succeeded:
-            console.print(
-                f"[bold green]Successfully deleted {len(succeeded)} tunnel(s):[/bold green]"
-            )
-            for tid in succeeded:
-                console.print(f"  ✓ {tid}")
-
-        if failed:
-            console.print(
-                f"\n[bold red]Failed to delete {len(failed)} tunnel(s):[/bold red]"
-            )
-            for failure in failed:
-                tid = failure.get("tunnel_id", "unknown")
-                error = failure.get("error", "Unknown error")
-                console.print(f"  ✗ {tid}: {error}")
-            raise typer.Exit(1)
-        return
-
-    parsed_ids: List[str] = []
-    if all:
+    elif all:
+        parsed_ids: List[str] = []
 
         async def fetch_tunnels() -> List[str]:
             client = TunnelClient()
@@ -269,6 +257,7 @@ def stop_tunnel(
                 )
             return
     else:
+        parsed_ids: List[str] = []
         raw_ids: List[str] = []
         for id_string in tunnel_ids or []:
             if "," in id_string:
@@ -286,12 +275,12 @@ def stop_tunnel(
             console.print("[red]Error:[/red] No valid tunnel IDs provided")
             raise typer.Exit(1)
 
-    if all:
+    if all or label:
         confirmation_msg = (
-            f"Are you sure you want to stop ALL {len(parsed_ids)} tunnel(s)? "
+            f"Are you sure you want to stop {len(parsed_ids)} tunnel(s)? "
             "This action cannot be undone."
         )
-        cancel_msg = "Stop all cancelled"
+        cancel_msg = "Stop cancelled"
     elif len(parsed_ids) == 1:
         confirmation_msg = f"Are you sure you want to stop tunnel {parsed_ids[0]}?"
         cancel_msg = "Stop cancelled"

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -170,7 +170,8 @@ def stop_tunnel(
 ) -> None:
     """Stop and delete one or more tunnels.
 
-    --only-mine controls whether '--all' and '--label' will restrict to your tunnels or delete for all users.
+    --only-mine controls whether '--all' and '--label' will restrict
+    to your tunnels or delete for all users.
     """
     modes = sum([bool(tunnel_ids), all, bool(label)])
     if modes > 1:
@@ -210,9 +211,7 @@ def stop_tunnel(
             raise typer.Exit(1)
 
         if not parsed_ids:
-            console.print(
-                f"[yellow]No tunnels found matching labels {', '.join(label)}[/yellow]"
-            )
+            console.print(f"[yellow]No tunnels found matching labels {', '.join(label)}[/yellow]")
             if only_mine:
                 console.print(
                     "\n[dim]Note: --label only deletes your own tunnels by default. "

--- a/packages/prime/src/prime_cli/commands/tunnel.py
+++ b/packages/prime/src/prime_cli/commands/tunnel.py
@@ -21,11 +21,12 @@ def start_tunnel(
     team_id: Optional[str] = typer.Option(
         None, "--team-id", help="Team ID for team tunnels (uses config team_id if not specified)"
     ),
+    label: Optional[List[str]] = typer.Option(None, "--label", "-l", help="Labels for the tunnel"),
 ) -> None:
     """Start a tunnel to expose a local port."""
 
     async def run_tunnel():
-        tunnel = Tunnel(local_port=port, name=name, team_id=team_id)
+        tunnel = Tunnel(local_port=port, name=name, team_id=team_id, labels=label or None)
 
         shutdown_event = asyncio.Event()
 
@@ -71,13 +72,19 @@ def list_tunnels(
         "--team-id",
         help="Team ID to list team tunnels (uses config team_id if not specified)",
     ),
+    label: Optional[List[str]] = typer.Option(
+        None,
+        "--label",
+        "-l",
+        help="Filter by labels (repeatable, tunnels must have ALL specified labels)",
+    ),
 ) -> None:
     """List active tunnels."""
 
     async def fetch_tunnels():
         client = TunnelClient()
         try:
-            tunnels = await client.list_tunnels(team_id=team_id)
+            tunnels = await client.list_tunnels(team_id=team_id, labels=label or None)
             return tunnels
         finally:
             await client.close()
@@ -95,12 +102,14 @@ def list_tunnels(
     table = Table(title="Active Tunnels")
     table.add_column("Tunnel ID", style="cyan")
     table.add_column("URL", style="green")
+    table.add_column("Labels", style="yellow")
     table.add_column("Expires At")
 
     for tunnel in tunnels:
         table.add_row(
             tunnel.tunnel_id,
             tunnel.url,
+            ", ".join(tunnel.labels) if tunnel.labels else "",
             str(tunnel.expires_at),
         )
 
@@ -142,6 +151,9 @@ def stop_tunnel(
         None, help="Tunnel ID(s) to stop (space or comma-separated)"
     ),
     all: bool = typer.Option(False, "--all", "-a", help="Stop all tunnels"),
+    label: Optional[List[str]] = typer.Option(
+        None, "--label", "-l", help="Stop all tunnels matching these labels"
+    ),
     team_id: Optional[str] = typer.Option(
         None,
         "--team-id",
@@ -160,14 +172,48 @@ def stop_tunnel(
 
     --only-mine controls whether '--all' will restrict to your tunnels or delete for all users.
     """
-
-    if all and tunnel_ids:
-        console.print("[red]Error:[/red] Cannot specify tunnel IDs with --all")
+    modes = sum([bool(tunnel_ids), all, bool(label)])
+    if modes > 1:
+        console.print("[red]Error:[/red] Specify only one of: tunnel IDs, --all, or --label")
         raise typer.Exit(1)
 
-    if not all and not tunnel_ids:
-        console.print("[red]Error:[/red] Must specify at least one tunnel ID or --all")
+    if modes == 0:
+        console.print("[red]Error:[/red] Must specify tunnel IDs, --all, or --label")
         raise typer.Exit(1)
+
+    # Handle --label: delete by labels directly via API
+    if label:
+        confirmation_msg = (
+            f"Are you sure you want to stop all tunnels with labels {label}? "
+            "This action cannot be undone."
+        )
+        if not confirm_or_skip(confirmation_msg, yes):
+            console.print("Stop cancelled")
+            return
+
+        async def delete_by_labels():
+            client = TunnelClient()
+            try:
+                return await client.bulk_delete_tunnels(labels=label)
+            finally:
+                await client.close()
+
+        try:
+            with console.status("[bold blue]Stopping tunnel(s)...", spinner="dots"):
+                result = asyncio.run(delete_by_labels())
+        except Exception as e:
+            console.print(f"[red]Error:[/red] {e}", style="bold")
+            raise typer.Exit(1)
+
+        succeeded = result.get("succeeded", [])
+        message = result.get("message", "")
+        if succeeded:
+            console.print(f"[green]{message}[/green]")
+            for tid in succeeded:
+                console.print(f"  ✓ {tid}")
+        else:
+            console.print(f"[yellow]No tunnels found matching labels {label}[/yellow]")
+        return
 
     parsed_ids: List[str] = []
     if all:
@@ -246,7 +292,7 @@ def stop_tunnel(
         not_found: List[dict] = []
         failed: List[dict] = []
         try:
-            result = await client.bulk_delete_tunnels(parsed_ids)
+            result = await client.bulk_delete_tunnels(tunnel_ids=parsed_ids)
             succeeded = result.get("succeeded", [])
             for failure in result.get("failed", []):
                 tid = failure.get("tunnel_id", "")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds label-based filtering and deletion paths in both client and CLI, changing request payloads/query params and bulk-delete behavior. Risk is moderate due to potential impact on tunnel lifecycle operations (listing/deleting) if backend expectations differ or filtering logic misbehaves.
> 
> **Overview**
> Adds first-class *tunnel labels* across the Python SDK and `prime` CLI.
> 
> `tunnel` creation now accepts `labels` and `TunnelInfo` includes a `labels` field; `list` can filter by labels and displays them in output. `stop` gains `--label` mode (mutually exclusive with IDs/`--all`) that resolves matching tunnels (optionally restricted by `--only-mine`) and then bulk-deletes them; `bulk_delete_tunnels` is extended to delete by IDs *or* labels (and now includes optional `teamId`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333bcc487c8c19a94d920187180626b8383dcb64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->