### PR TITLE
feat(evals): Add explicit env loading to prime eval run

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import time
 from functools import wraps
@@ -23,6 +24,7 @@ from ..utils import (
 )
 from ..utils.display import get_eval_viewer_url
 from ..utils.env_metadata import find_environment_metadata
+from ..utils.env_vars import EnvParseError, collect_env_vars
 from ..utils.eval_push import load_results_jsonl
 from ..utils.hosted_eval import (
     EvalStatus,
@@ -377,6 +379,31 @@ def _fetch_eval_status(client: APIClient, eval_id: str) -> dict[str, Any]:
 def _fetch_logs(client: APIClient, eval_id: str) -> str:
     response = client.get(f"/hosted-evaluations/{eval_id}/logs")
     return response.get("logs") or ""
+
+
+def _apply_eval_cli_env_overrides(
+    env_var: Optional[list[str]],
+    env_file: Optional[list[str]],
+) -> None:
+    """Load explicit eval CLI env inputs into the current process environment."""
+    if not env_var and not env_file:
+        return
+
+    def _warn(message: str) -> None:
+        console.print(f"[yellow]Warning:[/yellow] {message}")
+
+    try:
+        env_overrides = collect_env_vars(
+            env_args=env_var,
+            env_files=env_file,
+            on_warning=_warn,
+        )
+    except EnvParseError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    for key, value in env_overrides.items():
+        os.environ[key] = value
 
 
 def _build_hosted_evaluation_payload(config: HostedEvalConfig) -> dict[str, Any]:
@@ -1186,6 +1213,23 @@ def run_eval_cmd(
             "(used to locate .prime/.env-metadata.json for upstream resolution)"
         ),
     ),
