### PR TITLE
feat: add timeout kwarg to get_background_job

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -873,12 +873,16 @@ class SandboxClient:
         self,
         sandbox_id: str,
         job: BackgroundJob,
+        timeout: Optional[int] = None,
     ) -> BackgroundJobStatus:
         """Check the status of a background job.
 
         Args:
             sandbox_id: The sandbox ID
             job: The BackgroundJob handle from start_background_job()
+            timeout: Optional per-call timeout (in seconds) forwarded to the
+                underlying read_file calls. When None, the APIClient default
+                applies.
 
         Returns:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
@@ -886,7 +890,7 @@ class SandboxClient:
 
         def read_or_empty(path: str) -> str:
             try:
-                return self.read_file(sandbox_id, path).content
+                return self.read_file(sandbox_id, path, timeout=timeout).content
             except SandboxFileNotFoundError:
                 return ""
 
@@ -1724,12 +1728,16 @@ class AsyncSandboxClient:
         self,
         sandbox_id: str,
         job: BackgroundJob,
+        timeout: Optional[int] = None,
     ) -> BackgroundJobStatus:
         """Check the status of a background job (async).
 
         Args:
             sandbox_id: The sandbox ID
             job: The BackgroundJob handle from start_background_job()
+            timeout: Optional per-call timeout (in seconds) forwarded to the
+                underlying read_file calls. When None, the APIClient default
+                applies.
 
         Returns:
             BackgroundJobStatus with completed flag, and exit_code/stdout if done
@@ -1737,7 +1745,7 @@ class AsyncSandboxClient:
 
         async def read_or_empty(path: str) -> str:
             try:
-                return (await self.read_file(sandbox_id, path)).content
+                return (await self.read_file(sandbox_id, path, timeout=timeout)).content
             except SandboxFileNotFoundError:
                 return ""
 

--- a/packages/prime-sandboxes/tests/test_background_job_timeout.py
+++ b/packages/prime-sandboxes/tests/test_background_job_timeout.py
@@ -1,0 +1,132 @@
+"""Unit tests verifying that get_background_job forwards the timeout kwarg."""
+
+from typing import Any, List, Optional, cast
+
+import pytest
+
+from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.models import BackgroundJob, ReadFileResponse
+from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
+
+
+def _make_job() -> BackgroundJob:
+    return BackgroundJob(
+        job_id="job-123",
+        sandbox_id="sbx-123",
+        stdout_log_file="/tmp/job_abc.stdout",
+        stderr_log_file="/tmp/job_abc.stderr",
+        exit_file="/tmp/job_abc.exit",
+    )
+
+
+def test_sync_get_background_job_forwards_timeout_to_read_file():
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client_any = cast(Any, client)
+
+    seen_timeouts: List[Optional[int]] = []
+
+    def fake_read_file(
+        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+    ) -> ReadFileResponse:
+        seen_timeouts.append(timeout)
+        # Empty content => job not completed; single read_file invocation is enough.
+        return ReadFileResponse(content="", size=0)
+
+    client_any.read_file = fake_read_file
+
+    job = _make_job()
+    status = client.get_background_job("sbx-123", job, timeout=60)
+
+    assert not status.completed
+    assert seen_timeouts == [60]
+
+
+def test_sync_get_background_job_defaults_timeout_to_none():
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client_any = cast(Any, client)
+
+    seen_timeouts: List[Optional[int]] = []
+
+    def fake_read_file(
+        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+    ) -> ReadFileResponse:
+        seen_timeouts.append(timeout)
+        return ReadFileResponse(content="", size=0)
+
+    client_any.read_file = fake_read_file
+
+    job = _make_job()
+    client.get_background_job("sbx-123", job)
+
+    assert seen_timeouts == [None]
+
+
+def test_sync_get_background_job_forwards_timeout_on_completed_reads():
+    """When the exit file has content, stdout and stderr are also read - verify
+    all three read_file calls receive the same timeout."""
+
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client_any = cast(Any, client)
+
+    seen_timeouts: List[Optional[int]] = []
+
+    def fake_read_file(
+        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+    ) -> ReadFileResponse:
+        seen_timeouts.append(timeout)
+        if file_path.endswith(".exit"):
+            return ReadFileResponse(content="0\n", size=2)
+        return ReadFileResponse(content="out", size=3)
+
+    client_any.read_file = fake_read_file
+
+    job = _make_job()
+    status = client.get_background_job("sbx-123", job, timeout=45)
+
+    assert status.completed
+    assert status.exit_code == 0
+    # Exit file read, then stdout, then stderr.
+    assert seen_timeouts == [45, 45, 45]
+
+
+@pytest.mark.asyncio
+async def test_async_get_background_job_forwards_timeout_to_read_file():
+    client = AsyncSandboxClient(api_key="test-key")
+    client_any = cast(Any, client)
+
+    seen_timeouts: List[Optional[int]] = []
+
+    async def fake_read_file(
+        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+    ) -> ReadFileResponse:
+        seen_timeouts.append(timeout)
+        return ReadFileResponse(content="", size=0)
+
+    client_any.read_file = fake_read_file
+
+    job = _make_job()
+    status = await client.get_background_job("sbx-123", job, timeout=60)
+
+    assert not status.completed
+    assert seen_timeouts == [60]
+
+
+@pytest.mark.asyncio
+async def test_async_get_background_job_defaults_timeout_to_none():
+    client = AsyncSandboxClient(api_key="test-key")
+    client_any = cast(Any, client)
+
+    seen_timeouts: List[Optional[int]] = []
+
+    async def fake_read_file(
+        sandbox_id: str, file_path: str, timeout: Optional[int] = None
+    ) -> ReadFileResponse:
+        seen_timeouts.append(timeout)
+        return ReadFileResponse(content="", size=0)
+
+    client_any.read_file = fake_read_file
+
+    job = _make_job()
+    await client.get_background_job("sbx-123", job)
+
+    assert seen_timeouts == [None]


