### PR TITLE
Add top-level enable_thinking and reasoning_effort to RL config

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -1,7 +1,7 @@
 """Hosted RL (Reinforcement Learning) API client."""
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -143,6 +143,8 @@ class RLClient:
         checkpoint_id: Optional[str] = None,
         cluster_name: Optional[str] = None,
         infrastructure_config: Optional[Dict[str, Any]] = None,
+        enable_thinking: Optional[bool] = None,
+        reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
         run_config: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
         """Create a new RL training run."""
@@ -235,6 +237,12 @@ class RLClient:
             if infrastructure_config:
                 if "compute_size" in infrastructure_config:
                     payload["compute_size"] = infrastructure_config["compute_size"]
+
+            if enable_thinking is not None:
+                payload["enable_thinking"] = enable_thinking
+
+            if reasoning_effort is not None:
+                payload["reasoning_effort"] = reasoning_effort
 
             if run_config:
                 payload["run_config"] = run_config

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -4,7 +4,7 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import toml
 import typer
@@ -188,14 +188,16 @@ rollouts_per_example = 8
 # Optional: warm-start from an existing checkpoint
 # checkpoint_id = "..."
 
+# Optional: hosted RL reasoning controls (mutually exclusive)
+# enable_thinking = false    # supported models: Qwen3.5, Nemotron
+# reasoning_effort = "high"  # supported models: GPT-OSS ("low" | "medium" | "high")
+
 [sampling]
 max_tokens = 2048
 # temperature = 0.7
 # repetition_penalty = 1.0
 # min_tokens = 0
 # seed = 42
-# [sampling.extra_body]
-# enable_thinking = false
 
 # Optional: temperature scheduling (use instead of temperature)
 # [sampling.temp_scheduler]
@@ -498,9 +500,17 @@ class RLConfig(BaseModel):
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
+    enable_thinking: bool | None = None
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
     run_config: Dict[str, Any] = Field(default_factory=dict)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _reasoning_controls_mutually_exclusive(self) -> "RLConfig":
+        if self.enable_thinking is not None and self.reasoning_effort is not None:
+            raise ValueError("enable_thinking and reasoning_effort cannot both be set")
+        return self
 
 
 def _format_validation_errors(errors: list[Any]) -> list[str]:
@@ -863,6 +873,8 @@ def create_run(
             checkpoint_id=cfg.checkpoint_id,
             cluster_name=cfg.cluster_name,
             infrastructure_config=cfg.infrastructure.to_api_dict(),
+            enable_thinking=cfg.enable_thinking,
+            reasoning_effort=cfg.reasoning_effort,
             run_config=cfg.run_config if cfg.run_config else None,
         )
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -706,6 +706,10 @@ def create_run(
         console.print(f"  Environments: {', '.join(e.id for e in cfg.env)}")
         if app_config.team_id:
             console.print(f"  Team:         {app_config.team_id}")
+        if cfg.enable_thinking is not None:
+            console.print(f"  Enable Thinking:  {cfg.enable_thinking}")
+        if cfg.reasoning_effort is not None:
+            console.print(f"  Reasoning Effort: {cfg.reasoning_effort}")
 
         # Training
         console.print("\n[cyan]Training[/cyan]")

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -68,3 +68,33 @@ def test_flatten_config_schema_preserves_optional_array_item_types() -> None:
     }
 
     assert rows["buffer.env_ratios"] == "list[number]"
+
+
+def test_load_config_accepts_top_level_reasoning_effort(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "openai/gpt-oss-20b"\nreasoning_effort = "high"\n')
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.reasoning_effort == "high"
+    assert cfg.enable_thinking is None
+
+
+def test_load_config_accepts_top_level_enable_thinking(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "Qwen/Qwen3.5-35B-A3B"\nenable_thinking = false\n')
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.enable_thinking is False
+    assert cfg.reasoning_effort is None
+
+
+def test_load_config_rejects_both_reasoning_controls(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "openai/gpt-oss-20b"\nenable_thinking = false\nreasoning_effort = "low"\n'
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))


### PR DESCRIPTION
Adds the two hosted RL reasoning controls added to the backend in platform#1390 as top-level fields on `RLConfig`, so users don't have to guess the nested `sampling.extra_body.chat_template_kwargs` path.

- `enable_thinking: bool` — Qwen3.5 / Nemotron
- `reasoning_effort: "low" | "medium" | "high"` — GPT-OSS
- Mutual exclusion validated client-side, mirrored from the backend schema
- Forwarded 1:1 in `create_run`; server resolves model-family + trainer-image-version path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional config fields and forwards them to the existing run-creation API, with a small new validation rule that only errors when both options are set.
> 
> **Overview**
> Adds two optional, **top-level** hosted RL reasoning controls to `RLConfig`—`enable_thinking` and `reasoning_effort`—including client-side mutual-exclusion validation and updated `rl init` template/docs.
> 
> Updates `RLClient.create_run` and the `prime rl run` flow to display these settings and forward them 1:1 in the `/rft/runs` payload, and adds tests covering config loading and rejection when both controls are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dec5c628d55df601b81924ad957dcb10c37b069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->