### PR TITLE
auth thread safety

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -329,7 +329,7 @@ class SandboxAuthCache:
             response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
             with self._lock:
                 self._auth_cache[sandbox_id] = response
-                self._save_cache()
+            self._save_cache()
             return dict(response)
         finally:
             with self._lock:
@@ -352,7 +352,7 @@ class SandboxAuthCache:
         with self._lock:
             if sandbox_id in self._auth_cache:
                 self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-                self._save_cache()
+        self._save_cache()
 
         return is_gpu
 
@@ -361,7 +361,7 @@ class SandboxAuthCache:
         with self._lock:
             self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
-            self._save_cache()
+        self._save_cache()
 
     def clear(self) -> None:
         """Clear all cached auth tokens."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -373,6 +373,16 @@ class SandboxAuthCache:
 
         return is_gpu
 
+    async def clear_async(self) -> None:
+        """Clear all cached auth tokens (async)."""
+        async with self._get_async_lock():
+            self._auth_cache = {}
+            try:
+                if self._cache_file.exists():
+                    self._cache_file.unlink()
+            except Exception:
+                pass
+
 
 def _check_sandbox_statuses(
     sandboxes: List[Sandbox], target_ids: set
@@ -1243,9 +1253,9 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    def clear_auth_cache(self) -> None:
+    async def clear_auth_cache(self) -> None:
         """Clear all cached auth tokens"""
-        self._auth_cache.clear()
+        await self._auth_cache.clear_async()
 
     async def create(self, request: CreateSandboxRequest) -> Sandbox:
         """Create a new sandbox"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -6,6 +6,7 @@ import os
 import re
 import shlex
 import sys
+import threading
 import time
 import uuid
 from datetime import datetime, timezone
