### PR TITLE
fix: split sandbox gateway retry tuple so ReadError retries only on idempotent methods

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -61,12 +61,27 @@ from .rpc_command_session import (
     collect_command_session_start_event,
 )
 
-# Retry configuration for transient connection errors on gateway requests
-# Note: ReadTimeout is NOT included because the request may have been processed
-GATEWAY_RETRYABLE_EXCEPTIONS = (
+# Connection-level errors: request never reached the server, so retry is safe
+# for any HTTP method (including non-idempotent POSTs).
+# Note: ReadTimeout / ReadError are NOT in this tuple because they occur after
+# the server has (at least partially) started responding — meaning the request
+# was already processed and a retry would duplicate side effects on POST.
+GATEWAY_CONNECTION_RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
+)
+
+# Response-read failures: the server may have already processed the request
+# (TCP connection dropped mid-response body). Only safe to retry on idempotent
+# methods (GET/HEAD/PUT/DELETE), where a duplicate request is a no-op.
+# ReadTimeout is STILL excluded even for idempotent methods — we can't
+# distinguish "server hanging" from "server mid-processing", and retrying a
+# hung request compounds load on an already-stressed server instead of
+# recovering. ReadError (TCP reset / connection drop during read) is different:
+# the connection is definitively gone, so retrying doesn't pile on.
+GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS = GATEWAY_CONNECTION_RETRYABLE_EXCEPTIONS + (
+    httpx.ReadError,  # TCP connection broken while reading response
 )
 
 # Retryable HTTP 5xx status codes (e.g. Cloudflare 524 timeout, server errors)
@@ -78,8 +93,8 @@ RETRY_409_BASE_DELAY = 0.25  # 250ms, 500ms, 1000ms, 2000ms with exponential bac
 
 
 def _is_retryable_gateway_error(exc: BaseException) -> bool:
