### PR TITLE
QoL: add command for `prime config delete`

### DIFF
--- a/packages/prime/src/prime_cli/commands/config.py
+++ b/packages/prime/src/prime_cli/commands/config.py
@@ -328,6 +328,19 @@ def _list_environments() -> None:
     console.print(table)
 
 
+def _delete_environment(
+    name: str,
+) -> None:
+    """Delete a named saved environment."""
+    try:
+        config = Config()
+        config.delete_environment(name)
+        console.print(f"[green]Deleted environment '{name}'![/green]")
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
 @app.command(no_args_is_help=True)
 def set_share_resources_with_team(
     enabled: str = typer.Argument(
@@ -390,6 +403,12 @@ def use_environment(
 def save_env(name: str = typer.Argument(..., help="Name for the environment")) -> None:
     """Save current config as environment (including API key)"""
     _save_environment(name)
+
+
+@app.command(name="delete", no_args_is_help=True)
+def delete_env(name: str = typer.Argument(..., help="Name of the saved environment")) -> None:
+    """Delete a saved environment"""
+    _delete_environment(name)
 
 
 @app.command(name="envs")

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -260,6 +260,24 @@ class Config:
         }
         env_file.write_text(json.dumps(env_config, indent=2))
 
+    def delete_environment(self, name: str) -> None:
+        """Delete a saved environment configuration."""
+        if name.lower() == "production":
+            raise ValueError("Cannot delete built-in environment 'production'")
+
+        sanitized_name = self._sanitize_environment_name(name)
+        if self.current_environment == name:
+            raise ValueError(
+                f"Cannot delete currently active environment '{name}'. "
+                "Use 'prime config use production' or another saved environment first."
+            )
+
+        env_file = self.environments_dir / f"{sanitized_name}.json"
+        if not env_file.exists():
+            raise ValueError(f"Unknown environment: {name}")
+
+        env_file.unlink()
+
     def load_environment(self, name: str, persist: bool = True) -> bool:
         """Load a named environment configuration.
 

--- a/packages/prime/src/prime_cli/core/config.py
+++ b/packages/prime/src/prime_cli/core/config.py
@@ -266,7 +266,7 @@ class Config:
             raise ValueError("Cannot delete built-in environment 'production'")
 
         sanitized_name = self._sanitize_environment_name(name)
-        if self.current_environment == name:
+        if self.current_environment.casefold() == sanitized_name.casefold():
             raise ValueError(
                 f"Cannot delete currently active environment '{name}'. "
                 "Use 'prime config use production' or another saved environment first."

--- a/packages/prime/tests/test_config_delete.py
+++ b/packages/prime/tests/test_config_delete.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+}
+
+
+@pytest.fixture
+def temp_home(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+    return tmp_path
+
+
+def test_delete_saved_environment_removes_file(temp_home: Path) -> None:
+    save_result = runner.invoke(app, ["config", "save", "staging"], env=TEST_ENV)
+
+    assert save_result.exit_code == 0, save_result.output
+    env_file = temp_home / ".prime" / "environments" / "staging.json"
+    assert env_file.exists()
+
+    delete_result = runner.invoke(app, ["config", "delete", "staging"], env=TEST_ENV)
+
+    assert delete_result.exit_code == 0, delete_result.output
+    assert "Deleted environment 'staging'!" in delete_result.output
+    assert not env_file.exists()
+
+    list_result = runner.invoke(app, ["config", "envs"], env=TEST_ENV)
+
+    assert list_result.exit_code == 0, list_result.output
+    assert "staging" not in list_result.output
+
+
+def test_delete_reserved_production_environment_fails(temp_home: Path) -> None:
+    result = runner.invoke(app, ["config", "delete", "production"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot delete built-in environment 'production'" in result.output
+
+
+def test_delete_unknown_environment_fails(temp_home: Path) -> None:
+    result = runner.invoke(app, ["config", "delete", "missing"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "Unknown environment: missing" in result.output
+
+
+def test_delete_current_environment_requires_switching_first(temp_home: Path) -> None:
+    save_result = runner.invoke(app, ["config", "save", "staging"], env=TEST_ENV)
+    assert save_result.exit_code == 0, save_result.output
+
+    use_result = runner.invoke(app, ["config", "use", "staging"], env=TEST_ENV)
+    assert use_result.exit_code == 0, use_result.output
+
+    result = runner.invoke(app, ["config", "delete", "staging"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot delete currently active environment 'staging'" in result.output
+    assert "prime config use production" in result.output
+    assert (temp_home / ".prime" / "environments" / "staging.json").exists()

--- a/packages/prime/tests/test_config_delete.py
+++ b/packages/prime/tests/test_config_delete.py
@@ -67,3 +67,18 @@ def test_delete_current_environment_requires_switching_first(temp_home: Path) ->
     assert "Cannot delete currently active environment 'staging'" in result.output
     assert "prime config use production" in result.output
     assert (temp_home / ".prime" / "environments" / "staging.json").exists()
+
+
+def test_delete_current_environment_normalizes_name_before_guard(temp_home: Path) -> None:
+    save_result = runner.invoke(app, ["config", "save", "staging"], env=TEST_ENV)
+    assert save_result.exit_code == 0, save_result.output
+
+    use_result = runner.invoke(app, ["config", "use", "staging"], env=TEST_ENV)
+    assert use_result.exit_code == 0, use_result.output
+
+    result = runner.invoke(app, ["config", "delete", "STAGING"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "Cannot delete currently active environment 'STAGING'" in result.output
+    assert "prime config use production" in result.output
+    assert (temp_home / ".prime" / "environments" / "staging.json").exists()


### PR DESCRIPTION
tested locally:
<img width="579" height="103" alt="Screenshot 2026-04-21 at 10 35 55 PM" src="https://github.com/user-attachments/assets/258ce5fd-de4e-4240-a03a-ff7491251c8a" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to local CLI config file deletion with explicit guardrails and test coverage; no network/auth logic changes.
> 
> **Overview**
> Adds a new `prime config delete <name>` command to remove a saved CLI environment file.
> 
> Implements `Config.delete_environment()` with guardrails: blocks deleting `production`, prevents deleting the currently active environment (case-insensitive), and errors on unknown names; includes CLI-level error handling and tests covering success and failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925ff16520d34872e3d7256b5e851b29b6cf4f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->