### PR TITLE
ENG-3382: support explicit --name override in prime eval push

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -970,9 +970,11 @@ def _push_single_eval(
     run_id: Optional[str],
     eval_id: Optional[str],
     is_public: bool = False,
+    name: Optional[str] = None,
 ) -> str:
     path = _validate_eval_path(config_path)
     eval_data = _load_eval_directory(path)
+    eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
 
     detected_env = eval_data.get("env_id") or eval_data.get("env")
@@ -1004,7 +1006,7 @@ def _push_single_eval(
             console.print("[blue]Updating evaluation...[/blue]")
             client.update_evaluation(
                 evaluation_id=eval_id,
-                name=eval_data.get("eval_name"),
+                name=eval_name,
                 model_name=eval_data.get("model_name"),
                 framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
                 task_type=eval_data.get("metadata", {}).get("task_type"),
@@ -1020,7 +1022,7 @@ def _push_single_eval(
     else:
         console.print("[blue]Creating evaluation...[/blue]")
         create_response = client.create_evaluation(
-            name=eval_data["eval_name"],
+            name=eval_name,
             environments=environments,
             run_id=run_id,
             model_name=eval_data.get("model_name"),
@@ -1103,6 +1105,11 @@ def push_eval(
         "--eval-id",
         help="Push to existing evaluation id",
     ),
+    name: Optional[str] = typer.Option(
+        None,
+        "--name",
+        help="Explicit evaluation name override",
+    ),
     output: str = typer.Option("pretty", "--output", "-o", help="json|pretty"),
     is_public: bool = typer.Option(
         False,
@@ -1119,8 +1126,9 @@ def push_eval(
         prime eval push                                    # Push current dir or auto-discover
         prime eval push outputs/evals/gsm8k--gpt-4/abc123  # Push specific directory
         prime eval push --env gsm8k                        # Push with environment override
+        prime eval push --name "gsm8k smoke test"         # Override evaluation display name
         prime eval push --public                           # Create a public evaluation
-        prime eval push --eval xyz789                      # Push to existing evaluation
+        prime eval push --eval xyz789 --name "rerun"      # Update an existing evaluation name
     """
     try:
         if eval_id and is_public:
@@ -1141,7 +1149,7 @@ def push_eval(
         if config_path is None:
             current_dir = Path(".")
             if _has_eval_files(current_dir):
-                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id, is_public)
+                result_eval_id = _push_single_eval(".", env_id, run_id, eval_id, is_public, name)
                 if output == "json":
                     console.print()
                     output_data_as_json({"evaluation_id": result_eval_id}, console)
@@ -1165,7 +1173,7 @@ def push_eval(
             for eval_dir in eval_dirs:
                 try:
                     result_eval_id = _push_single_eval(
-                        str(eval_dir), env_id, run_id, eval_id, is_public
+                        str(eval_dir), env_id, run_id, eval_id, is_public, name
                     )
                     results.append(
                         {"path": str(eval_dir), "eval_id": result_eval_id, "status": "success"}
@@ -1189,7 +1197,7 @@ def push_eval(
 
             return
 
-        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id, is_public)
+        result_eval_id = _push_single_eval(config_path, env_id, run_id, eval_id, is_public, name)
 
         if output == "json":
             console.print()

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -142,6 +142,47 @@ def test_push_eval_rejects_public_with_eval_id(monkeypatch, tmp_path):
     assert "cannot be used with --eval-id" in result.output
 
 
+def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    captured = {}
+
+    def fake_push_single_eval(config_path, env_slug, run_id, eval_id, is_public, name):
+        captured.update(
+            {
+                "config_path": config_path,
+                "env_slug": env_slug,
+                "run_id": run_id,
+                "eval_id": eval_id,
+                "is_public": is_public,
+                "name": name,
+            }
+        )
+        return "eval-123"
+
+    monkeypatch.setattr("prime_cli.commands.evals._push_single_eval", fake_push_single_eval)
+
+    (tmp_path / "metadata.json").write_text(json.dumps({"env": "gsm8k", "model": "gpt-4"}))
+    (tmp_path / "results.jsonl").write_text("")
+
+    result = runner.invoke(
+        app,
+        ["eval", "push", ".", "--eval-id", "eval-123", "--name", "custom eval"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "config_path": ".",
+        "env_slug": None,
+        "run_id": None,
+        "eval_id": "eval-123",
+        "is_public": False,
+        "name": "custom eval",
+    }
+
+
 class TestPushSingleEval:
     def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
         metadata = {"env": "gsm8k", "model": "gpt-4"}
@@ -196,6 +237,64 @@ class TestPushSingleEval:
 
         assert eval_id == "eval-123"
         assert captured["is_public"] is True
+
+    def test_create_evaluation_prefers_explicit_name_override(self, tmp_path, monkeypatch):
+        metadata = {"env": "gsm8k", "model": "gpt-4", "eval_name": "metadata name"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured.update(kwargs)
+                return {"evaluation_id": "eval-123"}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+                captured["finalized_metrics"] = metrics
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), None, None, None, name="explicit override")
+
+        assert eval_id == "eval-123"
+        assert captured["name"] == "explicit override"
+
+    def test_update_evaluation_prefers_explicit_name_override(self, tmp_path, monkeypatch):
+        metadata = {"env": "gsm8k", "model": "gpt-4", "eval_name": "metadata name"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def get_evaluation(self, evaluation_id):
+                captured["checked_evaluation_id"] = evaluation_id
+                return {"evaluation_id": evaluation_id}
+
+            def update_evaluation(self, **kwargs):
+                captured.update(kwargs)
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+                captured["finalized_metrics"] = metrics
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), None, None, "eval-123", name="explicit override")
+
+        assert eval_id == "eval-123"
+        assert captured["checked_evaluation_id"] == "eval-123"
+        assert captured["name"] == "explicit override"
 
 
 class TestLoadEvalDirectory:


### PR DESCRIPTION
Closes ENG-3382.

This adds a first-class `--name` option to `prime eval push` and threads it into both the create and update paths.

Behavior:
- `prime eval push <path> --name "my eval"` uses that explicit display name.
- The CLI flag takes precedence over any name derived from `metadata.json`.
- Existing behavior stays unchanged when `--name` is omitted.

Why:
- hosted platform evals already know their intended display name when the Evaluation record is created
- `prime eval push --eval-id <id>` otherwise recomputes the name from eval metadata unless the caller mutates `metadata.json`
- this gives platform a clean way to preserve hosted eval names without rewriting sandbox metadata

Validation:
- `uv run ruff check packages/prime/src packages/prime/tests`
- `cd packages/prime && uv run pytest tests/test_eval_push.py -q`
- `cd packages/prime && uv run ty check src/`
