### PR TITLE
Align hosted eval CLI args with backend validation

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -4,7 +4,7 @@ import re
 import time
 from functools import wraps
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import typer
 from click.core import ParameterSource
@@ -17,7 +17,9 @@ from verifiers.cli.commands.eval import (
     merge_sampling_args,
 )
 from verifiers.utils.eval_utils import (
+    _expand_ablation,
     load_endpoints,
+    load_toml,
     load_toml_config,
     resolve_endpoints_file,
 )
@@ -83,6 +85,7 @@ HOSTED_LOGS_DEFAULT_POLL_INTERVAL_SECONDS = 5.0
 HOSTED_RUN_DEFAULT_POLL_INTERVAL_SECONDS = 10.0
 HOSTED_RUN_DEFAULT_NUM_EXAMPLES = 5
 HOSTED_RUN_DEFAULT_ROLLOUTS_PER_EXAMPLE = 3
+HOSTED_TIMEOUT_MINUTES_MINIMUM = 120
 HOSTED_LOGS_RATE_LIMIT_THRESHOLD = 3
 HOSTED_LOGS_RATE_LIMIT_WAIT_SECONDS = 30
 HOSTED_LOGS_RETRY_WAIT_SECONDS = 10
@@ -96,6 +99,7 @@ HOSTED_EVAL_CONFIG_EXTRA_FIELDS = {
     "allow_sandbox_access",
     "allow_instances_access",
     "eval_name",
+    "backend",
 }
 HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
     "env_dir_path": (str, "a non-empty string"),
@@ -138,6 +142,7 @@ HOSTED_SUPPORTED_TOML_FIELDS = {
     "api_base_url",
     "api_client_type",
     "api_key_var",
+    "backend",
     "endpoint_id",
     "endpoints_path",
     "env_id",
@@ -264,6 +269,42 @@ def _coerce_hosted_headers(raw: dict[str, Any]) -> list[str] | None:
     return [f"{name}: {value}" for name, value in normalized.items()]
 
 
+def _normalize_backend_alias_args(args: list[str]) -> list[str]:
+    normalized: list[str] = []
+    saw_backend = False
+    saw_api_client_type = False
+    index = 0
+
+    while index < len(args):
+        arg = args[index]
+        if arg == "--backend":
+            saw_backend = True
+            normalized.append("--api-client-type")
+            if index + 1 < len(args):
+                normalized.append(args[index + 1])
+                index += 2
+                continue
+            index += 1
+            continue
+        if arg.startswith("--backend="):
+            saw_backend = True
+            normalized.extend(["--api-client-type", arg.split("=", 1)[1]])
+            index += 1
+            continue
+
+        if arg == "--api-client-type" or arg.startswith("--api-client-type="):
+            saw_api_client_type = True
+
+        normalized.append(arg)
+        index += 1
+
+    if saw_backend and saw_api_client_type:
+        console.print("[red]Error:[/red] use either `--backend` or `--api-client-type`, not both")
+        raise typer.Exit(1)
+
+    return normalized
+
+
 def _parse_verifiers_eval_namespace(
     environment: str, passthrough_args: list[str], sampling_args: Optional[str]
 ) -> tuple[argparse.Namespace, set[str], dict[str, str]]:
@@ -331,6 +372,17 @@ def _validate_hosted_config_field(
         raise typer.Exit(1)
 
 
+def _validate_hosted_timeout_minutes(timeout_minutes: Optional[int], field_name: str) -> None:
+    if timeout_minutes is None:
+        return
+    if timeout_minutes < HOSTED_TIMEOUT_MINUTES_MINIMUM:
+        console.print(
+            f"[red]Error:[/red] `{field_name}` must be at least "
+            f"{HOSTED_TIMEOUT_MINUTES_MINIMUM} for hosted evaluations"
+        )
+        raise typer.Exit(1)
+
+
 def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) -> str:
     raw_endpoint_id = raw_config.get("endpoint_id")
     raw_model = raw_config.get("model")
@@ -389,9 +441,118 @@ def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) 
     return endpoint_group[0]["model"]
 
 
