### PR TITLE
release: prime-sandboxes 0.2.21

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -47,7 +47,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.20"
+__version__ = "0.2.21"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError


### PR DESCRIPTION
Bumps prime-sandboxes to 0.2.21

- Picks up #540 (feat: add timeout kwarg to get_background_job)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only change with no functional or behavioral code modifications.
> 
> **Overview**
> Bumps `prime_sandboxes` SDK version from `0.2.20` to `0.2.21` in `__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1305da3b567f0f1b1c3f1bc78072519d7f055633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->