### PR TITLE
ENG-3145: Add --region flag to sandbox create

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -57,6 +57,7 @@ class Sandbox(BaseModel):
     user_id: Optional[str] = Field(None, alias="userId")
     team_id: Optional[str] = Field(None, alias="teamId")
     kubernetes_job_id: Optional[str] = Field(None, alias="kubernetesJobId")
+    region: Optional[str] = None
     registry_credentials_id: Optional[str] = Field(default=None, alias="registryCredentialsId")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -91,6 +92,7 @@ class CreateSandboxRequest(BaseModel):
     secrets: Optional[Dict[str, str]] = None
     labels: List[str] = Field(default_factory=list)
     team_id: Optional[str] = None
+    region: Optional[str] = None
     advanced_configs: Optional[AdvancedConfigs] = None
     registry_credentials_id: Optional[str] = None
 

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -88,6 +88,7 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
         "network_access": sandbox.network_access,
         "timeout_minutes": sandbox.timeout_minutes,
         "labels": sandbox.labels,
+        "region": sandbox.region or "us-central1",
         "created_at": iso_timestamp(sandbox.created_at),
         "user_id": sandbox.user_id,
         "team_id": sandbox.team_id,
@@ -286,6 +287,7 @@ def get(
             )
             table.add_row("Network Access", network_display)
             table.add_row("Timeout (minutes)", str(sandbox_data["timeout_minutes"]))
+            table.add_row("Region", sandbox_data.get("region", "us-central1"))
 
             # Show labels
             labels_display = ", ".join(sandbox_data["labels"]) if sandbox_data["labels"] else "None"
@@ -387,6 +389,11 @@ def create(
         "-l",
         help="Labels/tags for the sandbox. Can be specified multiple times.",
     ),
+    region: Optional[str] = typer.Option(
+        None,
+        "--region",
+        help="Cluster region (e.g. us-central1, asia-south1). Defaults to us-central1.",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Create a new sandbox"""
@@ -473,6 +480,7 @@ def create(
             secrets=secrets_vars if secrets_vars else None,
             labels=labels if labels else [],
             team_id=team_id,
+            region=region,
             registry_credentials_id=registry_credentials_id,
         )
 
@@ -492,6 +500,8 @@ def create(
         network_status = "[green]Enabled[/green]" if network_access else "[yellow]Disabled[/yellow]"
         console.print(f"Network Access: {network_status}")
         console.print(f"Timeout: {timeout_minutes} minutes")
+        if region:
+            console.print(f"Region: {region}")
         console.print(f"Team: {team_id or 'Personal'}")
         if registry_credentials_id:
             console.print(f"Registry Credentials: {registry_credentials_id}")


### PR DESCRIPTION
## Summary

- adds `--region` option to `prime sandbox create` (e.g. `--region asia-south1`)
- adds `region` field to Sandbox and CreateSandboxRequest models
- displays region in sandbox details output

Companion to PrimeIntellect-ai/platform#955 which adds multi-cluster sandbox support to the backend.

Usage: `prime sandbox create ubuntu:latest --region asia-south1 --team-id <id>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI/SDK surface-area change: adds an optional `region` field and threads it through create and display paths, with a default fallback for older backends.
> 
> **Overview**
> Adds optional multi-region support to sandboxes by introducing a `region` field on the SDK models (`Sandbox`, `CreateSandboxRequest`) and wiring it into `prime sandbox create` via a new `--region` flag.
> 
> Updates `prime sandbox get`/details formatting to surface the sandbox region (defaulting to `us-central1` when absent) and includes the selected region in the create confirmation output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4c312f9bf586abc1575fb72b68e481ead34abc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->