### PR TITLE
feat: add install_prerelease field to rl.toml

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -144,6 +144,7 @@ class RLClient:
         cluster_name: Optional[str] = None,
         infrastructure_config: Optional[Dict[str, Any]] = None,
         run_config: Optional[Dict[str, Any]] = None,
+        install_prerelease: Optional[bool] = None,
     ) -> RLRun:
         """Create a new RL training run."""
         try:
@@ -238,6 +239,9 @@ class RLClient:
 
             if run_config:
                 payload["run_config"] = run_config
+
+            if install_prerelease is not None:
+                payload["install_prerelease"] = install_prerelease
 
             response = self.client.post("/rft/runs", json=payload)
             return RLRun.model_validate(response.get("run"))

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -499,6 +499,7 @@ class RLConfig(BaseModel):
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
     run_config: Dict[str, Any] = Field(default_factory=dict)
+    install_prerelease: bool | None = None
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
 
@@ -864,6 +865,7 @@ def create_run(
             cluster_name=cfg.cluster_name,
             infrastructure_config=cfg.infrastructure.to_api_dict(),
             run_config=cfg.run_config if cfg.run_config else None,
+            install_prerelease=cfg.install_prerelease,
         )
 
         if output == "json":

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -68,3 +68,24 @@ def test_flatten_config_schema_preserves_optional_array_item_types() -> None:
     }
 
     assert rows["buffer.env_ratios"] == "list[number]"
+
+
+def test_load_config_accepts_install_prerelease(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n'
+        "install_prerelease = true\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.install_prerelease is True
+
+
+def test_load_config_install_prerelease_defaults_to_none(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"\n')
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.install_prerelease is None


### PR DESCRIPTION
## Summary
- Adds `install_prerelease: bool | None` to `RLConfig` and threads it through `RLClient.create_run` into the `POST /rft/runs` payload as `install_prerelease`.
- Surfaces the new first-class field the platform API accepts (PrimeIntellect-ai/platform#1481).
- Users can now set `install_prerelease = true` in `rl.toml` to allow pre-release verifiers/env installs on their orchestrator + env-server pods.

## Test plan
- [x] 2 new unit tests in `packages/prime/tests/test_rl_config.py` pass locally; full `test_rl_config.py` suite (7 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single optional config flag and forwards it to the backend without changing default behavior or existing run parameters.
> 
> **Overview**
> Adds an optional `install_prerelease` field to `RLConfig` so users can set it in `rl.toml`, and wires it through `prime rl run` into `RLClient.create_run` as `install_prerelease` in the `/rft/runs` request payload.
> 
> Extends `test_rl_config.py` with coverage confirming the new TOML key is accepted and defaults to `None` when omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d179e678045acdab924bd096600c1955cc192a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->