+    env_var: Optional[list[str]] = typer.Option(
+        None,
+        "--env-var",
+        help=(
+            "Environment variable to load before Prime auth/model resolution. "
+            "Accepts: KEY=VALUE (direct value), KEY (reads from $KEY), "
+            "or path/to/file.env (loads env file)."
+        ),
+    ),
+    env_file: Optional[list[str]] = typer.Option(
+        None,
+        "--env-file",
+        help=(
+            "Path to .env file to load before Prime auth/model resolution. "
+            "Supports ${VAR} expansion from local env."
+        ),
+    ),
     hosted: bool = typer.Option(
         False,
         "--hosted",
@@ -1251,6 +1295,8 @@ def run_eval_cmd(
         console.print("[red]Error:[/red] Environment/config must be the first argument.")
         console.print(f"[dim]Example: {EVAL_RUN_EXAMPLE_COMMAND}[/dim]")
         raise typer.Exit(2)
+
+    _apply_eval_cli_env_overrides(env_var=env_var, env_file=env_file)
 
     env_dir_path = _parse_value_option(passthrough_args, "--env-dir-path", "-p")
     poll_interval_was_provided = (

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -118,6 +118,8 @@ def _write_help(text: str) -> None:
 
 def _append_eval_options(help_text: str) -> str:
     extra_lines = [
+        "  --env-var TEXT              Load env vars before Prime auth/model resolution.",
+        "  --env-file PATH             Load a .env file before Prime auth/model resolution.",
         "  --skip-upload               Skip uploading evaluation results to the platform.",
         "  --env-path PATH             Explicit path for upstream environment metadata.",
         "  --hosted                    Run the evaluation on the platform instead of locally.",

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -1,5 +1,5 @@
 from prime_cli.main import app
-from prime_cli.verifiers_bridge import _sanitize_help_text
+from prime_cli.verifiers_bridge import _append_eval_options, _sanitize_help_text
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -37,3 +37,10 @@ def test_sanitize_help_removes_vf_eval_aliases():
     assert "verifiers.cli.commands.eval" not in help_text
     assert "vf-eval" not in help_text
     assert "env_id_or_config" not in help_text
+
+
+def test_append_eval_options_includes_env_loading_flags() -> None:
+    help_text = _append_eval_options("Usage: prime eval run\n")
+
+    assert "--env-file PATH" in help_text
+    assert "--env-var TEXT" in help_text

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1,5 +1,7 @@
+import os
 from pathlib import Path
 
+import typer
 from prime_cli.client import APIError
 from prime_cli.commands.evals import (
     _create_hosted_evaluations,
@@ -974,6 +976,120 @@ def test_eval_run_local_sampling_args_passthrough(monkeypatch):
         "skip_upload": False,
         "env_path": None,
     }
+
+
+def patch_local_eval_bridge(monkeypatch, captured):
+    class DummyPlugin:
+        eval_module = "verifiers.cli.commands.eval"
+
+        def build_module_command(self, module, args):
+            return [module, *args]
+
+    class DummyConfig:
+        def __init__(self):
+            captured["config_api_key"] = os.environ.get("PRIME_API_KEY")
+            captured["config_inference_url"] = os.environ.get("PRIME_INFERENCE_URL")
+            self.api_key = captured["config_api_key"] or ""
+            self.inference_url = (
+                captured["config_inference_url"] or "https://configured.example/v1"
+            )
+            self.team_id = None
+
+    class DummyResolvedEnvironment:
+        def __init__(self, env_name):
+            self.env_name = env_name
+            self.upstream_slug = None
+            self.env_display_id = None
+
+    def fake_prepare_single_environment(_plugin, env_reference, _env_dir_path):
+        return DummyResolvedEnvironment(env_reference)
+
+    def fake_run_command(command, env=None):
+        captured["command"] = command
+        captured["run_env"] = env or {}
+        raise typer.Exit(0)
+
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin",
+        lambda console: DummyPlugin(),
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr("prime_cli.verifiers_bridge._validate_model", lambda *_args: None)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._preflight_inference_billing",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._prepare_single_environment",
+        fake_prepare_single_environment,
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge._run_command", fake_run_command)
+
+
+def test_eval_run_env_file_overrides_process_env(monkeypatch, tmp_path):
+    captured = {}
+    patch_local_eval_bridge(monkeypatch, captured)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "PRIME_API_KEY=from-env-file\n"
+        "PRIME_INFERENCE_URL=https://from-env-file.example/v1\n"
+    )
+
+    result = runner.invoke(
+        app,
+        ["eval", "run", "gsm8k", "--env-file", str(env_file)],
+        env={
+            "PRIME_DISABLE_VERSION_CHECK": "1",
+            "PRIME_API_KEY": "from-process-env",
+            "PRIME_INFERENCE_URL": "https://from-process.example/v1",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["config_api_key"] == "from-env-file"
+    assert captured["config_inference_url"] == "https://from-env-file.example/v1"
+    assert captured["run_env"]["PRIME_API_KEY"] == "from-env-file"
+    assert captured["run_env"]["PRIME_INFERENCE_URL"] == "https://from-env-file.example/v1"
+    assert "--env-file" not in captured["command"]
+
+
+def test_eval_run_env_var_overrides_env_file(monkeypatch, tmp_path):
+    captured = {}
+    patch_local_eval_bridge(monkeypatch, captured)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "PRIME_API_KEY=from-env-file\n"
+        "PRIME_INFERENCE_URL=https://from-env-file.example/v1\n"
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "gsm8k",
+            "--env-file",
+            str(env_file),
+            "--env-var",
+            "PRIME_API_KEY=from-env-var",
+            "--env-var",
+            "PRIME_INFERENCE_URL=https://from-env-var.example/v1",
+        ],
+        env={
+            "PRIME_DISABLE_VERSION_CHECK": "1",
+            "PRIME_API_KEY": "from-process-env",
+            "PRIME_INFERENCE_URL": "https://from-process.example/v1",
+        },
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["config_api_key"] == "from-env-var"
+    assert captured["config_inference_url"] == "https://from-env-var.example/v1"
+    assert captured["run_env"]["PRIME_API_KEY"] == "from-env-var"
+    assert captured["run_env"]["PRIME_INFERENCE_URL"] == "https://from-env-var.example/v1"
+    assert "--env-var" not in captured["command"]
 
 
 def test_eval_run_rejects_hosted_only_flags_without_hosted():


### PR DESCRIPTION
## Summary
This adds explicit env loading to `prime eval run` so local evals can use values from a repo-local `.env` before the CLI does auth/model resolution

`prime rl run` already had a nice workflow for this, but `prime eval run` didn’t. So if you kept something like `PRIME_API_KEY` in a local `.env`, the eval CLI still wouldn’t see it early enough unless you wrapped the command in something like:

```bash
uv run --env-file .env prime eval run ...
```
With this change, prime eval run now supports:

- ``--env-file``
- ``--env-var``

and it loads those values early enough for the CLI itself to use them

## What changed

- added `--env-file` to `prime eval run`
- added `--env-var` to `prime eval run`
- reused the existing shared env parsing helper that `prime rl run` already uses
- loaded those env values before local eval auth/model preflight
- updated eval help text
- added tests for help text and env precedence

## Notes

I kept this pretty small on purpose

This does not:
- auto-load .env from the current directory
- add eval config-level env_file / env_files
- use `-e` for env vars, since `prime eval run` already uses `-e` for `--endpoints-path`

So the goal here is mainly to make local eval workflows nicer and bring them closer to `prime rl run`, without changing a bunch of other eval behavior

## Testing

Ran:
- `uv run prime eval run --help`
- `uv run ruff check packages/prime/src/prime_cli/commands/evals.py packages/prime/src/prime_cli/verifiers_bridge.py packages/prime/tests/test_eval_help.py packages/prime/tests/test_hosted_eval.py`
- `uv run pytest packages/prime/tests/test_eval_help.py packages/prime/tests/test_hosted_eval.py packages/prime/tests/test_eval_billing.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI flags that mutate `os.environ` before auth/model resolution, which can change which credentials/endpoints are used during eval execution; impact is scoped to the eval command and covered by tests.
> 
> **Overview**
> `prime eval run` now supports explicit env loading via `--env-file` and `--env-var`, applying the parsed values to the current process environment *before* Prime config/auth/model resolution.
> 
> Help output is updated to advertise the new flags, and tests are added to verify help text plus precedence/behavior (env file overrides process env; `--env-var` overrides env file; flags are consumed and not forwarded to the underlying verifiers command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a394a59edb5d9b3ea63ab48fb0c4d089732b9557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->