### PR TITLE
release: prime-sandboxes 0.2.20

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -47,7 +47,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.19"
+__version__ = "0.2.20"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError


### PR DESCRIPTION
Bumps prime-sandboxes to 0.2.20

- Picks up #532 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only updates the SDK package version string, with no functional or API behavior changes. Low risk aside from downstream tooling that consumes `__version__`.
> 
> **Overview**
> Updates `prime_sandboxes.__version__` in `__init__.py` from `0.2.19` to `0.2.20` for the `prime-sandboxes` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa9d6bb7fe2979d189839906b8019e102169fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->