### PR DESCRIPTION
## Summary

All sibling `Sandbox` / `AsyncSandbox` methods — `execute_command`, `read_file`, `upload_file`, `download_file` — already accept a per-call `timeout` kwarg that overrides the `APIClient`'s 30s httpx default. `get_background_job` was the lone exception, so callers had no way to extend its effective timeout, even though the method internally just calls `read_file` (which does accept `timeout`).

In practice this surfaced as `Read file timed out after 30s: /tmp/job_XXX.exit` during RL polling loops in `verifiers` when the sandbox gateway had a brief slow response, bubbling up as `AgentError('Agent polling failed: ...')`.

## Change

Add `timeout: Optional[int] = None` to both the sync and async `get_background_job` signatures, and thread it through to the internal `read_file` calls on the exit file, stdout log, and stderr log. Default behavior is unchanged (falls back to `APIClient` default when `timeout` is not passed).

Pattern matches the existing `execute_command` / `read_file` signatures in the same file (`Optional[int]`, default `None`).

## Follow-up

The verifiers side — `CliAgentEnv.poll_job_completion` — will consume this with an explicit `timeout=60.0` once a release including this change lands. Separate PR.

## Test plan

- [x] Added `tests/test_background_job_timeout.py` — five unit tests (sync + async) that monkeypatch `read_file` and assert the kwarg propagates (including the multi-read path when the job is completed, where all three reads should receive the same timeout).
- [x] `uv run --extra dev pytest tests/test_background_job_timeout.py tests/test_gateway_error_mapping.py tests/test_models.py tests/test_client_retry.py` — 36 passed.
- [x] `uv run --extra dev ruff check src/ tests/` — clean.
- [x] `uv run --extra dev ruff format --check src/ tests/` — clean.
- [ ] Integration suite (`test_command_execution.py`, etc.) not run locally — requires real sandbox credentials; behavior should be unchanged since the default path (`timeout=None`) is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `timeout` parameter and simply forwards it to existing `read_file` calls, with default behavior unchanged when omitted.
> 
> **Overview**
> Adds an optional `timeout: Optional[int] = None` parameter to both sync and async `get_background_job`, and forwards it through to the underlying `read_file` calls for the exit/stdout/stderr polling files.
> 
> Introduces new unit tests (`test_background_job_timeout.py`) that monkeypatch `read_file` to assert the timeout kwarg is propagated (including the multi-read completed-job path) and that the default remains `None` when not provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0086e9929091227999d6c686bfe5a816adfe3433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->