@@ -200,10 +201,32 @@ def _raise_not_running_error(
 class SandboxAuthCache:
     """Shared auth cache management for sandbox clients"""
 
-    def __init__(self, cache_file_path: Any, client: Any) -> None:
+    def __init__(self, cache_file_path: Any, client: Any, *, lazy: bool = False) -> None:
         self._cache_file = cache_file_path
-        self._auth_cache = self._load_cache()
         self.client = client
+        self._lock = threading.Lock()
+        self._async_lock: Optional[asyncio.Lock] = None
+        if lazy:
+            self._auth_cache: Dict[str, Any] = {}
+            self._loaded = False
+        else:
+            self._auth_cache = self._load_cache()
+            self._loaded = True
+
+    def _get_async_lock(self) -> asyncio.Lock:
+        if self._async_lock is None:
+            self._async_lock = asyncio.Lock()
+        return self._async_lock
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self._auth_cache = self._load_cache()
+            self._loaded = True
+
+    async def _ensure_loaded_async(self) -> None:
+        if not self._loaded:
+            self._auth_cache = await asyncio.to_thread(self._load_cache)
+            self._loaded = True
 
     def _load_cache(self) -> Dict[str, Any]:
         """Load auth cache from file and clean expired entries"""
@@ -212,13 +235,13 @@ class SandboxAuthCache:
                 with open(self._cache_file, "r") as f:
                     cache = json.load(f)
                 cleaned_cache = {}
+                now = datetime.now(timezone.utc)
                 for sandbox_id, auth_info in cache.items():
                     try:
                         expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
                         expires_at = datetime.fromisoformat(expires_at_str)
                         if expires_at.tzinfo is None:
                             expires_at = expires_at.replace(tzinfo=timezone.utc)
-                        now = datetime.now(timezone.utc)
                         if now < expires_at:
                             cleaned_cache[sandbox_id] = auth_info
                     except Exception:
@@ -243,7 +266,7 @@ class SandboxAuthCache:
             pass
 
     async def _save_cache_async(self) -> None:
-        """Save auth cache to file (async version)"""
+        """Save auth cache to file without blocking the event loop."""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             async with aiofiles.open(self._cache_file, "w") as f:
@@ -252,7 +275,7 @@ class SandboxAuthCache:
             pass
 
     def _check_cached_auth(self, sandbox_id: str) -> Optional[Dict[str, Any]]:
-        """Check if cached auth info exists and is valid"""
+        """Return a copy of cached auth if still valid, else evict and return None."""
         if sandbox_id in self._auth_cache:
             auth_info = self._auth_cache[sandbox_id]
             expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
@@ -261,92 +284,92 @@ class SandboxAuthCache:
                 expires_at = expires_at.replace(tzinfo=timezone.utc)
             if datetime.now(timezone.utc) < expires_at:
                 return dict(auth_info)
-            else:
-                del self._auth_cache[sandbox_id]
-                self._save_cache()
-        return None
-
-    async def _check_cached_auth_async(self, sandbox_id: str) -> Optional[Dict[str, Any]]:
-        """Check if cached auth info exists and is valid (async version)"""
-        if sandbox_id in self._auth_cache:
-            auth_info = self._auth_cache[sandbox_id]
-            expires_at_str = auth_info["expires_at"].replace("Z", "+00:00")
-            expires_at = datetime.fromisoformat(expires_at_str)
-            if expires_at.tzinfo is None:
-                expires_at = expires_at.replace(tzinfo=timezone.utc)
-            if datetime.now(timezone.utc) < expires_at:
-                return dict(auth_info)
-            else:
-                del self._auth_cache[sandbox_id]
-                await self._save_cache_async()
+            del self._auth_cache[sandbox_id]
         return None
 
     def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing"""
-        cached_auth = self._check_cached_auth(sandbox_id)
-        if cached_auth:
-            return cached_auth
+        """Get cached auth info or fetch new token if expired/missing."""
+        with self._lock:
+            self._ensure_loaded()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth:
+                return cached_auth
 
         response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-        self.set(sandbox_id, response)
-        self._save_cache()
-        return dict(response)
 
-    async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing (async)"""
-        cached_auth = await self._check_cached_auth_async(sandbox_id)
-        if cached_auth:
-            return cached_auth
-        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
-        self._auth_cache[sandbox_id] = response
-        await self._save_cache_async()
+        with self._lock:
+            self._auth_cache[sandbox_id] = response
+            self._save_cache()
         return dict(response)
 
     def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
-        cached_auth = self._check_cached_auth(sandbox_id)
-        if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-            return bool(cached_auth["is_gpu"])
+        with self._lock:
+            self._ensure_loaded()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
+                return bool(cached_auth["is_gpu"])
 
         sandbox_data = self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
         is_gpu = sandbox.gpu_count > 0
 
-        if sandbox_id in self._auth_cache:
-            self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-            self._save_cache()
+        with self._lock:
+            if sandbox_id in self._auth_cache:
+                self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+                self._save_cache()
 
         return is_gpu
 
+    def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
+        """Cache auth info."""
+        with self._lock:
+            self._auth_cache[sandbox_id] = auth_info
+            self._save_cache()
+
+    def clear(self) -> None:
+        """Clear all cached auth tokens."""
+        with self._lock:
+            self._auth_cache = {}
+            try:
+                if self._cache_file.exists():
+                    self._cache_file.unlink()
+            except Exception:
+                pass
+
+    async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
+        """Get cached auth info or fetch new token if expired/missing (async)."""
+        async with self._get_async_lock():
+            await self._ensure_loaded_async()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth:
+                return cached_auth
+
+        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+
+        async with self._get_async_lock():
+            self._auth_cache[sandbox_id] = response
+            await self._save_cache_async()
+        return dict(response)
+
     async def is_gpu_async(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
-        cached_auth = await self._check_cached_auth_async(sandbox_id)
-        if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
-            return bool(cached_auth["is_gpu"])
+        async with self._get_async_lock():
+            await self._ensure_loaded_async()
+            cached_auth = self._check_cached_auth(sandbox_id)
+            if cached_auth and isinstance(cached_auth.get("is_gpu"), bool):
+                return bool(cached_auth["is_gpu"])
 
         sandbox_data = await self.client.request("GET", f"/sandbox/{sandbox_id}")
         sandbox = Sandbox.model_validate(sandbox_data)
         is_gpu = sandbox.gpu_count > 0
 
-        if sandbox_id in self._auth_cache:
-            self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
-            await self._save_cache_async()
+        async with self._get_async_lock():
+            if sandbox_id in self._auth_cache:
+                self._auth_cache[sandbox_id]["is_gpu"] = is_gpu
+                await self._save_cache_async()
 
         return is_gpu
-
-    def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
-        """Cache auth info"""
-        self._auth_cache[sandbox_id] = auth_info
-        self._save_cache()
-
-    def clear(self) -> None:
-        """Clear all cached auth tokens"""
-        self._auth_cache = {}
-        try:
-            if self._cache_file.exists():
-                self._cache_file.unlink()
-        except Exception:
-            pass
 
 
 def _check_sandbox_statuses(
@@ -1119,6 +1142,7 @@ class AsyncSandboxClient:
         self._auth_cache = SandboxAuthCache(
             self.client.config.config_dir / "sandbox_auth_cache.json",
             self.client,
+            lazy=True,
         )
         # Connection pool configuration
         self._max_connections = max_connections

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1254,8 +1254,12 @@ class AsyncSandboxClient:
         # Sandbox is not running
         _raise_not_running_error(sandbox_id, ctx, command=command, cause=error)
 
-    async def clear_auth_cache(self) -> None:
-        """Clear all cached auth tokens"""
+    def clear_auth_cache(self) -> None:
+        """Clear cached auth tokens synchronously for backward compatibility."""
+        self._auth_cache.clear()
+
+    async def clear_auth_cache_async(self) -> None:
+        """Clear cached auth tokens without blocking other async cache users."""
         await self._auth_cache.clear_async()
 
     async def create(self, request: CreateSandboxRequest) -> Sandbox:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -205,6 +205,7 @@ class SandboxAuthCache:
         self._cache_file = cache_file_path
         self.client = client
         self._lock = threading.Lock()
+        self._async_lock_init = threading.Lock()
         self._async_lock: Optional[asyncio.Lock] = None
         if lazy:
             self._auth_cache: Dict[str, Any] = {}
@@ -217,7 +218,9 @@ class SandboxAuthCache:
 
     def _get_async_lock(self) -> asyncio.Lock:
         if self._async_lock is None:
-            self._async_lock = asyncio.Lock()
+            with self._async_lock_init:
+                if self._async_lock is None:
+                    self._async_lock = asyncio.Lock()
         return self._async_lock
 
     def _ensure_loaded(self) -> None:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -207,6 +207,10 @@ class SandboxAuthCache:
         self._lock = threading.Lock()
         self._async_lock_init = threading.Lock()
         self._async_lock: Optional[asyncio.Lock] = None
+        # Per-sandbox in-flight auth futures to coalesce concurrent requests
+        self._inflight_sync: Dict[str, threading.Event] = {}
+        self._inflight_sync_results: Dict[str, Dict[str, Any]] = {}
+        self._inflight_async: Dict[str, asyncio.Future] = {}
         if lazy:
             self._auth_cache: Dict[str, Any] = {}
             self._loaded = False
@@ -293,19 +297,45 @@ class SandboxAuthCache:
         return None
 
     def get_or_refresh(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing."""
+        """Get cached auth info or fetch new token if expired/missing.
+
+        Coalesces concurrent requests for the same sandbox_id so only one
+        auth POST is issued while others wait for the result.
+        """
         with self._lock:
             self._ensure_loaded()
             cached_auth = self._check_cached_auth(sandbox_id)
             if cached_auth:
                 return cached_auth
 
-        response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            # Check if another thread is already fetching auth for this sandbox
+            if sandbox_id in self._inflight_sync:
+                event = self._inflight_sync[sandbox_id]
+            else:
+                event = None
+                self._inflight_sync[sandbox_id] = threading.Event()
 
-        with self._lock:
-            self._auth_cache[sandbox_id] = response
-            self._save_cache()
-        return dict(response)
+        if event is not None:
+            # Wait for the in-flight request to complete
+            event.wait()
+            with self._lock:
+                cached_auth = self._check_cached_auth(sandbox_id)
+                if cached_auth:
+                    return cached_auth
+            # Fallback: if the in-flight request failed, fetch ourselves
+            return self.get_or_refresh(sandbox_id)
+
+        try:
+            response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            with self._lock:
+                self._auth_cache[sandbox_id] = response
+                self._save_cache()
+            return dict(response)
+        finally:
+            with self._lock:
+                event = self._inflight_sync.pop(sandbox_id, None)
+            if event is not None:
+                event.set()
 
     def is_gpu(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""
@@ -345,19 +375,44 @@ class SandboxAuthCache:
                 pass
 
     async def get_or_refresh_async(self, sandbox_id: str) -> Dict[str, Any]:
-        """Get cached auth info or fetch new token if expired/missing (async)."""
+        """Get cached auth info or fetch new token if expired/missing (async).
+
+        Coalesces concurrent requests for the same sandbox_id so only one
+        auth POST is issued while others await the result.
+        """
         async with self._get_async_lock():
             await self._ensure_loaded_async()
             cached_auth = self._check_cached_auth(sandbox_id)
             if cached_auth:
                 return cached_auth
 
-        response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            # Check if another coroutine is already fetching auth for this sandbox
+            if sandbox_id in self._inflight_async:
+                future = self._inflight_async[sandbox_id]
+            else:
+                future = None
+                loop = asyncio.get_running_loop()
+                self._inflight_async[sandbox_id] = loop.create_future()
 
-        async with self._get_async_lock():
-            self._auth_cache[sandbox_id] = response
-            await self._save_cache_async()
-        return dict(response)
+        if future is not None:
+            # Wait for the in-flight request to complete
+            return dict(await future)
+
+        try:
+            response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+            async with self._get_async_lock():
+                self._auth_cache[sandbox_id] = response
+                await self._save_cache_async()
+                fut = self._inflight_async.pop(sandbox_id, None)
+            if fut is not None and not fut.done():
+                fut.set_result(response)
+            return dict(response)
+        except BaseException as e:
+            async with self._get_async_lock():
+                fut = self._inflight_async.pop(sandbox_id, None)
+            if fut is not None and not fut.done():
+                fut.set_exception(e)
+            raise
 
     async def is_gpu_async(self, sandbox_id: str) -> bool:
         """Return True if sandbox is GPU-backed, cached alongside auth token data."""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -210,8 +210,10 @@ class SandboxAuthCache:
             self._auth_cache: Dict[str, Any] = {}
             self._loaded = False
         else:
-            self._auth_cache = self._load_cache()
+            self._auth_cache, needs_save = self._load_cache()
             self._loaded = True
+            if needs_save:
+                self._save_cache()
 
     def _get_async_lock(self) -> asyncio.Lock:
         if self._async_lock is None:
@@ -220,15 +222,19 @@ class SandboxAuthCache:
 
     def _ensure_loaded(self) -> None:
         if not self._loaded:
-            self._auth_cache = self._load_cache()
+            self._auth_cache, needs_save = self._load_cache()
             self._loaded = True
+            if needs_save:
+                self._save_cache()
 
     async def _ensure_loaded_async(self) -> None:
         if not self._loaded:
-            self._auth_cache = await asyncio.to_thread(self._load_cache)
+            self._auth_cache, needs_save = await asyncio.to_thread(self._load_cache)
             self._loaded = True
+            if needs_save:
+                await self._save_cache_async()
 
-    def _load_cache(self) -> Dict[str, Any]:
+    def _load_cache(self) -> tuple[Dict[str, Any], bool]:
         """Load auth cache from file and clean expired entries"""
         try:
             if self._cache_file.exists():
@@ -247,14 +253,10 @@ class SandboxAuthCache:
                     except Exception:
                         pass
 
-                if len(cleaned_cache) != len(cache):
-                    self._auth_cache = cleaned_cache
-                    self._save_cache()
-
-                return cleaned_cache
+                return cleaned_cache, len(cleaned_cache) != len(cache)
         except Exception:
             pass
-        return {}
+        return {}, False
 
     def _save_cache(self) -> None:
         """Save auth cache to file"""

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -379,8 +379,7 @@ class SandboxAuthCache:
             self._auth_cache = {}
             self._loaded = True
             try:
-                if self._cache_file.exists():
-                    self._cache_file.unlink()
+                await asyncio.to_thread(self._cache_file.unlink, missing_ok=True)
             except Exception:
                 pass
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -277,7 +277,9 @@ class SandboxAuthCache:
     async def _save_cache_async(self) -> None:
         """Save auth cache to file (async version)"""
         try:
-            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(
+                self._cache_file.parent.mkdir, parents=True, exist_ok=True
+            )
             async with aiofiles.open(self._cache_file, "w") as f:
                 await f.write(json.dumps(self._auth_cache))
         except Exception:
@@ -1784,7 +1786,7 @@ class AsyncSandboxClient:
             local_file_path: Local file path to upload
             timeout: Optional timeout in seconds
         """
-        if not os.path.exists(local_file_path):
+        if not await asyncio.to_thread(os.path.exists, local_file_path):
             raise FileNotFoundError(f"Local file not found: {local_file_path}")
 
         auth = await self._auth_cache.get_or_refresh_async(sandbox_id)
@@ -1903,7 +1905,7 @@ class AsyncSandboxClient:
 
                 dir_path = os.path.dirname(local_file_path)
                 if dir_path:
-                    os.makedirs(dir_path, exist_ok=True)
+                    await asyncio.to_thread(os.makedirs, dir_path, exist_ok=True)
 
                 # Write file asynchronously (non-blocking I/O)
                 async with aiofiles.open(local_file_path, "wb") as f:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -324,6 +324,7 @@ class SandboxAuthCache:
     def set(self, sandbox_id: str, auth_info: Dict[str, Any]) -> None:
         """Cache auth info."""
         with self._lock:
+            self._ensure_loaded()
             self._auth_cache[sandbox_id] = auth_info
             self._save_cache()
 
@@ -331,6 +332,7 @@ class SandboxAuthCache:
         """Clear all cached auth tokens."""
         with self._lock:
             self._auth_cache = {}
+            self._loaded = True
             try:
                 if self._cache_file.exists():
                     self._cache_file.unlink()

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -377,6 +377,7 @@ class SandboxAuthCache:
         """Clear all cached auth tokens (async)."""
         async with self._get_async_lock():
             self._auth_cache = {}
+            self._loaded = True
             try:
                 if self._cache_file.exists():
                     self._cache_file.unlink()

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -266,7 +266,7 @@ class SandboxAuthCache:
             pass
 
     async def _save_cache_async(self) -> None:
-        """Save auth cache to file without blocking the event loop."""
+        """Save auth cache to file (async version)"""
         try:
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
             async with aiofiles.open(self._cache_file, "w") as f:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches auth token caching and refresh behavior, adding new locking/coalescing paths that could deadlock or cause stale/failed token reuse if incorrect, but scope is limited to client-side cache management.
> 
> **Overview**
> **Auth cache concurrency was hardened.** `SandboxAuthCache` is now thread-safe and async-safe via locks, and it coalesces concurrent `POST /sandbox/{id}/auth` refreshes so only one request is issued per sandbox while others wait.
> 
> **Cache lifecycle and I/O were adjusted.** The cache can be lazily loaded (used by `AsyncSandboxClient`), expired entries are cleaned on load with a save-on-clean, async file ops avoid blocking the event loop (`to_thread` for mkdir/unlink/exists/makedirs), and `AsyncSandboxClient` adds `clear_auth_cache_async()` alongside the existing sync method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcf61b7c1d125940557d578d1596d52d91f81acf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->