### PR TITLE
Support --verbose for hosted eval runs

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -110,6 +110,7 @@ HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
     "max_concurrent": (int, "an integer"),
     "max_retries": (int, "an integer"),
     "independent_scoring": (bool, "a boolean"),
+    "verbose": (bool, "a boolean"),
     "api_client_type": (str, "a non-empty string"),
     "api_base_url": (str, "a non-empty string"),
     "api_key_var": (str, "a non-empty string"),
@@ -125,6 +126,7 @@ HOSTED_SUPPORTED_VERIFIERS_FIELDS = {
     "header",
     "independent_scoring",
     "max_concurrent",
+    "verbose",
     "max_retries",
     "max_tokens",
     "model",
@@ -152,6 +154,7 @@ HOSTED_SUPPORTED_TOML_FIELDS = {
     "headers",
     "independent_scoring",
     "max_concurrent",
+    "verbose",
     "max_retries",
     "max_tokens",
     "model",
@@ -501,6 +504,8 @@ def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]
         eval_config["state_columns"] = config.state_columns
     if config.independent_scoring:
         eval_config["independent_scoring"] = True
+    if config.verbose:
+        eval_config["verbose"] = True
     if config.headers:
         eval_config["headers"] = config.headers
     if config.extra_env_kwargs:
@@ -1448,6 +1453,7 @@ def run_eval_cmd(
                     "max_retries": None,
                     "state_columns": None,
                     "independent_scoring": False,
+                    "verbose": False,
                     "headers": None,
                     "extra_env_kwargs": None,
                     "api_client_type": None,
@@ -1581,6 +1587,11 @@ def run_eval_cmd(
                         if "independent_scoring" in cli_overrides
                         else target_config.get("independent_scoring", False)
                     ),
+                    "verbose": (
+                        parsed_verifiers_args.verbose
+                        if "verbose" in cli_overrides
+                        else target_config.get("verbose", False)
+                    ),
                     "headers": (
                         cli_headers if "header" in cli_overrides else target_config.get("headers")
                     ),
@@ -1631,6 +1642,7 @@ def run_eval_cmd(
                 target.get("max_retries"),
                 _freeze_json_value(target.get("state_columns")),
                 target.get("independent_scoring", False),
+                target.get("verbose", False),
                 _freeze_json_value(target.get("headers")),
                 _freeze_json_value(target.get("extra_env_kwargs")),
                 target.get("api_client_type"),
@@ -1686,6 +1698,7 @@ def run_eval_cmd(
                     max_retries=target.get("max_retries"),
                     state_columns=target.get("state_columns"),
                     independent_scoring=target.get("independent_scoring", False),
+                    verbose=target.get("verbose", False),
                     headers=target.get("headers"),
                     extra_env_kwargs=target.get("extra_env_kwargs"),
                     api_client_type=target.get("api_client_type"),

--- a/packages/prime/src/prime_cli/utils/hosted_eval.py
+++ b/packages/prime/src/prime_cli/utils/hosted_eval.py
@@ -51,6 +51,7 @@ class HostedEvalConfig:
     max_retries: Optional[int] = None
     state_columns: Optional[list[str]] = None
     independent_scoring: bool = False
+    verbose: bool = False
     headers: Optional[list[str]] = None
     extra_env_kwargs: Optional[dict[str, Any]] = None
     api_client_type: Optional[str] = None

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -156,6 +156,7 @@ def test_eval_run_hosted_passes_runtime_args_from_cli(monkeypatch):
         captured["max_retries"] = config.max_retries
         captured["state_columns"] = config.state_columns
         captured["independent_scoring"] = config.independent_scoring
+        captured["verbose"] = config.verbose
         captured["headers"] = config.headers
         captured["sampling_args"] = config.sampling_args
         return {"evaluation_id": "eval-123"}
@@ -179,6 +180,7 @@ def test_eval_run_hosted_passes_runtime_args_from_cli(monkeypatch):
             "--state-columns",
             "turn,timing",
             "--independent-scoring",
+            "--verbose",
             "--header",
             "X-Test: one",
             "--max-tokens",
@@ -195,6 +197,7 @@ def test_eval_run_hosted_passes_runtime_args_from_cli(monkeypatch):
         "max_retries": 3,
         "state_columns": ["turn", "timing"],
         "independent_scoring": True,
+        "verbose": True,
         "headers": ["X-Test: one"],
         "sampling_args": {"max_tokens": 4096, "temperature": 0.2},
     }
@@ -465,6 +468,7 @@ def test_create_hosted_evaluation_includes_hosted_runtime_args_in_payload(monkey
             max_retries=3,
             state_columns=["turn", "timing"],
             independent_scoring=True,
+            verbose=True,
             headers=["X-Test: one", "X-Second: two"],
         )
     )
@@ -474,6 +478,7 @@ def test_create_hosted_evaluation_includes_hosted_runtime_args_in_payload(monkey
     assert captured["json"]["eval_config"]["max_retries"] == 3
     assert captured["json"]["eval_config"]["state_columns"] == ["turn", "timing"]
     assert captured["json"]["eval_config"]["independent_scoring"] is True
+    assert captured["json"]["eval_config"]["verbose"] is True
     assert captured["json"]["eval_config"]["headers"] == [
         "X-Test: one",
         "X-Second: two",
@@ -832,6 +837,7 @@ max_concurrent = 100
 max_retries = 3
 state_columns = ["turn", "timing"]
 independent_scoring = true
+verbose = true
 header = ["X-Test: one"]
 max_tokens = 4096
 temperature = 0.2
@@ -853,6 +859,7 @@ env_id = "gsm8k"
         captured["max_retries"] = config.max_retries
         captured["state_columns"] = config.state_columns
         captured["independent_scoring"] = config.independent_scoring
+        captured["verbose"] = config.verbose
         captured["headers"] = config.headers
         captured["sampling_args"] = config.sampling_args
         return {"evaluation_id": "eval-123"}
@@ -875,6 +882,7 @@ env_id = "gsm8k"
         "max_retries": 3,
         "state_columns": ["turn", "timing"],
         "independent_scoring": True,
+        "verbose": True,
         "headers": ["X-Test: one"],
         "sampling_args": {
             "max_tokens": 4096,
@@ -1080,7 +1088,6 @@ env_id = "gsm8k"
     ("field_assignment", "expected_field"),
     [
         ('provider = "azure"', "provider"),
-        ("verbose = true", "verbose"),
         ("debug = true", "debug"),
         ("save_results = false", "save_results"),
         ("resume = true", "resume"),
@@ -1335,7 +1342,6 @@ def test_eval_run_local_sampling_args_passthrough(monkeypatch):
         (["--provider", "openai"], "--provider"),
         (["--endpoints-path", "./configs/endpoints.toml"], "--endpoints-path"),
         (["--output-dir", "/tmp/results"], "--output-dir"),
-        (["--verbose"], "--verbose"),
         (["--no-interleave-scoring"], "--no-interleave-scoring"),
         (["--save-results"], "--save-results"),
         (["--resume", "/tmp/results.json"], "--resume"),


### PR DESCRIPTION
## Summary
- allow `--verbose` for hosted eval CLI runs and TOML configs
- forward the flag through hosted eval payload construction and batching
- add regression coverage for CLI, TOML, and payload forwarding

## Validation
- `uv run pytest packages/prime/tests/test_hosted_eval.py -q`
- verified end-to-end against platform with `prime --context dev-admin --plain eval run unscramble -m openai/gpt-4.1-nano -n 1 --verbose --hosted` and confirmed `eval_config.verbose: true` plus verbose runner logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single boolean config/CLI/TOML field and forwards it in the hosted evaluation payload, with regression tests to confirm wiring. Potential impact is limited to hosted eval request shaping and batching keys.
> 
> **Overview**
> Adds hosted-eval support for `verbose` across the CLI and TOML configs, treating it as an allowed/typed hosted field.
> 
> Plumbs `verbose` through hosted target merging/batching (`group_key` includes it), extends `HostedEvalConfig`, and includes `eval_config.verbose: true` in the `/hosted-evaluations` payload when enabled. Updates tests to cover CLI flag handling, TOML parsing, and payload forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 702fe45613bea0272e863cc02ab0ed24081d8d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->