### PR TITLE
ENG-2927: feat: add `prime feedback` command

### DIFF
--- a/packages/prime/src/prime_cli/commands/feedback.py
+++ b/packages/prime/src/prime_cli/commands/feedback.py
@@ -1,0 +1,85 @@
+import typer
+from click.exceptions import Abort
+
+from prime_cli import __version__
+
+from ..client import APIClient, APIError
+from ..utils import PlainTyper, get_console
+
+app = PlainTyper(
+    help="Submit feedback about Prime Intellect.",
+    no_args_is_help=False,
+    invoke_without_command=True,
+)
+console = get_console()
+
+
+_CATEGORY_CHOICES: tuple[tuple[str, str], ...] = (
+    ("bug", "Bug report"),
+    ("feature", "Feature request"),
+    ("general", "General feedback"),
+)
+
+
+def _prompt_category() -> str:
+    console.print("\n[bold]What are you sharing?[/bold]")
+    for idx, (_, label) in enumerate(_CATEGORY_CHOICES, start=1):
+        console.print(f"  [cyan]({idx})[/cyan] {label}")
+
+    while True:
+        selection = typer.prompt("Select", type=int, default=3)
+        if 1 <= selection <= len(_CATEGORY_CHOICES):
+            return _CATEGORY_CHOICES[selection - 1][0]
+        console.print(f"[red]Invalid selection. Enter 1-{len(_CATEGORY_CHOICES)}.[/red]")
+
+
+def _prompt_message() -> str:
+    console.print("\n[bold]Your feedback[/bold] [dim](required)[/dim]")
+    while True:
+        message = typer.prompt("", prompt_suffix="> ").strip()
+        if message:
+            return message
+        console.print("[red]Feedback cannot be empty.[/red]")
+
+
+def _prompt_run_id() -> str | None:
+    run_id = typer.prompt(
+        "Related run ID (optional)",
+        default="",
+        show_default=False,
+    ).strip()
+    return run_id or None
+
+
+@app.callback(invoke_without_command=True)
+def feedback(ctx: typer.Context) -> None:
+    """Submit feedback (bug, feature request, or general) to the Prime team."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    console.print("[bold]Prime Feedback[/bold]")
+    console.print("[dim]Share bugs, feature ideas, or general thoughts.[/dim]")
+
+    try:
+        category = _prompt_category()
+        run_id = _prompt_run_id()
+        message = _prompt_message()
+    except Abort:
+        console.print("\n[yellow]Cancelled[/yellow]")
+        raise typer.Exit(0)
+
+    payload = {
+        "message": message,
+        "category": category,
+        "cli_version": __version__,
+        "run_id": run_id,
+    }
+
+    try:
+        with console.status("Submitting...", spinner="dots"):
+            APIClient().post("/feedback", json=payload)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print("[green]Feedback submitted. Thanks![/green]")

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -10,6 +10,7 @@ from .commands.deployments import app as deployments_app
 from .commands.disks import app as disks_app
 from .commands.env import app as env_app
 from .commands.evals import app as evals_app
+from .commands.feedback import app as feedback_app
 from .commands.gepa import app as gepa_app
 from .commands.images import app as images_app
 from .commands.inference import app as inference_app
@@ -63,6 +64,7 @@ app.add_typer(teams_app, name="teams", rich_help_panel="Account")
 app.add_typer(secret_app, name="secret", rich_help_panel="Account")
 app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
 app.add_typer(upgrade_app, name="update", rich_help_panel="Account", hidden=True)
+app.add_typer(feedback_app, name="feedback", rich_help_panel="Account")
 
 
 @app.callback(invoke_without_command=True)

--- a/packages/prime/tests/test_feedback.py
+++ b/packages/prime/tests/test_feedback.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, Optional
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+    "PRIME_API_KEY": "test-key",
+}
+
+
+@pytest.fixture
+def capture_feedback_post(monkeypatch: pytest.MonkeyPatch) -> Dict[str, Any]:
+    captured: Dict[str, Any] = {}
+
+    def mock_post(
+        self: Any, endpoint: str, json: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        captured["endpoint"] = endpoint
+        captured["json"] = json
+        return {"message": "Feedback submitted"}
+
+    monkeypatch.setattr("prime_cli.client.APIClient.post", mock_post)
+    return captured
+
+
+def test_feedback_submits_general_without_run_id(
+    capture_feedback_post: Dict[str, Any],
+) -> None:
+    # 3 = general, blank run id, message on final prompt
+    result = runner.invoke(app, ["feedback"], input="3\n\nThe CLI is great\n", env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "Feedback submitted" in result.output
+    assert capture_feedback_post["endpoint"] == "/feedback"
+    payload = capture_feedback_post["json"]
+    assert payload["category"] == "general"
+    assert payload["message"] == "The CLI is great"
+    assert payload["run_id"] is None
+    assert payload["cli_version"]
+
+
+def test_feedback_submits_bug_with_run_id(
+    capture_feedback_post: Dict[str, Any],
+) -> None:
+    result = runner.invoke(
+        app,
+        ["feedback"],
+        input="1\nrun_abc123\nTraining crashed on step 42\n",
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = capture_feedback_post["json"]
+    assert payload["category"] == "bug"
+    assert payload["run_id"] == "run_abc123"
+    assert payload["message"] == "Training crashed on step 42"
+
+
+def test_feedback_rejects_empty_message(
+    capture_feedback_post: Dict[str, Any],
+) -> None:
+    # category general, no run id, empty message once, then real message
+    result = runner.invoke(
+        app,
+        ["feedback"],
+        input="3\n\n\nActually here is my feedback\n",
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    # Two '> ' prompts prove the first empty attempt was re-prompted.
+    assert result.output.count("> ") >= 2
+    assert capture_feedback_post["json"]["message"] == "Actually here is my feedback"


### PR DESCRIPTION
Adds an interactive `prime feedback` command so users can send bug reports, feature requests, or general feedback directly from the CLI.

- Prompts for category → optional run ID → feedback message
- POSTs to `/api/v1/feedback` on the backend (authenticated via user API token, rate-limited server-side)
- Registered under the `Account` help panel
- Covered by 3 unit tests in `packages/prime/tests/test_feedback.py`

Pairs with https://github.com/PrimeIntellect-ai/platform/pull/1508 which adds the backend endpoint.

Linear: https://linear.app/primeintellect/issue/ENG-2927/add-prime-feedback-to-cli

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI subcommand and test coverage, with a single authenticated POST to a new backend endpoint and no changes to existing command behavior beyond registration in `main.py`.
> 
> **Overview**
> Adds a new interactive `prime feedback` command that prompts for feedback category, optional run ID, and a required message, then submits the payload (including `cli_version`) via `APIClient().post("/feedback")` with basic cancel/error handling.
> 
> Registers the new command under the **Account** help panel and adds unit tests verifying successful submissions (with/without run ID) and re-prompting on empty feedback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604f0d0dfb5507f55dbe67cfff84637064c89eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->