-    """Check if an exception is retryable for gateway requests."""
-    if isinstance(exc, GATEWAY_RETRYABLE_EXCEPTIONS):
+    """Check if an exception is retryable for idempotent gateway requests."""
+    if isinstance(exc, GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS):
         return True
     if (
         isinstance(exc, httpx.HTTPStatusError)
@@ -91,7 +106,8 @@ def _is_retryable_gateway_error(exc: BaseException) -> bool:
     return False
 
 
-# Retry decorator for idempotent gateway requests (connection errors + 5xx responses)
+# Retry decorator for idempotent gateway requests (connection errors, ReadError,
+# and 5xx responses). Safe for GET/HEAD/PUT/DELETE since duplicate requests are no-ops.
 _gateway_retry = retry(
     retry=retry_if_exception(_is_retryable_gateway_error),
     stop=stop_after_attempt(4),
@@ -100,9 +116,10 @@ _gateway_retry = retry(
 )
 
 # Retry decorator for non-idempotent gateway requests (connection errors only —
-# 5xx means the server received the request, so retrying risks duplicate side effects)
+# ReadError and 5xx both imply the server received/processed the request, so
+# retrying POSTs on those risks duplicate side effects).
 _gateway_post_retry = retry(
-    retry=retry_if_exception_type(GATEWAY_RETRYABLE_EXCEPTIONS),
+    retry=retry_if_exception_type(GATEWAY_CONNECTION_RETRYABLE_EXCEPTIONS),
     stop=stop_after_attempt(4),
     wait=wait_exponential(multiplier=1, min=1, max=30),
     reraise=True,

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -184,6 +184,33 @@ class TestSyncGatewayRetry:
         assert result == "success"
         assert call_count == 2
 
+    def test_gateway_retry_on_read_error(self):
+        """Test retry on ReadError (TCP drop mid-response) — idempotent path."""
+        from prime_sandboxes.sandbox import _gateway_retry
+
+        call_count = 0
+
+        @_gateway_retry
+        def read_error_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise httpx.ReadError(
+                    "Connection broken", request=httpx.Request("GET", "http://test")
+                )
+            return "success"
+
+        result = read_error_then_succeed()
+        assert result == "success"
+        assert call_count == 2
+
+    def test_is_retryable_gateway_error_accepts_read_error(self):
+        """Predicate reports True for ReadError so idempotent GETs retry."""
+        from prime_sandboxes.sandbox import _is_retryable_gateway_error
+
+        exc = httpx.ReadError("Connection broken", request=httpx.Request("GET", "http://test"))
+        assert _is_retryable_gateway_error(exc) is True
+
     def test_gateway_retry_on_5xx(self):
         """Test retry on 5xx HTTPStatusError (e.g. Cloudflare 524 timeout)."""
         from prime_sandboxes.sandbox import _gateway_retry
@@ -358,5 +385,26 @@ class TestSyncGatewayPostRetry:
 
         with pytest.raises(httpx.HTTPStatusError):
             cf_timeout()
+
+        assert call_count == 1  # no retry
+
+    def test_post_no_retry_on_read_error(self):
+        """ReadError is NOT retried for POST — server may have processed the request,
+        and a retry would duplicate side effects (same hazard as ReadTimeout / 5xx)."""
+        from prime_sandboxes.sandbox import _gateway_post_retry
+
+        call_count = 0
+
+        @_gateway_post_retry
+        def read_error_on_post():
+            nonlocal call_count
+            call_count += 1
+            raise httpx.ReadError(
+                "Connection broken mid-response",
+                request=httpx.Request("POST", "http://test"),
+            )
+
+        with pytest.raises(httpx.ReadError):
+            read_error_on_post()
 
         assert call_count == 1  # no retry


### PR DESCRIPTION
## Problem

`httpx.ReadError` (TCP connection drop while reading a response body) is not currently retried by either gateway retry decorator. For idempotent calls like `read_file` / `get_background_job` (used for background-job polling), a single TCP blip fails the whole rollout when retrying would recover cleanly.

Under RL load (e.g. 384 inflight rollouts, ~1 QPS each) this surfaces as a flood of `Rollout error: Read file failed: ReadError` cascading into group rescheduling. Downstream effect seen in the opencode-math ablation runs on `prime-rl`.

## Why not just add `ReadError` to the existing tuple

`GATEWAY_RETRYABLE_EXCEPTIONS` is consumed by both retry decorators:

- `_gateway_retry` (via `_is_retryable_gateway_error`) — wraps idempotent calls.
- `_gateway_post_retry` — wraps non-idempotent POSTs.

Retrying POSTs on `ReadError` is unsafe: a `ReadError` means the server already started sending the response, so it *definitely* processed the request; a blind retry duplicates the side effect. This is the same hazard the existing comment calls out for `ReadTimeout`, and arguably stronger for `ReadError` (the "some bytes already came back" signal is even more conclusive).

## Change

Split the single tuple into two:

- `GATEWAY_CONNECTION_RETRYABLE_EXCEPTIONS` = `RemoteProtocolError`, `ConnectError`, `PoolTimeout`. Request never reached the server — safe to retry any method. Used by `_gateway_post_retry`.
- `GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS` = the above + `ReadError`. Only safe on GET/HEAD/PUT/DELETE where a duplicate request is a no-op. Used by `_is_retryable_gateway_error` → `_gateway_retry`.

`ReadTimeout` is **still** excluded even for idempotent methods: we can't distinguish "server is hanging" from "server is mid-processing", and retrying a hung request compounds load on an already-stressed server instead of recovering. `ReadError` is different — the connection is definitively gone, so a retry doesn't pile on.

Retry counts, backoff parameters, and `RETRYABLE_5XX_STATUSES` logic are unchanged.

`RETRYABLE_EXCEPTIONS` in `core/client.py` (lower-level generic HTTP client path; already includes `ReadError`) is intentionally untouched — different code path, different review.

## Related

- prime-rl scheduler fix: `PrimeIntellect-ai/prime-rl#2308`
- verifiers timeout fix: `PrimeIntellect-ai/verifiers#1170`
- context on why these errors became newly visible: `PrimeIntellect-ai/verifiers#1127`, `#1130`

## Test plan

- [x] Added `test_gateway_retry_on_read_error`: `ReadError` triggers a retry under `_gateway_retry` (idempotent path).
- [x] Added `test_is_retryable_gateway_error_accepts_read_error`: predicate returns `True` for `ReadError`.
- [x] Added `test_post_no_retry_on_read_error`: `ReadError` is **not** retried under `_gateway_post_retry` (raises through on first attempt, `call_count == 1`).
- [x] Existing 17 retry tests still pass (20/20 green).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on edited files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes retry semantics for gateway requests and could affect error handling and traffic patterns under load, though it is narrowly scoped and covered by new tests.
> 
> **Overview**
> Improves gateway retry logic by splitting retryable exceptions into **connection-only** failures vs **idempotent-safe** failures, and enabling retries on `httpx.ReadError` only for idempotent operations.
> 
> Updates the retry predicate/decorators so POSTs still retry only when the request likely never reached the server, and adds focused tests asserting `ReadError` retries for `_gateway_retry` but not for `_gateway_post_retry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94cd6e86d84e6e943afd0c89d921ca500e77deb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->