### PR TITLE
Clarify hosted eval behavior when local env code differs

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -683,20 +683,6 @@ def _resolve_hosted_environment(
 ) -> tuple[str, str]:
     resolved = _resolve_environment_reference(environment, env_dir_path or DEFAULT_ENV_DIR_PATH)
 
-    if resolved.recommend_push:
-        console.print(
-            "[red]Error:[/red] hosted evaluations require an environment "
-            "that is published to the platform"
-        )
-        if resolved.platform_slug:
-            console.print(
-                "[yellow]Publish the latest local changes for "
-                f"{resolved.platform_slug} first.[/yellow]"
-            )
-        else:
-            console.print("[yellow]Publish the environment with `prime env push` first.[/yellow]")
-        raise typer.Exit(1)
-
     platform_slug = resolved.platform_slug or resolved.upstream_slug
     if platform_slug is None and env_path:
         metadata = find_environment_metadata(
@@ -726,14 +712,34 @@ def _resolve_hosted_environment(
 
     owner, env_name = parts
     api_client = APIClient()
-    response = api_client.get(f"/environmentshub/{owner}/{env_name}/@latest")
+    try:
+        response = api_client.get(f"/environmentshub/{owner}/{env_name}/@latest")
+    except APIError as exc:
+        message = str(exc).lower()
+        if "404" in message or "not found" in message:
+            console.print(
+                "[red]Error:[/red] hosted evaluations require an environment "
+                "that is published to the platform"
+            )
+            console.print(f"[yellow]Publish {platform_slug} with `prime env push` first.[/yellow]")
+            raise typer.Exit(1) from exc
+        raise
+
     details = response.get("data", response)
     environment_id = details.get("id")
     if not environment_id:
         console.print(f"[red]Error:[/red] could not resolve environment id for {platform_slug}")
         raise typer.Exit(1)
 
-    console.print(f"[dim]Using hosted environment {platform_slug}[/dim]")
+    if resolved.install_mode == "local" and resolved.recommend_push:
+        console.print(
+            "[yellow]Local environment code differs from the latest published version of "
+            f"{platform_slug}.[/yellow]"
+        )
+    console.print(
+        f"[dim]Hosted evaluations always use the latest published version of {platform_slug}.[/dim]"
+    )
+    console.print(f"[dim]Using hosted environment {platform_slug}@latest[/dim]")
     return platform_slug, str(environment_id)
 
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 
 import pytest
+import typer
 from prime_cli.client import APIError
 from prime_cli.commands.evals import (
     _create_hosted_evaluations,
     _load_hosted_eval_configs,
     _print_eval_status,
+    _resolve_hosted_environment,
 )
 from prime_cli.main import app
 from prime_cli.utils.hosted_eval import (
@@ -14,6 +16,7 @@ from prime_cli.utils.hosted_eval import (
     filter_progress_bars,
     strip_ansi,
 )
+from prime_cli.verifiers_bridge import ResolvedEnvironment
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -1490,6 +1493,97 @@ def test_eval_run_hosted_passes_env_path_to_resolver(monkeypatch):
         "env_dir_path": None,
         "env_path": "/tmp/local-env",
     }
+
+
+def test_resolve_hosted_environment_warns_when_local_code_differs(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_environment_reference",
+        lambda environment, env_dir_path: ResolvedEnvironment(
+            original=environment,
+            env_name="gsm8k",
+            install_mode="local",
+            env_display_id="gsm8k (local - ahead of primeintellect/gsm8k)",
+            platform_slug="primeintellect/gsm8k",
+            recommend_push=True,
+            push_reason="ahead",
+        ),
+    )
+
+    class DummyAPIClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, endpoint):
+            assert endpoint == "/environmentshub/primeintellect/gsm8k/@latest"
+            return {"data": {"id": "env-123"}}
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    assert _resolve_hosted_environment("gsm8k", env_dir_path=None, env_path=None) == (
+        "primeintellect/gsm8k",
+        "env-123",
+    )
+
+    output = capsys.readouterr().out
+    assert "Local environment code differs from the latest published version of" in output
+    assert "Hosted evaluations always use the latest published version of" in output
+    assert "primeintellect/gsm8k" in output
+    assert "Using hosted environment primeintellect/gsm8k@latest" in output
+
+
+def test_resolve_hosted_environment_requires_a_published_environment(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_environment_reference",
+        lambda environment, env_dir_path: ResolvedEnvironment(
+            original=environment,
+            env_name="gsm8k",
+            install_mode="local",
+            env_display_id="gsm8k (local only)",
+            recommend_push=True,
+            push_reason="local_only",
+        ),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _resolve_hosted_environment("gsm8k", env_dir_path=None, env_path=None)
+
+    assert exc_info.value.exit_code == 1
+    output = capsys.readouterr().out
+    assert "hosted evaluations require an upstream environment on the platform" in output
+    assert "publish the local environment with `prime env push`" in output
+
+
+def test_resolve_hosted_environment_requires_a_pushed_hub_version(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "prime_cli.commands.evals._resolve_environment_reference",
+        lambda environment, env_dir_path: ResolvedEnvironment(
+            original=environment,
+            env_name="gsm8k",
+            install_mode="local",
+            env_display_id="gsm8k (local - ahead of primeintellect/gsm8k)",
+            platform_slug="primeintellect/gsm8k",
+            recommend_push=True,
+            push_reason="ahead",
+        ),
+    )
+
+    class DummyAPIClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, endpoint):
+            raise APIError("404 not found")
+
+    monkeypatch.setattr("prime_cli.commands.evals.APIClient", DummyAPIClient)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _resolve_hosted_environment("gsm8k", env_dir_path=None, env_path=None)
+
+    assert exc_info.value.exit_code == 1
+    output = capsys.readouterr().out
+    assert "hosted evaluations require an environment that is published to the" in output
+    assert "platform" in output
+    assert "Publish primeintellect/gsm8k with `prime env push` first." in output
 
 
 def test_eval_run_hosted_reports_resolve_api_errors(monkeypatch):


### PR DESCRIPTION
## Summary
- allow hosted evals to continue when local environment code is ahead of the published hub version
- warn that hosted evals still run against the latest published environment and show the `@latest` target explicitly
- keep failing with a clear `prime env push` message when no published hub version exists

## Testing
- uv run pytest packages/prime/tests/test_hosted_eval.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted-eval environment resolution and error handling, which can alter when `prime eval run --hosted` proceeds vs exits and how API 404s are interpreted; impact is limited to CLI behavior and messaging.
> 
> **Overview**
> Hosted eval environment resolution no longer hard-fails just because the local environment is ahead of the published hub version; it now proceeds while emitting a warning.
> 
> `_resolve_hosted_environment` now explicitly resolves `@latest` via the hub API, treats missing published versions (404/not found) as a clear `prime env push` actionable error, and always prints that hosted evals run against the **latest published** environment (showing `@latest` in the output).
> 
> Tests add coverage for the new warning path and the two failure modes (no upstream slug available vs hub `@latest` missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f1076d2ceb3f5090c69220431567abb71aa099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->