### PR TITLE
tunnel state

### DIFF
--- a/packages/prime-tunnel/src/prime_tunnel/__init__.py
+++ b/packages/prime-tunnel/src/prime_tunnel/__init__.py
@@ -12,7 +12,7 @@ from prime_tunnel.exceptions import (
     TunnelTimeoutError,
 )
 from prime_tunnel.models import TunnelInfo
-from prime_tunnel.tunnel import Tunnel
+from prime_tunnel.tunnel import StateCallback, Tunnel, TunnelState
 
 __all__ = [
     "__version__",
@@ -21,6 +21,8 @@ __all__ = [
     "TunnelClient",
     # Main interface
     "Tunnel",
+    "TunnelState",
+    "StateCallback",
     # Models
     "TunnelInfo",
     # Exceptions

--- a/packages/prime-tunnel/src/prime_tunnel/tunnel.py
+++ b/packages/prime-tunnel/src/prime_tunnel/tunnel.py
@@ -5,8 +5,10 @@ import re
 import subprocess
 import threading
 import time
+import traceback
+from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import httpx
 
@@ -28,6 +30,25 @@ _LOG_RE = re.compile(
     r"(.+)"
 )
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class TunnelState(str, Enum):
+    """Lifecycle state of a tunnel's frpc process."""
+
+    STOPPED = "stopped"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    DISCONNECTED = "disconnected"
+
+
+StateCallback = Callable[[TunnelState, TunnelState], None]
+
+_DISCONNECT_SIGNALS = (
+    "heartbeat timeout",
+    "pong message contains error",
+    "try to connect to server",
+)
+_CONNECTED_SIGNAL = "start proxy success"
 
 
 def _parse_frpc_error(
@@ -93,6 +114,10 @@ class Tunnel:
         self._started = False
         self._output_lines: list[str] = []
 
+        self._state: TunnelState = TunnelState.STOPPED
+        self._state_lock = threading.Lock()
+        self._state_callbacks: list[StateCallback] = []
+
     @property
     def tunnel_id(self) -> Optional[str]:
         """Get the tunnel ID."""
@@ -114,6 +139,52 @@ class Tunnel:
         if self._process is None:
             return False
         return self._process.poll() is None
+
+    @property
+    def state(self) -> TunnelState:
+        """Current tunnel state."""
+        with self._state_lock:
+            return self._state
+
+    def on_state_change(self, callback: StateCallback) -> StateCallback:
+        """Register a callback fired on state transitions."""
+        with self._state_lock:
+            self._state_callbacks.append(callback)
+        return callback
+
+    def off_state_change(self, callback: StateCallback) -> None:
+        """Unregister a previously-registered state callback."""
+        with self._state_lock:
+            try:
+                self._state_callbacks.remove(callback)
+            except ValueError:
+                pass
+
+    def _set_state(self, new_state: TunnelState) -> None:
+        with self._state_lock:
+            if self._state == new_state:
+                return
+            old_state = self._state
+            self._state = new_state
+            callbacks = list(self._state_callbacks)
+
+        for cb in callbacks:
+            try:
+                cb(old_state, new_state)
+            except Exception:
+                traceback.print_exc()
+
+    def _handle_log_line(self, line: str) -> None:
+        """Scan a drained frpc log line for state transition signals."""
+        clean = _ANSI_RE.sub("", line)
+        if _CONNECTED_SIGNAL in clean:
+            self._set_state(TunnelState.CONNECTED)
+            return
+        if self._state == TunnelState.CONNECTED:
+            for signal in _DISCONNECT_SIGNALS:
+                if signal in clean:
+                    self._set_state(TunnelState.DISCONNECTED)
+                    return
 
     async def check_registered(self) -> bool:
         """Check if the tunnel is still registered server-side.
@@ -143,6 +214,8 @@ class Tunnel:
         """
         if self._started:
             raise TunnelError("Tunnel is already started")
+
+        self._set_state(TunnelState.CONNECTING)
 
         # 1. Get frpc binary
         frpc_path = await asyncio.to_thread(get_frpc_path)
@@ -200,6 +273,7 @@ class Tunnel:
             raise TunnelConnectionError(message=f"Failed to start pipe drain: {e}") from e
 
         self._started = True
+        self._set_state(TunnelState.CONNECTED)
 
         return self.url
 
@@ -251,6 +325,7 @@ class Tunnel:
                 self._config_file = None
 
         self._started = False
+        self._set_state(TunnelState.STOPPED)
 
     async def _cleanup(self) -> None:
         """Clean up tunnel resources."""
@@ -293,6 +368,8 @@ class Tunnel:
         except Exception:
             pass
 
+        self._set_state(TunnelState.STOPPED)
+
     @property
     def recent_output(self) -> list[str]:
         """Last N lines of frpc output (thread-safe). Falls back to startup output."""
@@ -319,7 +396,7 @@ class Tunnel:
         self._recent_output: list[str] = list(self._output_lines[-max_lines:])
 
         def drain_pipe(pipe):
-            """Read output from a pipe, retaining recent lines."""
+            """Read output from a pipe, retaining recent lines and firing state events."""
             if pipe is None:
                 return
             try:
@@ -330,8 +407,15 @@ class Tunnel:
                             self._recent_output.append(line)
                             if len(self._recent_output) > max_lines:
                                 self._recent_output.pop(0)
+                        self._handle_log_line(line)
             except (OSError, ValueError):
                 pass  # Pipe closed
+            finally:
+                # If the process has exited, reflect it in state. Either pipe
+                # closing implies frpc is shutting down.
+                proc = self._process
+                if proc is None or proc.poll() is not None:
+                    self._set_state(TunnelState.STOPPED)
 
         self._drain_threads: list[threading.Thread] = []
         for pipe in (self._process.stdout, self._process.stderr):

--- a/packages/prime-tunnel/tests/test_state_events.py
+++ b/packages/prime-tunnel/tests/test_state_events.py
@@ -1,0 +1,228 @@
+"""Tests for the TunnelState state machine and on_state_change callback API."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from prime_tunnel import Tunnel, TunnelState
+
+
+def _make_tunnel() -> Tunnel:
+    return Tunnel(local_port=8080)
+
+
+def test_initial_state_is_stopped():
+    tunnel = _make_tunnel()
+    assert tunnel.state is TunnelState.STOPPED
+
+
+def test_set_state_emits_callback_with_old_and_new():
+    tunnel = _make_tunnel()
+    events: list[tuple[TunnelState, TunnelState]] = []
+    tunnel.on_state_change(lambda old, new: events.append((old, new)))
+
+    tunnel._set_state(TunnelState.CONNECTING)
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    assert events == [
+        (TunnelState.STOPPED, TunnelState.CONNECTING),
+        (TunnelState.CONNECTING, TunnelState.CONNECTED),
+    ]
+    assert tunnel.state is TunnelState.CONNECTED
+
+
+def test_set_state_is_idempotent():
+    tunnel = _make_tunnel()
+    events: list[tuple[TunnelState, TunnelState]] = []
+    tunnel.on_state_change(lambda old, new: events.append((old, new)))
+
+    tunnel._set_state(TunnelState.CONNECTED)
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    assert len(events) == 1
+
+
+def test_off_state_change_removes_callback():
+    tunnel = _make_tunnel()
+    calls: list[tuple[TunnelState, TunnelState]] = []
+
+    def cb(old, new):
+        calls.append((old, new))
+
+    tunnel.on_state_change(cb)
+    tunnel.off_state_change(cb)
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    assert calls == []
+
+
+def test_off_state_change_unknown_callback_is_silent():
+    tunnel = _make_tunnel()
+    tunnel.off_state_change(lambda *_: None)  # should not raise
+
+
+def test_callback_exception_does_not_break_dispatch():
+    tunnel = _make_tunnel()
+    other_called = False
+
+    def raising(old, new):
+        raise RuntimeError("boom")
+
+    def other(old, new):
+        nonlocal other_called
+        other_called = True
+
+    tunnel.on_state_change(raising)
+    tunnel.on_state_change(other)
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    assert other_called
+
+
+def test_on_state_change_returns_callback_for_decorator_use():
+    tunnel = _make_tunnel()
+
+    @tunnel.on_state_change
+    def handler(old, new):
+        pass
+
+    # handler should be the same object returned and registered
+    assert callable(handler)
+    assert handler in tunnel._state_callbacks
+
+
+# -- _handle_log_line transitions --------------------------------------------
+
+
+def test_handle_log_start_proxy_success_marks_connected():
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTING)
+
+    tunnel._handle_log_line("[I] [control.go:176] [abc] start proxy success")
+
+    assert tunnel.state is TunnelState.CONNECTED
+
+
+def test_handle_log_heartbeat_timeout_while_connected_marks_disconnected():
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    tunnel._handle_log_line("[W] [control.go:274] heartbeat timeout")
+
+    assert tunnel.state is TunnelState.DISCONNECTED
+
+
+def test_handle_log_pong_error_while_connected_marks_disconnected():
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    tunnel._handle_log_line(
+        "[E] [control.go:196] pong message contains error: session expired"
+    )
+
+    assert tunnel.state is TunnelState.DISCONNECTED
+
+
+def test_handle_log_try_to_connect_while_connected_marks_disconnected():
+    """Reconnect attempt after a drop — the key prod signal."""
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    tunnel._handle_log_line("[I] [service.go:378] try to connect to server...")
+
+    assert tunnel.state is TunnelState.DISCONNECTED
+
+
+def test_handle_log_try_to_connect_while_connecting_is_ignored():
+    """Initial connect also logs 'try to connect to server' — must not flip."""
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTING)
+
+    tunnel._handle_log_line("[I] [service.go:378] try to connect to server...")
+
+    assert tunnel.state is TunnelState.CONNECTING
+
+
+def test_handle_log_strips_ansi_before_matching():
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    tunnel._handle_log_line(
+        "\033[1;33m2026-04-20 19:32:34 [W] [control.go:274] heartbeat timeout\033[0m"
+    )
+
+    assert tunnel.state is TunnelState.DISCONNECTED
+
+
+def test_handle_log_reconnect_cycle_emits_both_transitions():
+    """Full prod pattern: CONNECTED -> DISCONNECTED -> CONNECTED on reconnect."""
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    events: list[tuple[TunnelState, TunnelState]] = []
+    tunnel.on_state_change(lambda old, new: events.append((old, new)))
+
+    tunnel._handle_log_line("[W] [control.go:274] heartbeat timeout")
+    tunnel._handle_log_line("[I] [service.go:378] try to connect to server...")
+    tunnel._handle_log_line("[I] [service.go:370] login to server success, get run id [x]")
+    tunnel._handle_log_line("[I] [control.go:176] [t-abc] start proxy success")
+
+    assert events == [
+        (TunnelState.CONNECTED, TunnelState.DISCONNECTED),
+        (TunnelState.DISCONNECTED, TunnelState.CONNECTED),
+    ]
+
+
+def test_handle_log_unrelated_line_does_not_change_state():
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+
+    tunnel._handle_log_line("[D] [control.go:244] send heartbeat to server")
+
+    assert tunnel.state is TunnelState.CONNECTED
+
+
+# -- sync_stop / _cleanup integration ----------------------------------------
+
+
+def test_sync_stop_transitions_to_stopped():
+    from datetime import datetime, timezone
+
+    from prime_tunnel.models import TunnelInfo
+
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.CONNECTED)
+    tunnel._started = True
+    tunnel._process = MagicMock()
+    tunnel._tunnel_info = TunnelInfo(
+        tunnel_id="t-test123",
+        hostname="t-test123.tunnel.example.com",
+        url="https://t-test123.tunnel.example.com",
+        frp_token="tok",
+        server_host="frp.example.com",
+        server_port=7000,
+        expires_at=datetime.now(timezone.utc),
+    )
+    tunnel._config_file = MagicMock()
+    tunnel._config_file.exists.return_value = True
+
+    events: list[tuple[TunnelState, TunnelState]] = []
+    tunnel.on_state_change(lambda old, new: events.append((old, new)))
+
+    from unittest.mock import patch
+
+    with patch("prime_tunnel.tunnel.httpx.delete"):
+        tunnel.sync_stop()
+
+    assert tunnel.state is TunnelState.STOPPED
+    assert events[-1] == (TunnelState.CONNECTED, TunnelState.STOPPED)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_transitions_to_stopped():
+    tunnel = _make_tunnel()
+    tunnel._set_state(TunnelState.DISCONNECTED)
+
+    await tunnel._cleanup()
+
+    assert tunnel.state is TunnelState.STOPPED


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new public state/callback API and updates runtime behavior based on parsed subprocess logs, which could affect how clients observe connection status and may be sensitive to frpc log format changes.
> 
> **Overview**
> Adds a tunnel lifecycle state machine to `Tunnel` via new `TunnelState` (`STOPPED`, `CONNECTING`, `CONNECTED`, `DISCONNECTED`) and a `on_state_change`/`off_state_change` callback API, exported from `prime_tunnel.__init__`.
> 
> Updates `Tunnel.start`, `sync_stop`, `_cleanup`, and the stdout/stderr drain threads to drive state transitions, including parsing frpc log lines to detect connect/disconnect signals and ensuring callback failures don’t break dispatch. Adds `test_state_events.py` covering state transitions, log-driven reconnect patterns, and cleanup/stop integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d127db1099ab006831e6eaad71b4d75f38d9078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->