### PR TITLE
release: cli 0.5.67

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.66"
+__version__ = "0.5.67"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI to 0.5.67. Includes #535 (honor .dockerignore in `prime images push`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the exposed package version string, with no functional or behavioral changes.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.66` to `0.5.67` in `prime_cli/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1a2ca81e2950913045e2179a6951103ea6899b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->