### PR TITLE
Add eval name to prime eval push if set

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -900,8 +900,12 @@ def _load_eval_directory(directory: Path) -> dict:
         else:
             metadata_copy[key] = value
 
+    eval_name = metadata.get("eval_name") or metadata.get("name")
+    if type(eval_name) is not str or not eval_name:
+        eval_name = f"{env_field}-{metadata['model']}"
+
     return {
-        "eval_name": f"{env_field}-{metadata['model']}",
+        "eval_name": eval_name,
         "model_name": metadata["model"],
         "env": env_field,
         "metrics": metrics,


### PR DESCRIPTION
The PR adds the eval name from the metadata to the eval push if it was set by the user

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to naming derived from `metadata.json`, with no changes to API calls or data processing beyond selecting the eval display name.
> 
> **Overview**
> When loading a local eval directory, the CLI now prefers an explicit eval name from `metadata.json` (via `eval_name` or `name`) instead of always generating `"<env>-<model>"`.
> 
> If the provided name is missing/empty/non-string, it falls back to the previous default generated name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8655f61bbc1d01afc9e15f7c79ef4f0f7b49d41b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->