### PR TITLE
improve sandbox bulk delete

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -168,6 +168,9 @@ class BulkDeleteSandboxRequest(BaseModel):
 
     sandbox_ids: Optional[List[str]] = None
     labels: Optional[List[str]] = None
+    team_id: Optional[str] = None
+    user_id: Optional[str] = None
+    all_users: bool = False
 
 
 class BulkDeleteSandboxResponse(BaseModel):

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1427,6 +1427,7 @@ class AsyncSandboxClient:
         page: int = 1,
         per_page: int = 50,
         exclude_terminated: Optional[bool] = None,
+        user_id: Optional[str] = None,
     ) -> SandboxListResponse:
         """List sandboxes"""
         if team_id is None:
@@ -1435,6 +1436,8 @@ class AsyncSandboxClient:
         params: Dict[str, Any] = {"page": page, "per_page": per_page}
         if team_id:
             params["team_id"] = team_id
+        if user_id:
+            params["user_id"] = user_id
         if status:
             params["status"] = status
         if labels:
@@ -1459,13 +1462,23 @@ class AsyncSandboxClient:
         self,
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
+        team_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        all_users: bool = False,
     ) -> BulkDeleteSandboxResponse:
-        """Bulk delete multiple sandboxes by IDs or labels"""
-        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels)
+        """Bulk delete multiple sandboxes."""
+        request = BulkDeleteSandboxRequest(
+            sandbox_ids=sandbox_ids,
+            labels=labels,
+            team_id=team_id,
+            user_id=user_id,
+            all_users=all_users,
+        )
+        payload = request.model_dump(by_alias=False, exclude_none=True)
         response = await self.client.request(
             "DELETE",
             "/sandbox",
-            json=request.model_dump(by_alias=False, exclude_none=True),
+            json=payload,
         )
         return BulkDeleteSandboxResponse.model_validate(response)
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -562,6 +562,7 @@ class SandboxClient:
         page: int = 1,
         per_page: int = 50,
         exclude_terminated: Optional[bool] = None,
+        user_id: Optional[str] = None,
     ) -> SandboxListResponse:
         """List sandboxes"""
         # Auto-populate team_id from config if not specified
@@ -571,6 +572,8 @@ class SandboxClient:
         params: Dict[str, Any] = {"page": page, "per_page": per_page}
         if team_id:
             params["team_id"] = team_id
+        if user_id:
+            params["user_id"] = user_id
         if status:
             params["status"] = status
         if labels:
@@ -595,13 +598,23 @@ class SandboxClient:
         self,
         sandbox_ids: Optional[List[str]] = None,
         labels: Optional[List[str]] = None,
+        team_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        all_users: bool = False,
     ) -> BulkDeleteSandboxResponse:
