### PR TITLE
fix(rl): whitespace-only API logs show placeholder, not blank

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -32,6 +32,9 @@ from ..utils.formatters import format_file_size, strip_ansi
 
 console = get_console()
 
+_RL_LOGS_INITIAL_WAIT_POLL_SECONDS = 5.0
+_RL_LOGS_INITIAL_WAIT_MAX_SECONDS = 30.0
+
 RL_RUN_JSON_HELP = json_output_help(
     ".run = {id, name?, status, base_model, environments[], "
     "rollouts_per_example, max_steps, batch_size, created_at, updated_at, ...}",
@@ -1180,9 +1183,15 @@ def get_logs(
 
                 time.sleep(5)
         else:
-            raw_logs = rl_client.get_logs(run_id, tail_lines=tail)
+            wait_deadline = time.monotonic() + _RL_LOGS_INITIAL_WAIT_MAX_SECONDS
+            raw_logs = ""
+            while time.monotonic() < wait_deadline:
+                raw_logs = rl_client.get_logs(run_id, tail_lines=tail)
+                if raw_logs.strip():
+                    break
+                time.sleep(_RL_LOGS_INITIAL_WAIT_POLL_SECONDS)
             if raw:
-                if raw_logs:
+                if raw_logs.strip():
                     console.print(raw_logs)
                 else:
                     console.print("[yellow]No logs available yet.[/yellow]")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When `prime rl logs` runs without `--follow`, the API can return a response that is only whitespace. Previously, **raw mode** (`--raw`) treated that string as truthy and printed it, so users saw a blank screen instead of the yellow "No logs available yet." message.

## Changes

- Poll for up to 30 seconds (5 second intervals) until log text has non-whitespace content, matching the wait behavior described for this flow.
- Use `raw_logs.strip()` for the raw-mode display branch so whitespace-only responses are handled like empty logs.

Formatted mode was already correct because `clean_logs` strips empty lines; the mismatch was between polling semantics and raw display.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9ac7a7-e5f3-4396-89e4-d8fc9e26c0f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9ac7a7-e5f3-4396-89e4-d8fc9e26c0f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

