### PR TITLE
feat: add `prime rl env-logs` for env-server pod logs

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -322,19 +322,6 @@ class RLClient:
                 raise APIError(f"Failed to get RL run logs: {e.response.text}")
             raise APIError(f"Failed to get RL run logs: {str(e)}")
 
-    def list_env_servers(self, run_id: str) -> List[Dict[str, Any]]:
-        """List environment server pods for an RL run.
-
-        Each entry has: env_name, env_index, pod_name, status.
-        """
-        try:
-            response = self.client.get(f"/rft/runs/{run_id}/env-servers")
-            return list(response.get("env_servers", []))
-        except Exception as e:
-            if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to list env servers: {e.response.text}")
-            raise APIError(f"Failed to list env servers: {str(e)}")
-
     def get_env_server_logs(
         self,
         run_id: str,

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -311,7 +311,7 @@ class RLClient:
             raise APIError(f"Failed to get RL run: {str(e)}")
 
     def get_logs(self, run_id: str, tail_lines: int = 1000) -> str:
-        """Get logs for an RL run."""
+        """Get orchestrator logs for an RL run."""
         try:
             response = self.client.get(
                 f"/rft/runs/{run_id}/logs", params={"tail_lines": tail_lines}
@@ -321,6 +321,49 @@ class RLClient:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to get RL run logs: {e.response.text}")
             raise APIError(f"Failed to get RL run logs: {str(e)}")
+
+    def list_env_servers(self, run_id: str) -> List[Dict[str, Any]]:
+        """List environment server pods for an RL run.
+
+        Each entry has: env_name, env_index, pod_name, status.
+        """
+        try:
+            response = self.client.get(f"/rft/runs/{run_id}/env-servers")
+            return list(response.get("env_servers", []))
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(f"Failed to list env servers: {e.response.text}")
+            raise APIError(f"Failed to list env servers: {str(e)}")
+
+    def get_env_server_logs(
+        self,
+        run_id: str,
+        env_name: str,
+        env_index: int = 0,
+        tail_lines: int = 1000,
+    ) -> str:
+        """Get logs for a specific env-server pod of an RL run.
+
+        Args:
+            run_id: RL run ID.
+            env_name: Sanitized environment name (e.g. ``reverse-text``).
+            env_index: Index of the env-server pod (default ``0``).
+            tail_lines: Number of lines to tail from the end of the log.
+        """
+        try:
+            response = self.client.get(
+                f"/rft/runs/{run_id}/env-server-logs",
+                params={
+                    "env_name": env_name,
+                    "env_index": env_index,
+                    "tail_lines": tail_lines,
+                },
+            )
+            return response.get("logs", "")
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(f"Failed to get env server logs: {e.response.text}")
+            raise APIError(f"Failed to get env server logs: {str(e)}")
 
     def get_metrics(
         self,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1323,9 +1323,6 @@ def restart_run(
         raise typer.Exit(1)
 
 
-LOG_COMPONENTS = ("orchestrator", "env-server")
-
-
 def _print_new_lines(last_lines: list[str], current_lines: list[str]) -> None:
     """Print only lines in current_lines that aren't in the tail of last_lines.
 
@@ -1346,78 +1343,6 @@ def _print_new_lines(last_lines: list[str], current_lines: list[str]) -> None:
         console.print(line)
 
 
-def _env_server_target_label(env_name: str, env_index: int) -> str:
-    """Human-readable env-server identifier for UI messages."""
-    return f"{env_name}[{env_index}]"
-
-
-def _resolve_env_server(
-    rl_client: RLClient,
-    run_id: str,
-    env: Optional[str],
-    index: int,
-) -> tuple[str, int]:
-    """Resolve an ``--env``/``--index`` pair for env-server log commands.
-
-    Auto-selects the only env-server when ``env`` is omitted and exactly one
-    exists. Otherwise prints the available servers and exits with code 1.
-    """
-    if env is not None:
-        return env, index
-
-    try:
-        env_servers = rl_client.list_env_servers(run_id)
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
-
-    if not env_servers:
-        console.print(
-            "[yellow]No env-server pods found for this run yet. "
-            "Env servers start after the orchestrator initializes.[/yellow]"
-        )
-        raise typer.Exit(1)
-
-    unique_names = {e.get("env_name") for e in env_servers if e.get("env_name")}
-    if len(env_servers) == 1:
-        only = env_servers[0]
-        resolved_name = only.get("env_name")
-        resolved_index_raw = only.get("env_index", "0")
-        try:
-            resolved_index = int(resolved_index_raw) if resolved_index_raw is not None else 0
-        except (TypeError, ValueError):
-            resolved_index = 0
-        if not resolved_name:
-            console.print("[red]Error:[/red] env-server pod is missing an env_name.")
-            raise typer.Exit(1)
-        return resolved_name, resolved_index
-
-    console.print(
-        "[yellow]Multiple env-server pods found. "
-        "Pass --env <name> to pick one (use --index for replicas).[/yellow]\n"
-    )
-    table = Table(title=f"Env servers for {run_id}")
-    table.add_column("Env", style="cyan")
-    table.add_column("Index", justify="right")
-    table.add_column("Pod", style="dim")
-    table.add_column("Status", style="bold")
-    for srv in env_servers:
-        table.add_row(
-            str(srv.get("env_name") or "?"),
-            str(srv.get("env_index") if srv.get("env_index") is not None else "?"),
-            str(srv.get("pod_name") or "?"),
-            str(srv.get("status") or "?"),
-        )
-    console.print(table)
-    if len(unique_names) == 1:
-        (only_name,) = unique_names
-        console.print(
-            "\n[dim]Tip: this run has one env but multiple replicas; "
-            f"try `--env {only_name} --index 0`.[/dim]"
-        )
-    raise typer.Exit(1)
-
-
 def _stream_logs(
     fetch_fn,  # Callable[[int], str]  -- returns raw log text for a given tail
     tail: int,
@@ -1425,7 +1350,7 @@ def _stream_logs(
     follow: bool,
     label: str,
 ) -> None:
-    """Common print loop shared by orchestrator and env-server logs."""
+    """Common print loop shared by orchestrator and env-server log commands."""
 
     def render(raw_logs: str) -> list[str]:
         if raw:
@@ -1471,90 +1396,111 @@ def _stream_logs(
             console.print("[yellow]No logs available yet.[/yellow]")
 
 
+def _handle_logs_api_error(e: APIError) -> None:
+    """Shared error handling for orchestrator/env-server log fetches."""
+    err_str = str(e).lower()
+    if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
+        msg = "Run has not started yet. Logs will be available once running."
+        console.print(f"[yellow]{msg}[/yellow]")
+        raise typer.Exit(0)
+    console.print(f"[red]Error:[/red] {e}")
+    raise typer.Exit(1)
+
+
 @app.command("logs", rich_help_panel="Monitoring")
 def get_logs(
     run_id: str = typer.Argument(..., help="Run ID to get logs for"),
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Show raw logs without formatting"),
-    component: str = typer.Option(
-        "orchestrator",
-        "--component",
-        "-c",
-        help="Which pod to read logs from: orchestrator (default) or env-server.",
-    ),
-    env: Optional[str] = typer.Option(
-        None,
-        "--env",
-        help="Env-server name when --component env-server. "
-        "Omit to auto-select the only env, or list available envs.",
-    ),
-    index: int = typer.Option(
-        0,
-        "--index",
-        help="Env-server replica index when --component env-server (default 0).",
-    ),
 ) -> None:
-    """Get logs for a run.
+    """Get orchestrator logs for a run.
+
+    To fetch logs for a specific env-server pod (useful when an env-server is
+    crash-looping and the orchestrator is stalled), use ``prime rl env-logs``.
 
     Examples:
 
-        prime rl logs <run_id>                                   # orchestrator
+        prime rl logs <run_id>
 
-        prime rl logs <run_id> -f                                # follow orchestrator
-
-        prime rl logs <run_id> --component env-server --env <name>
+        prime rl logs <run_id> -f
     """
-    component_normalized = component.lower().replace("_", "-")
-    if component_normalized not in LOG_COMPONENTS:
-        console.print(
-            f"[red]Error:[/red] --component must be one of "
-            f"{', '.join(LOG_COMPONENTS)} (got {component!r})"
-        )
-        raise typer.Exit(1)
-
     try:
         api_client = APIClient()
         rl_client = RLClient(api_client)
 
-        if component_normalized == "orchestrator":
-            if env is not None:
-                console.print(
-                    "[yellow]Warning:[/yellow] --env is ignored for --component orchestrator."
-                )
-            _stream_logs(
-                fetch_fn=lambda t: rl_client.get_logs(run_id, tail_lines=t),
-                tail=tail,
-                raw=raw,
-                follow=follow,
-                label="orchestrator",
-            )
-        else:
-            resolved_env, resolved_index = _resolve_env_server(rl_client, run_id, env, index)
-            label = f"env-server {_env_server_target_label(resolved_env, resolved_index)}"
-            _stream_logs(
-                fetch_fn=lambda t: rl_client.get_env_server_logs(
-                    run_id,
-                    env_name=resolved_env,
-                    env_index=resolved_index,
-                    tail_lines=t,
-                ),
-                tail=tail,
-                raw=raw,
-                follow=follow,
-                label=label,
-            )
+        _stream_logs(
+            fetch_fn=lambda t: rl_client.get_logs(run_id, tail_lines=t),
+            tail=tail,
+            raw=raw,
+            follow=follow,
+            label="orchestrator",
+        )
 
     except KeyboardInterrupt:
         console.print("\n[dim]Stopped watching logs.[/dim]")
     except APIError as e:
-        err_str = str(e).lower()
-        if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
-            msg = "Run has not started yet. Logs will be available once running."
-            console.print(f"[yellow]{msg}[/yellow]")
-            raise typer.Exit(0)
-        console.print(f"[red]Error:[/red] {e}")
-        raise typer.Exit(1)
+        _handle_logs_api_error(e)
+
+
+@app.command("env-logs", rich_help_panel="Monitoring")
+def get_env_logs(
+    run_id: str = typer.Argument(..., help="Run ID to get env-server logs for"),
+    env: str = typer.Option(
+        ...,
+        "--env",
+        help="Env-server name (e.g. 'reverse-text' or 'opencode-math').",
+    ),
+    index: int = typer.Option(
+        0,
+        "--index",
+        help="Env-server replica index (default 0).",
+    ),
+    tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
+    raw: bool = typer.Option(False, "--raw", "-r", help="Show raw logs without formatting"),
+) -> None:
+    """Get logs for a specific env-server pod of a run.
+
+    Useful when env-server pods crash-loop (e.g. ``ModuleNotFoundError`` during
+    environment import) and the orchestrator stalls silently at
+    ``Starting orchestrator step 0``. ``prime rl logs`` only reads the
+    orchestrator pod, so these failures are invisible without this subcommand.
+
+    ``--env`` is required — pass the sanitized environment name. Use ``--index``
+    to target a specific replica when multiple env-server pods exist for the
+    same environment.
+
+    Examples:
+
+        prime rl env-logs <run_id> --env reverse-text
+
+        prime rl env-logs <run_id> --env opencode-math --index 0 -f
+
+        prime rl env-logs <run_id> --env reverse-text --tail 200 --raw
+    """
+    try:
+        api_client = APIClient()
+        rl_client = RLClient(api_client)
+
+        label = f"env-server {env}[{index}]"
+        _stream_logs(
+            fetch_fn=lambda t: rl_client.get_env_server_logs(
+                run_id,
+                env_name=env,
+                env_index=index,
+                tail_lines=t,
+            ),
+            tail=tail,
+            raw=raw,
+            follow=follow,
+            label=label,
+        )
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Stopped watching logs.[/dim]")
+    except APIError as e:
+        _handle_logs_api_error(e)
 
 
 @app.command("init", rich_help_panel="Commands")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1323,96 +1323,227 @@ def restart_run(
         raise typer.Exit(1)
 
 
+LOG_COMPONENTS = ("orchestrator", "env-server")
+
+
+def _print_new_lines(last_lines: list[str], current_lines: list[str]) -> None:
+    """Print only lines in current_lines that aren't in the tail of last_lines.
+
+    Uses suffix-prefix overlap detection to avoid reprinting lines between polls.
+    """
+    if current_lines == last_lines:
+        return
+    if not last_lines:
+        for line in current_lines:
+            console.print(line)
+        return
+    overlap = 0
+    max_overlap = min(len(last_lines), len(current_lines))
+    for i in range(1, max_overlap + 1):
+        if last_lines[-i:] == current_lines[:i]:
+            overlap = i
+    for line in current_lines[overlap:]:
+        console.print(line)
+
+
+def _env_server_target_label(env_name: str, env_index: int) -> str:
+    """Human-readable env-server identifier for UI messages."""
+    return f"{env_name}[{env_index}]"
+
+
+def _resolve_env_server(
+    rl_client: RLClient,
+    run_id: str,
+    env: Optional[str],
+    index: int,
+) -> tuple[str, int]:
+    """Resolve an ``--env``/``--index`` pair for env-server log commands.
+
+    Auto-selects the only env-server when ``env`` is omitted and exactly one
+    exists. Otherwise prints the available servers and exits with code 1.
+    """
+    if env is not None:
+        return env, index
+
+    try:
+        env_servers = rl_client.list_env_servers(run_id)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if not env_servers:
+        console.print(
+            "[yellow]No env-server pods found for this run yet. "
+            "Env servers start after the orchestrator initializes.[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    unique_names = {e.get("env_name") for e in env_servers if e.get("env_name")}
+    if len(env_servers) == 1:
+        only = env_servers[0]
+        resolved_name = only.get("env_name")
+        resolved_index_raw = only.get("env_index", "0")
+        try:
+            resolved_index = int(resolved_index_raw) if resolved_index_raw is not None else 0
+        except (TypeError, ValueError):
+            resolved_index = 0
+        if not resolved_name:
+            console.print("[red]Error:[/red] env-server pod is missing an env_name.")
+            raise typer.Exit(1)
+        return resolved_name, resolved_index
+
+    console.print(
+        "[yellow]Multiple env-server pods found. "
+        "Pass --env <name> to pick one (use --index for replicas).[/yellow]\n"
+    )
+    table = Table(title=f"Env servers for {run_id}")
+    table.add_column("Env", style="cyan")
+    table.add_column("Index", justify="right")
+    table.add_column("Pod", style="dim")
+    table.add_column("Status", style="bold")
+    for srv in env_servers:
+        table.add_row(
+            str(srv.get("env_name") or "?"),
+            str(srv.get("env_index") if srv.get("env_index") is not None else "?"),
+            str(srv.get("pod_name") or "?"),
+            str(srv.get("status") or "?"),
+        )
+    console.print(table)
+    if len(unique_names) == 1:
+        (only_name,) = unique_names
+        console.print(
+            "\n[dim]Tip: this run has one env but multiple replicas; "
+            f"try `--env {only_name} --index 0`.[/dim]"
+        )
+    raise typer.Exit(1)
+
+
+def _stream_logs(
+    fetch_fn,  # Callable[[int], str]  -- returns raw log text for a given tail
+    tail: int,
+    raw: bool,
+    follow: bool,
+    label: str,
+) -> None:
+    """Common print loop shared by orchestrator and env-server logs."""
+
+    def render(raw_logs: str) -> list[str]:
+        if raw:
+            return raw_logs.splitlines()
+        return clean_logs(raw_logs)
+
+    if follow:
+        console.print(f"[dim]Watching {label} logs... (Ctrl+C to stop)[/dim]\n")
+        last_lines: list[str] = []
+        consecutive_errors = 0
+
+        while True:
+            try:
+                raw_logs = fetch_fn(tail)
+                consecutive_errors = 0
+            except APIError as e:
+                err_str = str(e).lower()
+                if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
+                    console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
+                    time.sleep(10)
+                    continue
+                consecutive_errors += 1
+                if "429" in str(e):
+                    if consecutive_errors >= 3:
+                        console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
+                        time.sleep(30)
+                    else:
+                        time.sleep(10)
+                    continue
+                raise
+
+            current_lines = render(raw_logs)
+            _print_new_lines(last_lines, current_lines)
+            last_lines = current_lines
+            time.sleep(5)
+    else:
+        raw_logs = fetch_fn(tail)
+        rendered = render(raw_logs)
+        if rendered:
+            for line in rendered:
+                console.print(line)
+        else:
+            console.print("[yellow]No logs available yet.[/yellow]")
+
+
 @app.command("logs", rich_help_panel="Monitoring")
 def get_logs(
     run_id: str = typer.Argument(..., help="Run ID to get logs for"),
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Show raw logs without formatting"),
+    component: str = typer.Option(
+        "orchestrator",
+        "--component",
+        "-c",
+        help="Which pod to read logs from: orchestrator (default) or env-server.",
+    ),
+    env: Optional[str] = typer.Option(
+        None,
+        "--env",
+        help="Env-server name when --component env-server. "
+        "Omit to auto-select the only env, or list available envs.",
+    ),
+    index: int = typer.Option(
+        0,
+        "--index",
+        help="Env-server replica index when --component env-server (default 0).",
+    ),
 ) -> None:
-    """Get logs for a run."""
+    """Get logs for a run.
+
+    Examples:
+
+        prime rl logs <run_id>                                   # orchestrator
+
+        prime rl logs <run_id> -f                                # follow orchestrator
+
+        prime rl logs <run_id> --component env-server --env <name>
+    """
+    component_normalized = component.lower().replace("_", "-")
+    if component_normalized not in LOG_COMPONENTS:
+        console.print(
+            f"[red]Error:[/red] --component must be one of "
+            f"{', '.join(LOG_COMPONENTS)} (got {component!r})"
+        )
+        raise typer.Exit(1)
+
     try:
         api_client = APIClient()
         rl_client = RLClient(api_client)
 
-        if follow:
-            console.print(f"[dim]Watching logs for run {run_id}... (Ctrl+C to stop)[/dim]\n")
-            last_lines: list[str] = []
-            consecutive_errors = 0
-
-            while True:
-                try:
-                    raw_logs = rl_client.get_logs(run_id, tail_lines=tail)
-                    consecutive_errors = 0
-
-                    if raw:
-                        # Raw mode with overlap detection
-                        current_lines = raw_logs.splitlines()
-                        if current_lines != last_lines:
-                            if not last_lines:
-                                for line in current_lines:
-                                    console.print(line)
-                            else:
-                                # Find new lines by comparing with previous
-                                overlap = 0
-                                max_overlap = min(len(last_lines), len(current_lines))
-                                for i in range(1, max_overlap + 1):
-                                    if last_lines[-i:] == current_lines[:i]:
-                                        overlap = i
-                                for line in current_lines[overlap:]:
-                                    console.print(line)
-                            last_lines = current_lines
-                    else:
-                        # Formatted mode
-                        formatted_lines = clean_logs(raw_logs)
-
-                        if formatted_lines != last_lines:
-                            if not last_lines:
-                                for line in formatted_lines:
-                                    console.print(line)
-                            else:
-                                # Find new lines by comparing with previous
-                                overlap = 0
-                                max_overlap = min(len(last_lines), len(formatted_lines))
-                                for i in range(1, max_overlap + 1):
-                                    if last_lines[-i:] == formatted_lines[:i]:
-                                        overlap = i
-                                for line in formatted_lines[overlap:]:
-                                    console.print(line)
-
-                            last_lines = formatted_lines
-                except APIError as e:
-                    if "404" in str(e) and (
-                        "queued" in str(e).lower() or "pending" in str(e).lower()
-                    ):
-                        console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
-                        time.sleep(10)
-                        continue
-                    consecutive_errors += 1
-                    if "429" in str(e):
-                        if consecutive_errors >= 3:
-                            console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
-                            time.sleep(30)
-                        else:
-                            time.sleep(10)
-                        continue
-                    raise
-
-                time.sleep(5)
+        if component_normalized == "orchestrator":
+            if env is not None:
+                console.print(
+                    "[yellow]Warning:[/yellow] --env is ignored for --component orchestrator."
+                )
+            _stream_logs(
+                fetch_fn=lambda t: rl_client.get_logs(run_id, tail_lines=t),
+                tail=tail,
+                raw=raw,
+                follow=follow,
+                label="orchestrator",
+            )
         else:
-            raw_logs = rl_client.get_logs(run_id, tail_lines=tail)
-            if raw:
-                if raw_logs:
-                    console.print(raw_logs)
-                else:
-                    console.print("[yellow]No logs available yet.[/yellow]")
-            else:
-                formatted_lines = clean_logs(raw_logs)
-                if formatted_lines:
-                    for line in formatted_lines:
-                        console.print(line)
-                else:
-                    console.print("[yellow]No logs available yet.[/yellow]")
+            resolved_env, resolved_index = _resolve_env_server(rl_client, run_id, env, index)
+            label = f"env-server {_env_server_target_label(resolved_env, resolved_index)}"
+            _stream_logs(
+                fetch_fn=lambda t: rl_client.get_env_server_logs(
+                    run_id,
+                    env_name=resolved_env,
+                    env_index=resolved_index,
+                    tail_lines=t,
+                ),
+                tail=tail,
+                raw=raw,
+                follow=follow,
+                label=label,
+            )
 
     except KeyboardInterrupt:
         console.print("\n[dim]Stopped watching logs.[/dim]")

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -1,8 +1,10 @@
-"""Tests for `prime rl logs` (orchestrator and env-server components)."""
+"""Tests for `prime rl logs` (orchestrator) and `prime rl env-logs` (env-server)."""
 
 from typing import Any, Dict, List
 
 import pytest
+from prime_cli.api.rl import RLClient
+from prime_cli.client import APIError
 from prime_cli.main import app
 from typer.testing import CliRunner
 
@@ -24,7 +26,6 @@ def _make_mock_get(
     responses: Dict[str, Any],
     orchestrator_call_log: List[Dict[str, Any]],
     env_server_call_log: List[Dict[str, Any]],
-    env_servers_list_log: List[int],
 ):
     def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
         if endpoint == f"/rft/runs/{RUN_ID}/logs":
@@ -37,23 +38,21 @@ def _make_mock_get(
                 "env_name": (params or {}).get("env_name"),
                 "env_index": (params or {}).get("env_index", 0),
             }
-        if endpoint == f"/rft/runs/{RUN_ID}/env-servers":
-            env_servers_list_log.append(1)
-            return {"env_servers": responses.get("env_servers", [])}
         raise AssertionError(f"Unexpected endpoint: {endpoint}")
 
     return mock_get
 
 
-def test_logs_defaults_to_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
+# -------------------- `prime rl logs` (orchestrator) --------------------
+
+
+def test_logs_fetches_orchestrator_only(monkeypatch: pytest.MonkeyPatch) -> None:
     orch_calls: List[Dict[str, Any]] = []
     env_calls: List[Dict[str, Any]] = []
-    list_calls: List[int] = []
     mock_get = _make_mock_get(
         {"orchestrator_logs": "orchestrator line one\norchestrator line two"},
         orch_calls,
         env_calls,
-        list_calls,
     )
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
@@ -62,22 +61,35 @@ def test_logs_defaults_to_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.exit_code == 0, result.output
     assert "orchestrator line one" in result.output
     assert "orchestrator line two" in result.output
-    # Orchestrator endpoint hit, env-server endpoints untouched.
+    # Orchestrator endpoint hit; env-server endpoint never called.
     assert len(orch_calls) == 1
     assert orch_calls[0]["tail_lines"] == 1000
     assert env_calls == []
-    assert list_calls == []
 
 
-def test_logs_env_server_with_explicit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_logs_rejects_unknown_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make sure `prime rl logs` has not grown env-specific flags."""
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise AssertionError(f"Should not be called: {endpoint}")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    # --env is an env-logs flag; it must not silently be accepted by `logs`.
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--env", "reverse-text"])
+    assert result.exit_code != 0
+
+
+# -------------------- `prime rl env-logs` --------------------
+
+
+def test_env_logs_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     orch_calls: List[Dict[str, Any]] = []
     env_calls: List[Dict[str, Any]] = []
-    list_calls: List[int] = []
     mock_get = _make_mock_get(
         {"env_server_logs": "env-server crashed: ModuleNotFoundError: no module foo"},
         orch_calls,
         env_calls,
-        list_calls,
     )
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
@@ -85,10 +97,8 @@ def test_logs_env_server_with_explicit_env(monkeypatch: pytest.MonkeyPatch) -> N
         app,
         [
             "rl",
-            "logs",
+            "env-logs",
             RUN_ID,
-            "--component",
-            "env-server",
             "--env",
             "reverse-text",
             "--index",
@@ -101,9 +111,8 @@ def test_logs_env_server_with_explicit_env(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert result.exit_code == 0, result.output
     assert "ModuleNotFoundError" in result.output
-    # Env-server endpoint hit with the right params; orchestrator + list untouched.
+    # Env-server endpoint hit with the right params; orchestrator untouched.
     assert orch_calls == []
-    assert list_calls == []
     assert len(env_calls) == 1
     assert env_calls[0] == {
         "env_name": "reverse-text",
@@ -112,85 +121,96 @@ def test_logs_env_server_with_explicit_env(monkeypatch: pytest.MonkeyPatch) -> N
     }
 
 
-def test_logs_env_server_autoselects_single_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_logs_default_index_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     orch_calls: List[Dict[str, Any]] = []
     env_calls: List[Dict[str, Any]] = []
-    list_calls: List[int] = []
     mock_get = _make_mock_get(
-        {
-            "env_servers": [
-                {
-                    "env_name": "reverse-text",
-                    "env_index": "0",
-                    "pod_name": "rft-env-reverse-text-0",
-                    "status": "Running",
-                }
-            ],
-            "env_server_logs": "only-env-line",
-        },
+        {"env_server_logs": "line"},
         orch_calls,
         env_calls,
-        list_calls,
-    )
-    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
-
-    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--component", "env-server", "--raw"])
-
-    assert result.exit_code == 0, result.output
-    assert "only-env-line" in result.output
-    assert list_calls == [1]
-    assert len(env_calls) == 1
-    assert env_calls[0]["env_name"] == "reverse-text"
-    assert env_calls[0]["env_index"] == 0
-
-
-def test_logs_env_server_lists_when_ambiguous(monkeypatch: pytest.MonkeyPatch) -> None:
-    orch_calls: List[Dict[str, Any]] = []
-    env_calls: List[Dict[str, Any]] = []
-    list_calls: List[int] = []
-    mock_get = _make_mock_get(
-        {
-            "env_servers": [
-                {
-                    "env_name": "reverse-text",
-                    "env_index": "0",
-                    "pod_name": "rft-env-reverse-text-0",
-                    "status": "Running",
-                },
-                {
-                    "env_name": "opencode-math",
-                    "env_index": "0",
-                    "pod_name": "rft-env-opencode-math-0",
-                    "status": "CrashLoopBackOff",
-                },
-            ]
-        },
-        orch_calls,
-        env_calls,
-        list_calls,
     )
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
     result = CliRunner().invoke(
         app,
-        ["rl", "logs", RUN_ID, "--component", "env-server"],
-        env={"COLUMNS": "200"},
+        ["rl", "env-logs", RUN_ID, "--env", "opencode-math", "--raw"],
     )
 
-    assert result.exit_code == 1, result.output
-    # Both env names appear in the listing; no logs were fetched.
-    assert "reverse-text" in result.output
-    assert "opencode-math" in result.output
-    assert env_calls == []
+    assert result.exit_code == 0, result.output
+    assert len(env_calls) == 1
+    assert env_calls[0]["env_index"] == 0
+    assert env_calls[0]["tail_lines"] == 1000
 
 
-def test_logs_rejects_invalid_component(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_logs_requires_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
         raise AssertionError(f"Should not be called: {endpoint}")
 
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
-    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--component", "worker"])
+    result = CliRunner().invoke(app, ["rl", "env-logs", RUN_ID])
+
+    assert result.exit_code != 0, result.output
+
+
+def test_env_logs_run_not_started(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Queued runs return a 404 with a 'queued'/'pending' marker; CLI should
+    exit 0 with a friendly message, matching `prime rl logs` behavior."""
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise APIError("Failed to get env server logs: 404 run is queued")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "env-logs", RUN_ID, "--env", "reverse-text", "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert "has not started yet" in result.output
+
+
+def test_env_logs_run_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise APIError("Failed to get env server logs: run not found")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "env-logs", RUN_ID, "--env", "reverse-text", "--raw"])
 
     assert result.exit_code == 1, result.output
-    assert "--component" in result.output
+    # Rich may wrap lines; collapse whitespace for the substring check.
+    collapsed = " ".join(result.output.lower().split())
+    assert "run not found" in collapsed
+
+
+def test_env_logs_follow_loops_and_dedupes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Follow-mode should re-poll and avoid reprinting overlapping tail lines."""
+    call_count = {"n": 0}
+
+    def mock_get_env_server_logs(
+        self: Any,
+        run_id: str,
+        env_name: str,
+        env_index: int = 0,
+        tail_lines: int = 1000,
+    ) -> str:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return "line-1\nline-2"
+        if call_count["n"] == 2:
+            return "line-2\nline-3"
+        # Break the loop on the third iteration.
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(RLClient, "get_env_server_logs", mock_get_env_server_logs)
+
+    result = CliRunner().invoke(
+        app,
+        ["rl", "env-logs", RUN_ID, "--env", "reverse-text", "--follow", "--raw"],
+    )
+
+    assert result.exit_code == 0, result.output
+    # line-1, line-2, line-3 each appear exactly once.
+    assert result.output.count("line-1") == 1
+    assert result.output.count("line-2") == 1
+    assert result.output.count("line-3") == 1
+    assert call_count["n"] >= 2

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -1,0 +1,196 @@
+"""Tests for `prime rl logs` (orchestrator and env-server components)."""
+
+from typing import Any, Dict, List
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+RUN_ID = "rl-run-123"
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("prime_cli.commands.rl.time.sleep", lambda _: None)
+
+
+def _make_mock_get(
+    responses: Dict[str, Any],
+    orchestrator_call_log: List[Dict[str, Any]],
+    env_server_call_log: List[Dict[str, Any]],
+    env_servers_list_log: List[int],
+):
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        if endpoint == f"/rft/runs/{RUN_ID}/logs":
+            orchestrator_call_log.append(params or {})
+            return {"logs": responses.get("orchestrator_logs", "")}
+        if endpoint == f"/rft/runs/{RUN_ID}/env-server-logs":
+            env_server_call_log.append(params or {})
+            return {
+                "logs": responses.get("env_server_logs", ""),
+                "env_name": (params or {}).get("env_name"),
+                "env_index": (params or {}).get("env_index", 0),
+            }
+        if endpoint == f"/rft/runs/{RUN_ID}/env-servers":
+            env_servers_list_log.append(1)
+            return {"env_servers": responses.get("env_servers", [])}
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    return mock_get
+
+
+def test_logs_defaults_to_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch_calls: List[Dict[str, Any]] = []
+    env_calls: List[Dict[str, Any]] = []
+    list_calls: List[int] = []
+    mock_get = _make_mock_get(
+        {"orchestrator_logs": "orchestrator line one\norchestrator line two"},
+        orch_calls,
+        env_calls,
+        list_calls,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert "orchestrator line one" in result.output
+    assert "orchestrator line two" in result.output
+    # Orchestrator endpoint hit, env-server endpoints untouched.
+    assert len(orch_calls) == 1
+    assert orch_calls[0]["tail_lines"] == 1000
+    assert env_calls == []
+    assert list_calls == []
+
+
+def test_logs_env_server_with_explicit_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch_calls: List[Dict[str, Any]] = []
+    env_calls: List[Dict[str, Any]] = []
+    list_calls: List[int] = []
+    mock_get = _make_mock_get(
+        {"env_server_logs": "env-server crashed: ModuleNotFoundError: no module foo"},
+        orch_calls,
+        env_calls,
+        list_calls,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "rl",
+            "logs",
+            RUN_ID,
+            "--component",
+            "env-server",
+            "--env",
+            "reverse-text",
+            "--index",
+            "2",
+            "--tail",
+            "50",
+            "--raw",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "ModuleNotFoundError" in result.output
+    # Env-server endpoint hit with the right params; orchestrator + list untouched.
+    assert orch_calls == []
+    assert list_calls == []
+    assert len(env_calls) == 1
+    assert env_calls[0] == {
+        "env_name": "reverse-text",
+        "env_index": 2,
+        "tail_lines": 50,
+    }
+
+
+def test_logs_env_server_autoselects_single_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch_calls: List[Dict[str, Any]] = []
+    env_calls: List[Dict[str, Any]] = []
+    list_calls: List[int] = []
+    mock_get = _make_mock_get(
+        {
+            "env_servers": [
+                {
+                    "env_name": "reverse-text",
+                    "env_index": "0",
+                    "pod_name": "rft-env-reverse-text-0",
+                    "status": "Running",
+                }
+            ],
+            "env_server_logs": "only-env-line",
+        },
+        orch_calls,
+        env_calls,
+        list_calls,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--component", "env-server", "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert "only-env-line" in result.output
+    assert list_calls == [1]
+    assert len(env_calls) == 1
+    assert env_calls[0]["env_name"] == "reverse-text"
+    assert env_calls[0]["env_index"] == 0
+
+
+def test_logs_env_server_lists_when_ambiguous(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch_calls: List[Dict[str, Any]] = []
+    env_calls: List[Dict[str, Any]] = []
+    list_calls: List[int] = []
+    mock_get = _make_mock_get(
+        {
+            "env_servers": [
+                {
+                    "env_name": "reverse-text",
+                    "env_index": "0",
+                    "pod_name": "rft-env-reverse-text-0",
+                    "status": "Running",
+                },
+                {
+                    "env_name": "opencode-math",
+                    "env_index": "0",
+                    "pod_name": "rft-env-opencode-math-0",
+                    "status": "CrashLoopBackOff",
+                },
+            ]
+        },
+        orch_calls,
+        env_calls,
+        list_calls,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(
+        app,
+        ["rl", "logs", RUN_ID, "--component", "env-server"],
+        env={"COLUMNS": "200"},
+    )
+
+    assert result.exit_code == 1, result.output
+    # Both env names appear in the listing; no logs were fetched.
+    assert "reverse-text" in result.output
+    assert "opencode-math" in result.output
+    assert env_calls == []
+
+
+def test_logs_rejects_invalid_component(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise AssertionError(f"Should not be called: {endpoint}")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--component", "worker"])
+
+    assert result.exit_code == 1, result.output
+    assert "--component" in result.output


### PR DESCRIPTION
## Problem

`prime rl logs <run_id>` only streams the orchestrator pod. When an env-server pod crash-loops (e.g. `ModuleNotFoundError` during environment import), the orchestrator silently stalls at `Starting orchestrator step 0`, and the CLI user sees no signal — they have to open the web dashboard to read the failing env-server log. The backend already exposes env-server logs (the web UI uses them); the CLI just wasn't wired up.

## What this PR does

Adds a new **subcommand** `prime rl env-logs` that calls `GET /rft/runs/{run_id}/env-server-logs`:

```
prime rl env-logs <run_id> --env <env_name> [--index N] \
    [-n/--tail N] [-f/--follow] [-r/--raw] [--plain]
```

- `--env` is **required** (no default) — users must name which env-server to read.
- `--index` defaults to `0`; use it to disambiguate replicas of the same env.
- `--tail` defaults to `1000`, matching `prime rl logs`.
- `--follow/-f` polls the endpoint on the same interval as `prime rl logs` (5s), reusing the same `_stream_logs` helper so suffix/prefix overlap dedup, 404/queued, and 429/rate-limit handling are identical.
- `--raw/-r` and the global `--plain` are mirrored from `prime rl logs`.

### Design notes

- **Not a flag on `logs`.** `--env`/`--index` are meaningless under orchestrator mode, so bolting them onto `logs` would make them dead flags half the time. A dedicated subcommand keeps flag surface scoped. `prime rl logs` behavior and help text are unchanged — no one scripting against it needs to care.
- **One pod per invocation, mirroring `kubectl logs`.** No interleaved multi-pod streaming — the suffix-overlap math in follow-mode gets awkward quickly across multiple streams. If that becomes necessary, it can land separately.
- **No env-server discovery endpoint.** The user names the env directly. The backend only exposes the log-fetch endpoint.

### Error handling (same style as `prime rl logs`)

- Queued/pending runs → friendly "Run has not started yet" message, exit 0.
- Run not found / access denied / other API errors → red error, exit 1.
- `Ctrl+C` in follow-mode → "Stopped watching logs.", exit 0.

## Files

- `packages/prime/src/prime_cli/api/rl.py` — `RLClient.get_env_server_logs(run_id, env_name, env_index=0, tail_lines=1000)`.
- `packages/prime/src/prime_cli/commands/rl.py` — new `env-logs` subcommand; extracted shared `_stream_logs` and `_print_new_lines` helpers; factored a `_handle_logs_api_error` helper so `logs` and `env-logs` surface the same error messages.
- `packages/prime/tests/test_rl_logs.py` — rewritten: `logs` still orchestrator-only (plus a guard that it does not silently accept `--env`); env-logs happy path; required `--env`; queued-run friendly exit; not-found hard error; follow-mode loop with overlap dedup.

## Test plan

- [x] `uv run pytest packages/prime/tests/test_rl_logs.py -v` — 8 tests, all pass.
- [x] `uv run pytest packages/prime/tests/ -k "logs or rl"` — 27 tests, all pass.
- [x] `uv run ruff check` on touched files — clean.
- [x] `uv run ruff format` on touched files — clean.
- [x] `uv run ty check src/` — clean.
- [x] `prime rl --help` shows `env-logs` in the Monitoring panel; `prime rl env-logs --help` shows `--env` as required with `--index`, `--tail`, `--follow`, `--raw`, `--plain`.
- [x] `prime rl logs --help` is unchanged from pre-branch (no new flags leaked).

## Limitations / follow-ups

- No multi-pod interleaved streaming (`--component all`-style). If operators want a one-shot overview, they run `prime rl env-logs` per env in separate panes. Can be revisited if the need is real.
- No tab-completion of `--env` values — the backend doesn't currently expose a per-run env-server list endpoint, and the brief explicitly requires the user name the env, so there's nothing to complete against. Could be added later if a listing endpoint is shipped.
- Follow-mode polls (does not stream) — same as `prime rl logs`. Matches backend shape, which returns a tail snapshot per request.

Backend endpoint (pre-existing, not modified by this PR): `GET /rft/runs/{run_id}/env-server-logs` with `?env_name=&env_index=&tail_lines=`, same `rft:read` scope as `/logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)