### PR TITLE
ENG-3398: Display eval link after prime eval push

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -964,6 +964,13 @@ def _discover_eval_outputs() -> list[Path]:
     return sorted(eval_dirs)
 
 
+def _resolve_eval_viewer_url(evaluation_id: str, response: Optional[dict[str, Any]] = None) -> str:
+    viewer_url = response.get("viewer_url") if response else None
+    if viewer_url:
+        return str(viewer_url)
+    return get_eval_viewer_url(evaluation_id)
+
+
 def _push_single_eval(
     config_path: str,
     env_slug: Optional[str],
@@ -1049,14 +1056,16 @@ def _push_single_eval(
         console.print()
 
     console.print("[blue]Finalizing evaluation...[/blue]")
-    client.finalize_evaluation(eval_id, metrics=eval_data.get("metrics"))
+    finalize_response = client.finalize_evaluation(eval_id, metrics=eval_data.get("metrics"))
+    viewer_url = _resolve_eval_viewer_url(eval_id, finalize_response)
     console.print("[green]✓ Evaluation finalized[/green]")
     console.print()
 
     console.print("[green]✓ Success[/green]")
     console.print(f"[blue]Evaluation ID:[/blue] {eval_id}")
+    console.print(f"[dim]View results:[/dim] {viewer_url}")
     console.print()
-    console.print("[dim]View your evaluation:[/dim]")
+    console.print("[dim]Inspect evaluation data:[/dim]")
     console.print(f"  prime eval get {eval_id}")
     console.print(f"  prime eval samples {eval_id}")
 

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -296,6 +296,69 @@ class TestPushSingleEval:
         assert captured["checked_evaluation_id"] == "eval-123"
         assert captured["name"] == "explicit override"
 
+    def test_push_single_eval_prints_returned_viewer_url(self, tmp_path, monkeypatch, capsys):
+        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **_kwargs):
+                return {"evaluation_id": "eval-123"}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                assert evaluation_id == "eval-123"
+                assert metrics == {}
+                return {
+                    "viewer_url": "https://app.primeintellect.ai/dashboard/evaluations/eval-123"
+                }
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+        monkeypatch.setattr(
+            "prime_cli.commands.evals.get_eval_viewer_url",
+            lambda _eval_id: "https://fallback.example/eval-123",
+        )
+
+        _push_single_eval(str(tmp_path), None, None, None)
+
+        output = capsys.readouterr().out
+        assert "https://app.primeintellect.ai/dashboard/evaluations/eval-123" in output
+        assert "https://fallback.example/eval-123" not in output
+
+    def test_push_single_eval_falls_back_to_configured_viewer_url(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **_kwargs):
+                return {"evaluation_id": "eval-123"}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                assert evaluation_id == "eval-123"
+                assert metrics == {}
+                return {}
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+        monkeypatch.setattr(
+            "prime_cli.commands.evals.get_eval_viewer_url",
+            lambda _eval_id: "https://fallback.example/eval-123",
+        )
+
+        _push_single_eval(str(tmp_path), None, None, None)
+
+        output = capsys.readouterr().out
+        assert "https://fallback.example/eval-123" in output
+
 
 class TestLoadEvalDirectory:
     """Tests for _load_eval_directory function"""


### PR DESCRIPTION
Print the evaluation viewer URL after `prime eval push`, preferring the backend-provided link when available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI output formatting after `finalize_evaluation` and add unit tests around URL selection logic.
> 
> **Overview**
> After `prime eval push` finalizes an evaluation, the CLI now prints a **“View results”** URL.
> 
> The URL is resolved via a new helper that **prefers `viewer_url` returned by `finalize_evaluation`** and otherwise falls back to `get_eval_viewer_url`, and tests were added to cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d627dc49ddd7b630aa37c6fcc929f8aa6afd8bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->