+def _validate_hosted_backend_alias_scope(
+    scope: dict[str, Any],
+    *,
+    scope_name: str,
+) -> None:
+    if "backend" in scope and "api_client_type" in scope:
+        console.print(
+            "[red]Error:[/red] hosted eval config cannot set both `backend` "
+            f"and `api_client_type` in {scope_name}"
+        )
+        raise typer.Exit(1)
+
+
+def _load_hosted_raw_config(config_path: Path) -> dict[str, Any]:
+    try:
+        with config_path.open("rb") as config_file:
+            return load_toml(config_file)
+    except Exception as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+
+def _validate_hosted_backend_alias_scopes(raw_config: dict[str, Any]) -> None:
+    _validate_hosted_backend_alias_scope(raw_config, scope_name="top-level config")
+
+    eval_entries = raw_config.get("eval")
+    if isinstance(eval_entries, list):
+        for index, eval_entry in enumerate(eval_entries, start=1):
+            if isinstance(eval_entry, dict):
+                _validate_hosted_backend_alias_scope(
+                    eval_entry,
+                    scope_name=f"[[eval]] entry {index}",
+                )
+
+    ablation_entries = raw_config.get("ablation")
+    if isinstance(ablation_entries, list):
+        for index, ablation_entry in enumerate(ablation_entries, start=1):
+            if not isinstance(ablation_entry, dict):
+                continue
+            _validate_hosted_backend_alias_scope(
+                ablation_entry,
+                scope_name=f"[[ablation]] entry {index}",
+            )
+            sweep = ablation_entry.get("sweep")
+            if isinstance(sweep, dict):
+                _validate_hosted_backend_alias_scope(
+                    sweep,
+                    scope_name=f"[[ablation]] entry {index} sweep",
+                )
+
+
+def _collect_hosted_api_client_type_overrides(
+    raw_config: dict[str, Any],
+) -> list[Optional[str]]:
+    overrides: list[Optional[str]] = []
+    global_defaults = {
+        key: value for key, value in raw_config.items() if key not in {"eval", "ablation"}
+    }
+    aliasless_global_defaults = {
+        key: value
+        for key, value in global_defaults.items()
+        if key not in {"backend", "api_client_type"}
+    }
+
+    eval_entries = raw_config.get("eval")
+    if isinstance(eval_entries, list):
+        for eval_entry in eval_entries:
+            if not isinstance(eval_entry, dict):
+                continue
+            overrides.append(
+                cast(Optional[str], eval_entry.get("api_client_type") or eval_entry.get("backend"))
+            )
+
+    ablation_entries = raw_config.get("ablation")
+    if isinstance(ablation_entries, list):
+        for ablation_entry in ablation_entries:
+            if not isinstance(ablation_entry, dict):
+                continue
+            expanded_configs = _expand_ablation(ablation_entry, aliasless_global_defaults)
+            for expanded_config in expanded_configs:
+                overrides.append(
+                    cast(
+                        Optional[str],
+                        expanded_config.get("api_client_type") or expanded_config.get("backend"),
+                    )
+                )
+
+    return overrides
+
+
+def _apply_hosted_api_client_type_overrides(
+    loaded_configs: list[dict[str, Any]],
+    overrides: list[Optional[str]],
+) -> None:
+    for config, override in zip(loaded_configs, overrides):
+        if override is None:
+            continue
+        config["api_client_type"] = override
+        config.pop("backend", None)
+
+
+def _normalize_hosted_backend_alias(merged: dict[str, Any]) -> None:
+    backend = merged.pop("backend", None)
+    if backend is None or "api_client_type" in merged:
+        return
+    merged["api_client_type"] = backend
+
+
 def _validate_single_hosted_eval_config(
     merged: dict[str, Any], config_path: Path
 ) -> dict[str, Any]:
+    _normalize_hosted_backend_alias(merged)
     unsupported_fields = sorted(
         field_name for field_name in merged if field_name not in HOSTED_SUPPORTED_TOML_FIELDS
     )
