### PR TITLE
Handle failed hosted eval creation responses

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -410,7 +410,11 @@ def _print_eval_status(eval_data: dict[str, Any]) -> None:
 def _result_evaluation_ids(result: dict[str, Any]) -> list[str]:
     evaluation_ids = result.get("evaluation_ids")
     if isinstance(evaluation_ids, list):
-        return [evaluation_id for evaluation_id in evaluation_ids if isinstance(evaluation_id, str)]
+        filtered_ids = [
+            evaluation_id for evaluation_id in evaluation_ids if isinstance(evaluation_id, str)
+        ]
+        if filtered_ids:
+            return filtered_ids
 
     evaluation_id = result.get("evaluation_id")
     if isinstance(evaluation_id, str):

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -377,6 +377,10 @@ def _create_hosted_evaluations(
     evaluation_id = created.get("evaluation_id")
     evaluation_ids = created.get("evaluation_ids")
 
+    if created.get("status") == "FAILED":
+        error_message = created.get("error") or created.get("error_message")
+        raise APIError(error_message or f"Hosted evaluation creation failed: {created}")
+
     if not evaluation_id and not evaluation_ids:
         raise APIError(f"Failed to get evaluation ID from response: {created}")
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -377,7 +377,7 @@ def _create_hosted_evaluations(
     evaluation_id = created.get("evaluation_id")
     evaluation_ids = created.get("evaluation_ids")
 
-    if created.get("status") == "FAILED":
+    if created.get("status") == "FAILED" and not evaluation_id and not evaluation_ids:
         error_message = created.get("error") or created.get("error_message")
         raise APIError(error_message or f"Hosted evaluation creation failed: {created}")
 
@@ -393,7 +393,7 @@ def _print_eval_status(eval_data: dict[str, Any]) -> None:
 
     console.print(f"[{color}]Status: {status_str}[/{color}]")
 
-    error_message = eval_data.get("error_message")
+    error_message = eval_data.get("error_message") or eval_data.get("error")
     if error_message:
         console.print(f"[red]Error:[/red] {error_message}")
 
@@ -405,6 +405,39 @@ def _print_eval_status(eval_data: dict[str, Any]) -> None:
     eval_id = eval_data.get("evaluation_id")
     if eval_id:
         console.print(f"[dim]View: {get_eval_viewer_url(eval_id)}[/dim]")
+
+
+def _result_evaluation_ids(result: dict[str, Any]) -> list[str]:
+    evaluation_ids = result.get("evaluation_ids")
+    if isinstance(evaluation_ids, list):
+        return [evaluation_id for evaluation_id in evaluation_ids if isinstance(evaluation_id, str)]
+
+    evaluation_id = result.get("evaluation_id")
+    if isinstance(evaluation_id, str):
+        return [evaluation_id]
+
+    return []
+
+
+def _print_hosted_evaluation_ids(platform_slugs: list[str], evaluation_ids: list[str]) -> None:
+    if len(platform_slugs) == 1:
+        console.print(f"[cyan]Environment:[/cyan] {platform_slugs[0]}")
+    else:
+        console.print(f"[cyan]Environments:[/cyan] {', '.join(platform_slugs)}")
+    console.print(f"[cyan]Evaluation IDs:[/cyan] {', '.join(evaluation_ids)}")
+
+
+def _print_failed_hosted_creation_results(
+    platform_slugs: list[str],
+    evaluation_ids: list[str],
+    failed_results: list[dict[str, Any]],
+) -> None:
+    console.print("[yellow]Hosted evaluation creation returned failed evaluations.[/yellow]")
+    _print_hosted_evaluation_ids(platform_slugs, evaluation_ids)
+    for failed_result in failed_results:
+        _print_eval_status(failed_result)
+        for evaluation_id in _result_evaluation_ids(failed_result):
+            console.print(f"[dim]View logs:[/dim] prime eval logs {evaluation_id} -f")
 
 
 def _parse_eval_status(eval_data: dict[str, Any]) -> tuple[str, EvalStatus | None]:
@@ -1364,6 +1397,7 @@ def run_eval_cmd(
 
         all_platform_slugs: list[str] = []
         all_evaluation_ids: list[str] = []
+        failed_results: list[dict[str, Any]] = []
         try:
             for group_key in target_order:
                 group = grouped_targets[group_key]
@@ -1385,10 +1419,20 @@ def run_eval_cmd(
                     environment_ids=group["environment_ids"],
                 )
                 all_platform_slugs.extend(group["platform_slugs"])
-                all_evaluation_ids.extend(result.get("evaluation_ids") or [result["evaluation_id"]])
+                all_evaluation_ids.extend(_result_evaluation_ids(result))
+                if result.get("status") == EvalStatus.FAILED.value:
+                    failed_results.append(result)
         except APIError as exc:
             console.print(f"[red]Hosted evaluation failed:[/red] {exc}")
             raise typer.Exit(1) from exc
+
+        if failed_results:
+            _print_failed_hosted_creation_results(
+                all_platform_slugs,
+                all_evaluation_ids,
+                failed_results,
+            )
+            raise typer.Exit(1)
 
         if follow:
             console.print("[green]✓ Hosted evaluation started[/green]")

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -382,7 +382,7 @@ def _create_hosted_evaluations(
         and not evaluation_id
         and not evaluation_ids
     ):
-        error_message = created.get("error") or created.get("error_message")
+        error_message = created.get("error")
         raise APIError(error_message or f"Hosted evaluation creation failed: {created}")
 
     if not evaluation_id and not evaluation_ids:
@@ -397,7 +397,7 @@ def _print_eval_status(eval_data: dict[str, Any]) -> None:
 
     console.print(f"[{color}]Status: {status_str}[/{color}]")
 
-    error_message = eval_data.get("error_message") or eval_data.get("error")
+    error_message = eval_data.get("error_message")
     if error_message:
         console.print(f"[red]Error:[/red] {error_message}")
 
@@ -412,13 +412,13 @@ def _print_eval_status(eval_data: dict[str, Any]) -> None:
 
 
 def _result_evaluation_ids(result: dict[str, Any]) -> list[str]:
-    evaluation_ids = result.get("evaluation_ids")
-    if isinstance(evaluation_ids, list):
-        filtered_ids = [
-            evaluation_id for evaluation_id in evaluation_ids if isinstance(evaluation_id, str)
-        ]
-        if filtered_ids:
-            return filtered_ids
+    evaluation_ids = [
+        evaluation_id
+        for evaluation_id in (result.get("evaluation_ids") or [])
+        if isinstance(evaluation_id, str)
+    ]
+    if evaluation_ids:
+        return evaluation_ids
 
     evaluation_id = result.get("evaluation_id")
     if isinstance(evaluation_id, str):
@@ -443,8 +443,16 @@ def _print_failed_hosted_creation_results(
     console.print("[yellow]Hosted evaluation creation returned failed evaluations.[/yellow]")
     _print_hosted_evaluation_ids(platform_slugs, evaluation_ids)
     for failed_result in failed_results:
-        _print_eval_status(failed_result)
+        status_str, status = _parse_eval_status(failed_result)
+        color = status.color if status else "white"
+        console.print(f"[{color}]Status: {status_str}[/{color}]")
+
+        error_message = failed_result.get("error")
+        if error_message:
+            console.print(f"[red]Error:[/red] {error_message}")
+
         for evaluation_id in _result_evaluation_ids(failed_result):
+            console.print(f"[dim]View: {get_eval_viewer_url(evaluation_id)}[/dim]")
             console.print(f"[dim]View logs:[/dim] prime eval logs {evaluation_id} -f")
 
 

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -377,7 +377,11 @@ def _create_hosted_evaluations(
     evaluation_id = created.get("evaluation_id")
     evaluation_ids = created.get("evaluation_ids")
 
-    if created.get("status") == "FAILED" and not evaluation_id and not evaluation_ids:
+    if (
+        created.get("status") == EvalStatus.FAILED.value
+        and not evaluation_id
+        and not evaluation_ids
+    ):
         error_message = created.get("error") or created.get("error_message")
         raise APIError(error_message or f"Hosted evaluation creation failed: {created}")
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -295,6 +295,37 @@ def test_eval_run_hosted_reports_failed_create_response_with_plural_ids(monkeypa
     assert "prime eval logs eval-456 -f" in result.output
 
 
+def test_create_hosted_evaluation_ids_falls_back_to_singular_id_when_plural_is_empty(monkeypatch):
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            return {
+                "evaluation_id": "eval-123",
+                "evaluation_ids": [],
+                "status": "FAILED",
+                "error": "Startup failed",
+            }
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    result = _create_hosted_evaluations(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
+        )
+    )
+
+    assert result["evaluation_id"] == "eval-123"
+    assert result["evaluation_ids"] == []
+
+
 def test_eval_run_hosted_follow_streams_logs(monkeypatch):
     captured = {}
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 from prime_cli.client import APIError
 from prime_cli.commands.evals import (
     _create_hosted_evaluations,
@@ -194,7 +193,7 @@ def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):
     assert result["evaluation_ids"] == ["eval-123", "eval-456"]
 
 
-def test_create_hosted_evaluation_raises_api_error_for_failed_create_response(monkeypatch):
+def test_create_hosted_evaluation_preserves_failed_response_with_evaluation_id(monkeypatch):
     class DummyConfig:
         team_id = None
 
@@ -211,18 +210,21 @@ def test_create_hosted_evaluation_raises_api_error_for_failed_create_response(mo
 
     monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
 
-    with pytest.raises(APIError, match="You are not a member of this team"):
-        _create_hosted_evaluations(
-            HostedEvalConfig(
-                environment_id="env-123",
-                inference_model="openai/gpt-4.1-mini",
-                num_examples=5,
-                rollouts_per_example=3,
-            )
+    result = _create_hosted_evaluations(
+        HostedEvalConfig(
+            environment_id="env-123",
+            inference_model="openai/gpt-4.1-mini",
+            num_examples=5,
+            rollouts_per_example=3,
         )
+    )
+
+    assert result["evaluation_id"] == "eval-123"
+    assert result["status"] == "FAILED"
+    assert result["error"] == "You are not a member of this team"
 
 
-def test_eval_run_hosted_reports_failed_create_response(monkeypatch):
+def test_eval_run_hosted_reports_failed_create_response_with_evaluation_id(monkeypatch):
     monkeypatch.setattr(
         "prime_cli.commands.evals._resolve_hosted_environment",
         lambda environment, env_dir_path=None, env_path=None: (
@@ -232,7 +234,11 @@ def test_eval_run_hosted_reports_failed_create_response(monkeypatch):
     )
 
     def fake_run_hosted_evaluation(config, environment_ids=None):
-        raise APIError("You are not a member of this team")
+        return {
+            "evaluation_id": "eval-123",
+            "status": "FAILED",
+            "error": "You are not a member of this team",
+        }
 
     monkeypatch.setattr(
         "prime_cli.commands.evals._create_hosted_evaluations",
@@ -246,9 +252,47 @@ def test_eval_run_hosted_reports_failed_create_response(monkeypatch):
     )
 
     assert result.exit_code == 1
-    assert "Hosted evaluation failed:" in result.output
+    assert "Hosted evaluation creation returned failed evaluations." in result.output
+    assert "Evaluation IDs:" in result.output
+    assert "eval-123" in result.output
+    assert "Status: FAILED" in result.output
     assert "You are not a member of this team" in result.output
+    assert "prime eval logs eval-123 -f" in result.output
     assert "Hosted evaluation started" not in result.output
+
+
+def test_eval_run_hosted_reports_failed_create_response_with_plural_ids(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        return {
+            "evaluation_ids": ["eval-123", "eval-456"],
+            "status": "FAILED",
+            "error": "Startup failed",
+        }
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "primeintellect/gsm8k", "--hosted", "-m", "openai/gpt-4.1-mini"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "Evaluation IDs:" in result.output
+    assert "eval-123, eval-456" in result.output
+    assert "prime eval logs eval-123 -f" in result.output
+    assert "prime eval logs eval-456 -f" in result.output
 
 
 def test_eval_run_hosted_follow_streams_logs(monkeypatch):

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from prime_cli.client import APIError
 from prime_cli.commands.evals import (
     _create_hosted_evaluations,
@@ -191,6 +192,63 @@ def test_create_hosted_evaluation_accepts_plural_ids_response(monkeypatch):
     )
 
     assert result["evaluation_ids"] == ["eval-123", "eval-456"]
+
+
+def test_create_hosted_evaluation_raises_api_error_for_failed_create_response(monkeypatch):
+    class DummyConfig:
+        team_id = None
+
+    class DummyAPIClient:
+        def __init__(self):
+            self.config = DummyConfig()
+
+        def post(self, endpoint, json=None):
+            return {
+                "evaluation_id": "eval-123",
+                "status": "FAILED",
+                "error": "You are not a member of this team",
+            }
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    with pytest.raises(APIError, match="You are not a member of this team"):
+        _create_hosted_evaluations(
+            HostedEvalConfig(
+                environment_id="env-123",
+                inference_model="openai/gpt-4.1-mini",
+                num_examples=5,
+                rollouts_per_example=3,
+            )
+        )
+
+
+def test_eval_run_hosted_reports_failed_create_response(monkeypatch):
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        raise APIError("You are not a member of this team")
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "primeintellect/gsm8k", "--hosted", "-m", "openai/gpt-4.1-mini"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "Hosted evaluation failed:" in result.output
+    assert "You are not a member of this team" in result.output
+    assert "Hosted evaluation started" not in result.output
 
 
 def test_eval_run_hosted_follow_streams_logs(monkeypatch):


### PR DESCRIPTION
## Summary
- treat hosted eval create responses with status FAILED as errors even when an evaluation_id is returned
- surface the backend error to users instead of printing a false success message
- add unit coverage for helper-level and CLI-level failure handling

## Testing
- pytest packages/prime/tests/test_hosted_eval.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted eval creation/launch flow to treat `status=FAILED` responses as errors and exit non-zero, which can alter CLI behavior for users and CI scripts. Risk is limited to CLI error-handling paths and is covered by new unit tests.
> 
> **Overview**
> **Hosted eval creation failures are now surfaced correctly in the CLI.** When the hosted-eval create API returns `status=FAILED`, the command collects the returned `evaluation_id`/`evaluation_ids`, prints the backend `error`, provides viewer/log commands, and exits with code 1 instead of showing a false success.
> 
> Adds helper logic to normalize singular vs plural evaluation IDs and expands tests to cover failed create responses (including plural IDs and empty `evaluation_ids` fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05651b0e4e8f831f1e675f96ab620530660a7baa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->