### PR TITLE
extend sandbox lifetime

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -630,6 +630,19 @@ class SandboxClient:
         response = self.client.request("DELETE", f"/sandbox/{sandbox_id}")
         return response
 
+    def extend(self, sandbox_id: str, timeout_minutes: int) -> Sandbox:
+        """Set a new total lifetime for a sandbox.
+
+        `timeout_minutes` is absolute (minutes from startedAt), not a delta.
+        Capped at 1440.
+        """
+        response = self.client.request(
+            "PATCH",
+            f"/sandbox/{sandbox_id}",
+            json={"timeout_minutes": timeout_minutes},
+        )
+        return Sandbox.model_validate(response)
+
     def bulk_delete(
         self,
         sandbox_ids: Optional[List[str]] = None,
@@ -1521,6 +1534,19 @@ class AsyncSandboxClient:
         """Delete a sandbox"""
         response = await self.client.request("DELETE", f"/sandbox/{sandbox_id}")
         return response
+
+    async def extend(self, sandbox_id: str, timeout_minutes: int) -> Sandbox:
+        """Set a new total lifetime for a sandbox.
+
+        ``timeout_minutes`` is absolute (minutes from startedAt), not a delta.
+        Capped at 1440.
+        """
+        response = await self.client.request(
+            "PATCH",
+            f"/sandbox/{sandbox_id}",
+            json={"timeout_minutes": timeout_minutes},
+        )
+        return Sandbox.model_validate(response)
 
     async def bulk_delete(
         self,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -633,7 +633,7 @@ class SandboxClient:
     def extend(self, sandbox_id: str, timeout_minutes: int) -> Sandbox:
         """Set a new total lifetime for a sandbox.
 
-        `timeout_minutes` is absolute (minutes from startedAt), not a delta.
+        timeout_minutes is absolute (minutes from startedAt), not a delta.
         Capped at 1440.
         """
         response = self.client.request(

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1538,7 +1538,7 @@ class AsyncSandboxClient:
     async def extend(self, sandbox_id: str, timeout_minutes: int) -> Sandbox:
         """Set a new total lifetime for a sandbox.
 
-        ``timeout_minutes`` is absolute (minutes from startedAt), not a delta.
+        timeout_minutes is absolute (minutes from startedAt), not a delta.
         Capped at 1440.
         """
         response = await self.client.request(

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -816,6 +816,50 @@ def delete(
 
 
 @app.command(no_args_is_help=True)
+def extend(
+    sandbox_id: str = typer.Argument(..., help="Sandbox ID to extend"),
+    timeout_minutes: int = typer.Option(
+        ...,
+        "--timeout-minutes",
+        "-t",
+        min=1,
+        max=1440,
+        help=(
+            "New total lifetime in minutes, measured from when the sandbox"
+            " started. Absolute, not a delta. Max 1440."
+        ),
+    ),
+) -> None:
+    """Extend the total lifetime of a running sandbox."""
+    try:
+        base_client = APIClient()
+        sandbox_client = SandboxClient(base_client)
+
+        with console.status("[bold blue]Extending sandbox...", spinner="dots"):
+            updated: Sandbox = sandbox_client.extend(sandbox_id, timeout_minutes)
+
+        console.print(
+            f"[green]Extended sandbox {sandbox_id} →"
+            f" total lifetime {updated.timeout_minutes}m[/green]"
+        )
+    except typer.Exit:
+        raise
+    except UnauthorizedError as e:
+        console.print(f"[red]Unauthorized:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except PaymentRequiredError as e:
+        console.print(f"[red]Payment Required:[/red] {str(e)}")
+        raise typer.Exit(1)
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {escape(str(e))}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
+        console.print_exception(show_locals=True)
+        raise typer.Exit(1)
+
+
+@app.command(no_args_is_help=True)
 def logs(sandbox_id: str) -> None:
     """Get logs from a sandbox"""
     try:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `PATCH /sandbox/{id}` operation that mutates sandbox lifetime; incorrect server-side behavior or validation could lead to unexpectedly long-running sandboxes or API errors.
> 
> **Overview**
> Adds a new `extend()` operation to both sync and async sandbox clients that calls `PATCH /sandbox/{sandbox_id}` with `timeout_minutes` to set a sandbox’s *absolute* total lifetime (capped at 1440 minutes).
> 
> Exposes this capability in the CLI via `prime sandbox extend`, including argument validation (`--timeout-minutes/-t`) and standard error handling, and prints the updated timeout on success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0047fd91ef693665491180caf207f2f35639888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->