@@ -427,6 +588,8 @@ def _validate_single_hosted_eval_config(
     for field_name, (expected_type, description) in HOSTED_EVAL_CONFIG_FIELD_TYPES.items():
         _validate_hosted_config_field(merged, field_name, expected_type, description)
 
+    _validate_hosted_timeout_minutes(merged.get("timeout_minutes"), "timeout_minutes")
+
     temperature = merged.get("temperature")
     if temperature is not None and type(temperature) not in {int, float}:
         console.print("[red]Error:[/red] `temperature` must be a number")
@@ -450,6 +613,8 @@ def _validate_single_hosted_eval_config(
 
 def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
     config_path = Path(config_path_str)
+    raw_config = _load_hosted_raw_config(config_path)
+    _validate_hosted_backend_alias_scopes(raw_config)
     try:
         loaded_configs = load_toml_config(
             config_path,
@@ -458,6 +623,11 @@ def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
     except Exception as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
+
+    _apply_hosted_api_client_type_overrides(
+        loaded_configs,
+        _collect_hosted_api_client_type_overrides(raw_config),
+    )
 
     return [
         _validate_single_hosted_eval_config(dict(config), config_path) for config in loaded_configs
@@ -1344,7 +1514,7 @@ def run_eval_cmd(
     ),
 ) -> None:
     """Run an evaluation with local-first environment resolution."""
-    passthrough_args = list(ctx.args)
+    passthrough_args = _normalize_backend_alias_args(list(ctx.args))
 
     if is_help_request(environment or "", passthrough_args):
         print_eval_run_help()
@@ -1498,6 +1668,13 @@ def run_eval_cmd(
                 or None
             )
 
+            effective_timeout_minutes = (
+                timeout_minutes
+                if timeout_minutes is not None
+                else cast(Optional[int], target_config.get("timeout_minutes"))
+            )
+            _validate_hosted_timeout_minutes(effective_timeout_minutes, "timeout_minutes")
+
             effective_targets.append(
                 {
                     "env_id": target_config["env_id"],
@@ -1514,11 +1691,7 @@ def run_eval_cmd(
                         if "env_args" in cli_overrides
                         else target_config.get("env_args")
                     ),
-                    "timeout_minutes": (
-                        timeout_minutes
-                        if timeout_minutes is not None
-                        else target_config.get("timeout_minutes")
-                    ),
+                    "timeout_minutes": effective_timeout_minutes,
                     "allow_sandbox_access": (
                         allow_sandbox_access
                         if allow_sandbox_access

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -132,6 +132,7 @@ def _append_eval_options(help_text: str) -> str:
         "Allow instance creation and management for hosted evaluations.",
         "  --custom-secrets JSON       Custom sandbox secrets for hosted evaluations.",
         "  --eval-name TEXT            Custom name for the hosted evaluation.",
+        "  --backend TEXT              Alias for --api-client-type.",
     ]
     lines = help_text.rstrip("\n").splitlines()
     for extra_line in extra_lines:

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -240,6 +240,63 @@ def test_eval_run_hosted_passes_api_base_url_and_key_var(monkeypatch):
     assert captured["api_key_var"] == "OPENAI_API_KEY"
 
 
+def test_eval_run_hosted_accepts_backend_alias(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_hosted_environment",
+        lambda environment, env_dir_path=None, env_path=None: (
+            "primeintellect/gsm8k",
+            "env-123",
+        ),
+    )
+
+    def fake_run_hosted_evaluation(config, environment_ids=None):
+        captured["api_client_type"] = config.api_client_type
+        return {"evaluation_id": "eval-123"}
+
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._create_hosted_evaluations",
+        fake_run_hosted_evaluation,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "primeintellect/gsm8k",
+            "--hosted",
+            "--backend",
+            "anthropic_messages",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["api_client_type"] == "anthropic_messages"
+
+
+def test_eval_run_hosted_rejects_backend_and_api_client_type_together():
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "primeintellect/gsm8k",
+            "--hosted",
+            "--backend",
+            "anthropic_messages",
+            "--api-client-type",
+            "openai_chat_completions",
+        ],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "use either `--backend` or `--api-client-type`, not both" in result.output
+
+
 def test_eval_run_hosted_passes_extra_env_kwargs(monkeypatch):
     captured = {}
 
@@ -956,6 +1013,27 @@ env_id = "gsm8k"
     assert "`timeout_minutes` must be an integer" in result.output
 
 
+def test_eval_run_hosted_rejects_toml_timeout_minutes_below_backend_minimum(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+timeout_minutes = 60
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "`timeout_minutes` must be at least 120 for hosted evaluations" in result.output
+
+
 def test_eval_run_hosted_rejects_non_json_serializable_sampling_args_in_toml(tmp_path):
     config_path = tmp_path / "eval.toml"
     config_path.write_text(
@@ -1192,6 +1270,72 @@ model = "anthropic/claude-sonnet-4"
     assert loaded["model"] == "anthropic/claude-sonnet-4"
 
 
+def test_hosted_eval_config_accepts_backend_alias(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+backend = "anthropic_messages"
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    loaded = _load_hosted_eval_configs(str(config_path))[0]
+
+    assert loaded["api_client_type"] == "anthropic_messages"
+    assert "backend" not in loaded
+
+
+def test_hosted_eval_config_rejects_backend_and_api_client_type_together(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+backend = "anthropic_messages"
+api_client_type = "openai_chat_completions"
+
+[[eval]]
+env_id = "gsm8k"
+""".strip()
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", str(config_path), "--hosted"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "cannot set both `backend` and `api_client_type`" in result.output
+
+
+@pytest.mark.parametrize(
+    ("global_field", "global_value", "eval_field", "eval_value"),
+    [
+        ("backend", "anthropic_messages", "api_client_type", "openai_chat_completions"),
+        ("api_client_type", "anthropic_messages", "backend", "openai_chat_completions"),
+    ],
+)
+def test_hosted_eval_config_allows_backend_alias_override_across_scopes(
+    tmp_path, global_field, global_value, eval_field, eval_value
+):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        f"""
+{global_field} = "{global_value}"
+
+[[eval]]
+env_id = "gsm8k"
+{eval_field} = "{eval_value}"
+""".strip()
+    )
+
+    loaded = _load_hosted_eval_configs(str(config_path))[0]
+
+    assert loaded["api_client_type"] == eval_value
+    assert "backend" not in loaded
+
+
 def test_eval_run_local_toml_passthrough(monkeypatch, tmp_path):
     captured = {}
     config_path = tmp_path / "eval.toml"
@@ -1253,6 +1397,32 @@ def test_eval_run_local_sampling_args_passthrough(monkeypatch):
     }
 
 
+def test_eval_run_local_backend_alias_passthrough(monkeypatch):
+    captured = {}
+
+    def fake_run_eval_passthrough(environment, passthrough_args, skip_upload, env_path):
+        captured["environment"] = environment
+        captured["passthrough_args"] = passthrough_args
+        captured["skip_upload"] = skip_upload
+        captured["env_path"] = env_path
+
+    monkeypatch.setattr("prime_cli.commands.evals.run_eval_passthrough", fake_run_eval_passthrough)
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--backend", "anthropic_messages"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "environment": "gsm8k",
+        "passthrough_args": ["--api-client-type", "anthropic_messages"],
+        "skip_upload": False,
+        "env_path": None,
+    }
+
+
 @pytest.mark.parametrize(
     ("extra_args", "expected_flag"),
     [
@@ -1309,6 +1479,17 @@ def test_eval_run_hosted_accepts_negative_num_examples_value(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["num_examples"] == -1
+
+
+def test_eval_run_hosted_rejects_timeout_minutes_below_backend_minimum():
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--hosted", "--timeout-minutes", "60"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "`timeout_minutes` must be at least 120 for hosted evaluations" in result.output
 
 
 def test_eval_run_rejects_hosted_only_flags_without_hosted():


### PR DESCRIPTION
## Summary
- add hosted eval CLI/backend alias parity for `--backend` and TOML `backend`
- validate hosted `timeout_minutes` locally so values below the backend minimum fail fast
- add hosted eval regression tests for CLI and TOML parsing/validation

## Testing
- uv run pytest packages/prime/tests/test_hosted_eval.py -q
- uv run prime eval run gsm8k --hosted --timeout-minutes 60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted eval config parsing and CLI argument normalization; incorrect override ordering or scope handling could cause unexpected provider selection or new validation failures for existing configs.
> 
> **Overview**
> Adds `--backend`/TOML `backend` as an alias for `api_client_type` across `prime eval run`, including help text updates, normalization to `--api-client-type`, and explicit errors when both are set.
> 
> Introduces local validation for hosted eval `timeout_minutes`, enforcing a minimum of `120` minutes for both CLI-provided and TOML-derived values (including per-target overrides), with new regression tests covering alias behavior and timeout fast-fail cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a2495fd514821cb814002a0140d565f6611006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->