### PR TITLE
Simplify enable_thinking config for Qwen3.5 models

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -349,6 +349,24 @@ class SamplingConfig(BaseModel):
     temp_scheduler: TemperatureSchedulerConfig | None = None
     extra_body: Dict[str, Any] | None = None
 
+    @model_validator(mode="after")
+    def wrap_enable_thinking(self) -> "SamplingConfig":
+        """Allow `enable_thinking` as a top-level shorthand in extra_body.
+
+        Transforms:
+            [sampling.extra_body]
+            enable_thinking = false
+
+        Into what the backend expects:
+            [sampling.extra_body]
+            chat_template_kwargs = { enable_thinking = false }
+        """
+        if self.extra_body and "enable_thinking" in self.extra_body:
+            value = self.extra_body.pop("enable_thinking")
+            kwargs = self.extra_body.setdefault("chat_template_kwargs", {})
+            kwargs["enable_thinking"] = value
+        return self
+
 
 class EvalConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -38,6 +38,59 @@ def test_load_config_still_rejects_other_unknown_keys(tmp_path: Path) -> None:
         load_config(str(config_path))
 
 
+def test_enable_thinking_shorthand_wraps_in_chat_template_kwargs(tmp_path: Path) -> None:
+    """enable_thinking in extra_body should be wrapped into chat_template_kwargs."""
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-397B-A17B"\n'
+        "\n"
+        "[sampling.extra_body]\n"
+        "enable_thinking = false\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.sampling.extra_body == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
+
+
+def test_enable_thinking_shorthand_preserves_other_extra_body_keys(tmp_path: Path) -> None:
+    """Other keys in extra_body should be preserved alongside the wrapped value."""
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-397B-A17B"\n'
+        "\n"
+        "[sampling.extra_body]\n"
+        "enable_thinking = false\n"
+        "some_other_key = 42\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.sampling.extra_body == {
+        "chat_template_kwargs": {"enable_thinking": False},
+        "some_other_key": 42,
+    }
+
+
+def test_chat_template_kwargs_still_works_directly(tmp_path: Path) -> None:
+    """The explicit chat_template_kwargs form should still work."""
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "Qwen/Qwen3.5-397B-A17B"\n'
+        "\n"
+        "[sampling.extra_body]\n"
+        "chat_template_kwargs = { enable_thinking = false }\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.sampling.extra_body == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
+
+
 def test_generate_rl_config_template_uses_broad_buffer_threshold_examples() -> None:
     template = generate_rl_config_template()
 


### PR DESCRIPTION
## Summary
- Allow `enable_thinking = false` directly in `[sampling.extra_body]` instead of requiring the verbose `chat_template_kwargs = { enable_thinking = false }` wrapper
- A model validator on `SamplingConfig` automatically wraps the shorthand into the `chat_template_kwargs` structure the backend expects
- The explicit `chat_template_kwargs` form continues to work

## Test plan
- [x] New test: shorthand `enable_thinking` gets wrapped into `chat_template_kwargs`
- [x] New test: other `extra_body` keys are preserved alongside the wrapped value
- [x] New test: explicit `chat_template_kwargs` form still works
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small config-normalization change in the CLI that only rewrites `sampling.extra_body` when `enable_thinking` is provided, with added unit coverage to prevent regressions.
> 
> **Overview**
> Adds a `SamplingConfig` Pydantic model validator that accepts `enable_thinking` as a shorthand key under `sampling.extra_body` and automatically nests it into `chat_template_kwargs` to match backend expectations.
> 
> Extends RL config tests to cover the shorthand transformation, ensure other `extra_body` keys are preserved, and confirm the explicit `chat_template_kwargs` form continues to work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba2f50e77134b629695bec33c448c5ebb1dac86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->