### PR TITLE
fix: honor .dockerignore in prime images push context tarball

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -110,11 +110,20 @@ def push_image(
             tar_path = tmp_file.name
 
         # Build a .dockerignore matcher so we don't upload ignored paths
-        # (e.g. local .venv, node_modules) with the context.
-        dockerignore_path = context_path / ".dockerignore"
+        # (e.g. local .venv, node_modules) with the context. BuildKit
+        # looks for <Dockerfile>.dockerignore next to the Dockerfile first
+        # and falls back to <context>/.dockerignore, so mirror that.
+        per_dockerfile_ignore = dockerfile_path.with_name(dockerfile_path.name + ".dockerignore")
+        root_dockerignore = context_path / ".dockerignore"
+        if per_dockerfile_ignore.is_file():
+            dockerignore_path: Optional[Path] = per_dockerfile_ignore
+        elif root_dockerignore.is_file():
+            dockerignore_path = root_dockerignore
+        else:
+            dockerignore_path = None
         ignore_matcher = (
             parse_gitignore(str(dockerignore_path), base_dir=str(context_path))
-            if dockerignore_path.is_file()
+            if dockerignore_path is not None
             else None
         )
 

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -10,6 +10,7 @@ from typing import Optional
 import click
 import httpx
 import typer
+from gitignore_parser import parse_gitignore
 from prime_sandboxes import APIClient, APIError, Config, UnauthorizedError
 from rich.table import Table
 
@@ -108,9 +109,30 @@ def push_image(
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp_file:
             tar_path = tmp_file.name
 
+        # Build a .dockerignore matcher so we don't upload ignored paths
+        # (e.g. local .venv, node_modules) with the context.
+        dockerignore_path = context_path / ".dockerignore"
+        ignore_matcher = (
+            parse_gitignore(str(dockerignore_path), base_dir=str(context_path))
+            if dockerignore_path.is_file()
+            else None
+        )
+
+        def tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+            if ignore_matcher is None:
+                return tarinfo
+            rel = tarinfo.name
+            if rel.startswith("./"):
+                rel = rel[2:]
+            if not rel or rel == ".":
+                return tarinfo
+            if ignore_matcher(str(context_path / rel)):
+                return None
+            return tarinfo
+
         try:
             with tarfile.open(tar_path, "w:gz") as tar:
-                tar.add(context_path, arcname=".")
+                tar.add(context_path, arcname=".", filter=tar_filter)
                 tar.add(dockerfile_path, arcname=PACKAGED_DOCKERFILE_PATH)
 
             tar_size_mb = Path(tar_path).stat().st_size / (1024 * 1024)


### PR DESCRIPTION
`prime images push` was packaging the entire context (including local `.venv`, `node_modules`, etc.) because `tar.add` ran with no filter.

- Parse `.dockerignore` via `gitignore_parser` (already a dep)
- Filter matching paths out of the tarball before upload

Reported in Slack: a 245MB push ballooned to 373MB after a local `.venv` (374MB) landed in the context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the client-side context tarball creation to exclude `.dockerignore`-matched files, which may slightly alter which files are uploaded but follows standard Docker/BuildKit ignore precedence.
> 
> **Overview**
> `prime images push` now filters the build context tarball using `.dockerignore` rules so ignored paths (e.g. `.venv`, `node_modules`) are not uploaded.
> 
> It mirrors Docker/BuildKit precedence by checking for `<Dockerfile>.dockerignore` next to the Dockerfile before falling back to `<context>/.dockerignore`, applying the matcher via a `tarfile` `filter` during `tar.add`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec6adeeab6e915fa1bf8fe7168d2d38972fb023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->