-        """Bulk delete multiple sandboxes by IDs or labels (must specify one, not both)"""
-        request = BulkDeleteSandboxRequest(sandbox_ids=sandbox_ids, labels=labels)
+        """Bulk delete multiple sandboxes."""
+        request = BulkDeleteSandboxRequest(
+            sandbox_ids=sandbox_ids,
+            labels=labels,
+            team_id=team_id,
+            user_id=user_id,
+            all_users=all_users,
+        )
+        payload = request.model_dump(by_alias=False, exclude_none=True)
         response = self.client.request(
             "DELETE",
             "/sandbox",
-            json=request.model_dump(by_alias=False, exclude_none=True),
+            json=payload,
         )
         return BulkDeleteSandboxResponse.model_validate(response)
 

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -564,73 +564,57 @@ def create(
         raise typer.Exit(1)
 
 
-def _fetch_and_filter_sandboxes(
+def _preview_bulk_delete_count(
     sandbox_client: SandboxClient,
-    only_mine: bool,
-    labels: Optional[List[str]] = None,
-    flag_name: str = "--all",
-) -> Optional[List[str]]:
-    """Fetch sandboxes (optionally by label), filter by only_mine.
+    team_id: Optional[str],
+    user_id: Optional[str],
+    labels: Optional[List[str]],
+) -> Optional[int]:
+    """Fetch the total number of sandboxes matching the scope, cheaply.
 
-    Returns a list of sandbox IDs to delete, or None if there are
-    no matching sandboxes (after printing appropriate messages).
-    Raises typer.Exit(1) if only_mine is set but user_id is missing.
+    Uses a single list(per_page=1) call and reads the total field.
+    Returns None on API error so the caller can still proceed (server will
+    re-evaluate the filter on delete).
     """
-    status_msg = (
-        "[bold blue]Fetching sandboxes by labels..."
-        if labels
-        else "[bold blue]Fetching all sandboxes..."
-    )
-    with console.status(status_msg, spinner="dots"):
-        all_sandboxes = []
-        page = 1
-        while True:
-            list_response = sandbox_client.list(
-                per_page=100,
-                page=page,
-                labels=labels,
-                exclude_terminated=True,
-            )
-            all_sandboxes.extend(list_response.sandboxes)
-            if not list_response.has_next:
-                break
-            page += 1
+    try:
+        response = sandbox_client.list(
+            per_page=1,
+            page=1,
+            team_id=team_id,
+            user_id=user_id,
+            labels=labels or None,
+            exclude_terminated=True,
+        )
+    except APIError:
+        return None
+    return response.total
 
-        if only_mine:
-            current_user_id = config.user_id
-            if not current_user_id:
-                console.print(
-                    "[red]Error:[/red] Cannot filter by user"
-                    " - no user_id configured. Use --all-users"
-                    " to delete all sandboxes, or configure"
-                    " your user_id."
-                )
-                raise typer.Exit(1)
-            sandboxes_to_delete = [s for s in all_sandboxes if s.user_id == current_user_id]
-        else:
-            sandboxes_to_delete = all_sandboxes
 
-        sandbox_ids = [s.id for s in sandboxes_to_delete]
+def _display_bulk_delete_result(result: BulkDeleteSandboxResponse) -> None:
+    """Pretty-print a single bulk_delete response."""
+    total = len(result.succeeded) + len(result.failed)
+    console.print(f"\n[green]Processed {total} sandbox(es)[/green]")
 
-        if not sandbox_ids:
-            console.print("[yellow]No sandboxes to delete[/yellow]")
-            if only_mine and all_sandboxes:
-                console.print(
-                    f"\n[dim]Note: {flag_name} only deletes your"
-                    " own sandboxes by default. Use --all-users"
-                    " to delete sandboxes from all team"
-                    " members.[/dim]"
-                )
-            return None
+    if result.succeeded:
+        console.print(
+            f"\n[bold green]Successfully deleted {len(result.succeeded)} sandbox(es):[/bold green]"
+        )
+        for sid in result.succeeded:
+            console.print(f"  ✓ {sid}")
 
-    return sandbox_ids
+    if result.failed:
+        console.print(f"\n[bold red]Failed to delete {len(result.failed)} sandbox(es):[/bold red]")
+        for failure in result.failed:
+            sid = failure.get("sandbox_id", "unknown")
+            error = failure.get("error", "unknown error")
+            console.print(f"  ✗ {sid}: {error}")
 
 
 def _bulk_delete_and_display(
     sandbox_client: SandboxClient,
     sandbox_ids: List[str],
 ) -> None:
-    """Batch-delete sandbox IDs and print results."""
+    """Batch-delete explicit sandbox IDs (up to 500 per request) and print results."""
     batch_size = 100
     all_succeeded: List[str] = []
     all_failed: List[Dict[str, Any]] = []
@@ -655,22 +639,13 @@ def _bulk_delete_and_display(
             if result.failed:
                 all_failed.extend(result.failed)
 
-    total = len(all_succeeded) + len(all_failed)
-    console.print(f"\n[green]Processed {total} sandbox(es)[/green]")
-
-    if all_succeeded:
-        console.print(
-            f"\n[bold green]Successfully deleted {len(all_succeeded)} sandbox(es):[/bold green]"
+    _display_bulk_delete_result(
+        BulkDeleteSandboxResponse(
+            succeeded=all_succeeded,
+            failed=all_failed,
+            message="",
         )
-        for sid in all_succeeded:
-            console.print(f"  ✓ {sid}")
-
-    if all_failed:
-        console.print(f"\n[bold red]Failed to delete {len(all_failed)} sandbox(es):[/bold red]")
-        for failure in all_failed:
-            sid = failure.get("sandbox_id", "unknown")
-            error = failure.get("error", "unknown error")
-            console.print(f"  ✗ {sid}: {error}")
+    )
 
 
 @app.command(no_args_is_help=True)
@@ -687,14 +662,19 @@ def delete(
         True,
         "--only-mine/--all-users",
         "-m/-A",
-        help="Restrict '--all' and '--label' deletes to only your sandboxes",
+        help=(
+            "Restrict '--all' and '--label' deletes to your own sandboxes."
+            " --all-users deletes across every user in the team and requires"
+            " team admin role."
+        ),
         show_default=True,
     ),
 ) -> None:
     """Delete one or more sandboxes by ID, by label, or all sandboxes with --all
 
-    --only-mine controls whether '--all' and '--label' will restrict
-    to your sandboxes or delete for all users.
+    '--all' and '--label' perform a single server-side scoped delete: by
+    default it is scoped to your own sandboxes in the configured team.
+    Pass '--all-users' to delete across the whole team (team admin only).
     """
     try:
         base_client = APIClient()
@@ -712,50 +692,89 @@ def delete(
             )
             raise typer.Exit(1)
 
-        if all:
-            sandbox_ids = _fetch_and_filter_sandboxes(sandbox_client, only_mine, flag_name="--all")
-            if sandbox_ids is None:
-                return
-        elif labels:
-            sandbox_ids = _fetch_and_filter_sandboxes(
+        if all or labels:
+            team_id = config.team_id
+            if only_mine:
+                scope_user_id = config.user_id
+                all_users_flag = False
+                if not scope_user_id:
+                    console.print(
+                        "[red]Error:[/red] Cannot scope to your sandboxes -"
+                        " no user_id configured. Use --all-users to delete"
+                        " sandboxes across the team (requires team admin), or"
+                        " configure your user_id."
+                    )
+                    raise typer.Exit(1)
+            else:
+                scope_user_id = None
+                all_users_flag = True
+
+            total = _preview_bulk_delete_count(
                 sandbox_client,
-                only_mine,
+                team_id=team_id,
+                user_id=scope_user_id,
                 labels=labels,
-                flag_name="--label",
             )
-            if sandbox_ids is None:
+
+            if total == 0:
+                console.print("[yellow]No sandboxes to delete[/yellow]")
+                if only_mine:
+                    console.print(
+                        "\n[dim]Note: --all/--label only deletes your own"
+                        " sandboxes by default. Use --all-users to delete"
+                        " sandboxes from all team members (requires team"
+                        " admin).[/dim]"
+                    )
                 return
-        else:
-            parsed_ids = []
-            for id_string in sandbox_ids or []:
-                if "," in id_string:
-                    parsed_ids.extend([id.strip() for id in id_string.split(",") if id.strip()])
-                else:
-                    parsed_ids.append(id_string.strip())
 
-            cleaned_ids = []
-            seen = set()
-            for id in parsed_ids:
-                if id and id not in seen:
-                    cleaned_ids.append(id)
-                    seen.add(id)
-            sandbox_ids = cleaned_ids
-
-        if labels:
-            labels_str = ", ".join(labels)
-            confirmation_msg = (
-                f"Are you sure you want to delete {len(sandbox_ids)} "
-                f"sandbox(es) with labels: {labels_str}? "
-                f"This action cannot be undone."
-            )
+            count_str = str(total) if total is not None else "all matching"
+            scope_suffix = "" if only_mine else " across ALL users"
+            if labels:
+                labels_str = ", ".join(labels)
+                confirmation_msg = (
+                    f"Are you sure you want to delete {count_str} sandbox(es)"
+                    f" with labels: {labels_str}{scope_suffix}? This action"
+                    " cannot be undone."
+                )
+                cancel_msg = "Delete cancelled"
+            else:
+                confirmation_msg = (
+                    f"Are you sure you want to delete ALL {count_str}"
+                    f" sandbox(es){scope_suffix}? This action cannot be undone."
+                )
+                cancel_msg = "Delete all cancelled"
 
             if not confirm_or_skip(confirmation_msg, yes):
-                console.print("Delete cancelled")
+                console.print(cancel_msg)
                 return
 
-            _bulk_delete_and_display(sandbox_client, sandbox_ids)
+            with console.status("[bold blue]Deleting sandboxes...", spinner="dots"):
+                result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(
+                    team_id=team_id,
+                    user_id=scope_user_id,
+                    all_users=all_users_flag,
+                    labels=labels or None,
+                )
 
-        elif len(sandbox_ids) == 1 and not all:
+            _display_bulk_delete_result(result)
+            return
+
+        parsed_ids = []
+        for id_string in sandbox_ids or []:
+            if "," in id_string:
+                parsed_ids.extend([id.strip() for id in id_string.split(",") if id.strip()])
+            else:
+                parsed_ids.append(id_string.strip())
+
+        cleaned_ids = []
+        seen = set()
+        for id in parsed_ids:
+            if id and id not in seen:
+                cleaned_ids.append(id)
+                seen.add(id)
+        sandbox_ids = cleaned_ids
+
+        if len(sandbox_ids) == 1:
             sandbox_id = sandbox_ids[0]
             if not confirm_or_skip(f"Are you sure you want to delete sandbox {sandbox_id}?", yes):
                 console.print("Delete cancelled")
@@ -765,25 +784,14 @@ def delete(
                 sandbox_client.delete(sandbox_id)
 
             console.print(f"[green]Successfully deleted sandbox {sandbox_id}[/green]")
+            return
 
-        else:
-            if all:
-                confirmation_msg = (
-                    f"Are you sure you want to delete ALL {len(sandbox_ids)} "
-                    f"sandbox(es)? This action cannot be undone."
-                )
-                cancel_msg = "Delete all cancelled"
-            else:
-                confirmation_msg = (
-                    f"Are you sure you want to delete {len(sandbox_ids)} sandbox(es)?"
-                )
-                cancel_msg = "Bulk delete cancelled"
+        confirmation_msg = f"Are you sure you want to delete {len(sandbox_ids)} sandbox(es)?"
+        if not confirm_or_skip(confirmation_msg, yes):
+            console.print("Bulk delete cancelled")
+            return
 
-            if not confirm_or_skip(confirmation_msg, yes):
-                console.print(cancel_msg)
-                return
-
-            _bulk_delete_and_display(sandbox_client, sandbox_ids)
+        _bulk_delete_and_display(sandbox_client, sandbox_ids)
 
     except typer.Exit:
         raise

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -727,20 +727,25 @@ def delete(
                     )
                 return
 
-            count_str = str(total) if total is not None else "all matching"
             scope_suffix = "" if only_mine else " across ALL users"
             if labels:
                 labels_str = ", ".join(labels)
+                count_phrase = (
+                    f"{total} sandbox(es)" if total is not None else "all matching sandboxes"
+                )
                 confirmation_msg = (
-                    f"Are you sure you want to delete {count_str} sandbox(es)"
+                    f"Are you sure you want to delete {count_phrase}"
                     f" with labels: {labels_str}{scope_suffix}? This action"
                     " cannot be undone."
                 )
                 cancel_msg = "Delete cancelled"
             else:
+                count_phrase = (
+                    f"ALL {total} sandbox(es)" if total is not None else "EVERY matching sandbox"
+                )
                 confirmation_msg = (
-                    f"Are you sure you want to delete ALL {count_str}"
-                    f" sandbox(es){scope_suffix}? This action cannot be undone."
+                    f"Are you sure you want to delete {count_phrase}"
+                    f"{scope_suffix}? This action cannot be undone."
                 )
                 cancel_msg = "Delete all cancelled"
 

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -242,9 +242,15 @@ def test_sandbox_create_vm_without_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["request"].gpu_count == 0
 
 
-def test_sandbox_delete_by_label_only_deletes_owned_sandboxes(
+def test_sandbox_delete_by_label_scopes_to_caller(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Default --label delete scopes to the caller's user_id server-side.
+
+    The CLI now makes a single ``list(per_page=1)`` call to preview the count,
+    then a single ``bulk_delete`` with the scope/labels — the server does the
+    filtering, so no pagination and no client-side user_id filter.
+    """
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
     monkeypatch.setenv("PRIME_USER_ID", "user-1")
@@ -254,17 +260,17 @@ def test_sandbox_delete_by_label_only_deletes_owned_sandboxes(
     def mock_list(self: Any, **kwargs: Any) -> Any:
         captured["list_kwargs"] = kwargs
         return SimpleNamespace(
-            sandboxes=[
-                SimpleNamespace(id="sbx-owned", user_id="user-1"),
-                SimpleNamespace(id="sbx-other", user_id="user-2"),
-            ],
+            sandboxes=[SimpleNamespace(id="sbx-owned", user_id="user-1")],
+            total=1,
+            page=1,
+            per_page=1,
             has_next=False,
         )
 
-    def mock_bulk_delete(self: Any, sandbox_ids: list[str] | None = None, **_: Any) -> Any:
-        captured["sandbox_ids"] = sandbox_ids
+    def mock_bulk_delete(self: Any, **kwargs: Any) -> Any:
+        captured["bulk_delete_kwargs"] = kwargs
         return SimpleNamespace(
-            succeeded=sandbox_ids or [],
+            succeeded=["sbx-owned"],
             failed=[],
             message="deleted",
         )
@@ -276,29 +282,46 @@ def test_sandbox_delete_by_label_only_deletes_owned_sandboxes(
 
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
-    assert captured["list_kwargs"]["labels"] == ["keep"]
-    assert captured["list_kwargs"]["exclude_terminated"] is True
-    assert captured["sandbox_ids"] == ["sbx-owned"]
+
+    # Preview call: scoped to caller + labels, only active sandboxes
+    list_kwargs = captured["list_kwargs"]
+    assert list_kwargs["labels"] == ["keep"]
+    assert list_kwargs["user_id"] == "user-1"
+    assert list_kwargs["exclude_terminated"] is True
+    assert list_kwargs["per_page"] == 1
+
+    # Delete call: server-side scope, no client-side ID list
+    bulk_kwargs = captured["bulk_delete_kwargs"]
+    assert bulk_kwargs["labels"] == ["keep"]
+    assert bulk_kwargs["user_id"] == "user-1"
+    assert bulk_kwargs["all_users"] is False
+    assert bulk_kwargs.get("sandbox_ids") is None
+
     assert "Successfully deleted 1 sandbox(es):" in output
 
 
-def test_sandbox_delete_by_label_aligns_with_all_active_only_filter(
+def test_sandbox_delete_by_label_all_users_passes_admin_scope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """--all-users flips user_id scoping to all_users=True (server admin-gated)."""
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
     monkeypatch.setenv("PRIME_USER_ID", "user-1")
 
+    captured: dict[str, Any] = {}
+
     def mock_list(self: Any, **kwargs: Any) -> Any:
-        assert kwargs["labels"] == ["archive"]
-        assert kwargs["exclude_terminated"] is True
+        captured["list_kwargs"] = kwargs
         return SimpleNamespace(
             sandboxes=[SimpleNamespace(id="sbx-active", user_id="user-1")],
+            total=1,
+            page=1,
+            per_page=1,
             has_next=False,
         )
 
-    def mock_bulk_delete(self: Any, sandbox_ids: list[str] | None = None, **_: Any) -> Any:
-        assert sandbox_ids == ["sbx-active"]
+    def mock_bulk_delete(self: Any, **kwargs: Any) -> Any:
+        captured["bulk_delete_kwargs"] = kwargs
         return SimpleNamespace(
             succeeded=["sbx-active"],
             failed=[],
@@ -308,8 +331,19 @@ def test_sandbox_delete_by_label_aligns_with_all_active_only_filter(
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
     monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.bulk_delete", mock_bulk_delete)
 
-    result = runner.invoke(app, ["sandbox", "delete", "--label", "archive", "--yes"])
+    result = runner.invoke(app, ["sandbox", "delete", "--label", "archive", "--all-users", "--yes"])
 
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
+
+    list_kwargs = captured["list_kwargs"]
+    assert list_kwargs["labels"] == ["archive"]
+    assert list_kwargs["exclude_terminated"] is True
+    assert list_kwargs["user_id"] is None
+
+    bulk_kwargs = captured["bulk_delete_kwargs"]
+    assert bulk_kwargs["labels"] == ["archive"]
+    assert bulk_kwargs["all_users"] is True
+    assert bulk_kwargs["user_id"] is None
+
     assert "Processed 1 sandbox(es)" in output

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -240,3 +240,76 @@ def test_sandbox_create_vm_without_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Successfully created sandbox sbx-vm-123" in output
     assert captured["request"].vm is True
     assert captured["request"].gpu_count == 0
+
+
+def test_sandbox_delete_by_label_only_deletes_owned_sandboxes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    monkeypatch.setenv("PRIME_USER_ID", "user-1")
+
+    captured: dict[str, Any] = {}
+
+    def mock_list(self: Any, **kwargs: Any) -> Any:
+        captured["list_kwargs"] = kwargs
+        return SimpleNamespace(
+            sandboxes=[
+                SimpleNamespace(id="sbx-owned", user_id="user-1"),
+                SimpleNamespace(id="sbx-other", user_id="user-2"),
+            ],
+            has_next=False,
+        )
+
+    def mock_bulk_delete(self: Any, sandbox_ids: list[str] | None = None, **_: Any) -> Any:
+        captured["sandbox_ids"] = sandbox_ids
+        return SimpleNamespace(
+            succeeded=sandbox_ids or [],
+            failed=[],
+            message="deleted",
+        )
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.bulk_delete", mock_bulk_delete)
+
+    result = runner.invoke(app, ["sandbox", "delete", "--label", "keep", "--yes"])
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert captured["list_kwargs"]["labels"] == ["keep"]
+    assert captured["list_kwargs"]["exclude_terminated"] is True
+    assert captured["sandbox_ids"] == ["sbx-owned"]
+    assert "Successfully deleted 1 sandbox(es):" in output
+
+
+def test_sandbox_delete_by_label_aligns_with_all_active_only_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    monkeypatch.setenv("PRIME_USER_ID", "user-1")
+
+    def mock_list(self: Any, **kwargs: Any) -> Any:
+        assert kwargs["labels"] == ["archive"]
+        assert kwargs["exclude_terminated"] is True
+        return SimpleNamespace(
+            sandboxes=[SimpleNamespace(id="sbx-active", user_id="user-1")],
+            has_next=False,
+        )
+
+    def mock_bulk_delete(self: Any, sandbox_ids: list[str] | None = None, **_: Any) -> Any:
+        assert sandbox_ids == ["sbx-active"]
+        return SimpleNamespace(
+            succeeded=["sbx-active"],
+            failed=[],
+            message="deleted",
+        )
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.list", mock_list)
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.bulk_delete", mock_bulk_delete)
+
+    result = runner.invoke(app, ["sandbox", "delete", "--label", "archive", "--yes"])
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Processed 1 sandbox(es)" in output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deletion scoping and request payloads for `--all/--label` operations, which are destructive and could delete the wrong set if the backend contract differs; covered by targeted CLI tests but still impacts critical behavior.
> 
> **Overview**
> Improves sandbox bulk deletion to be **server-scoped** instead of client-collected IDs for `prime sandbox delete --all/--label`, with an optional cheap preflight count via `list(per_page=1)` for confirmation messaging.
> 
> Extends the `prime-sandboxes` SDK request/params to support scoping (`team_id`, `user_id`, `all_users`) and adds `user_id` filtering to `SandboxClient.list` (sync + async), then updates the CLI to pass these scope fields (including `--all-users` semantics) and centralizes bulk-delete result printing. Adds CLI tests covering label-based deletes scoped to the caller vs `--all-users`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6311ff39b77ba9646bc38434e4341664990f49cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->