### PR TITLE
revert sandbox extend lifetime

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -630,19 +630,6 @@ class SandboxClient:
         response = self.client.request("DELETE", f"/sandbox/{sandbox_id}")
         return response
 
-    def extend(self, sandbox_id: str, timeout_minutes: int) -> Sandbox:
-        """Set a new total lifetime for a sandbox.
-
-        timeout_minutes is absolute (minutes from startedAt), not a delta.
-        Capped at 1440.
-        """
-        response = self.client.request(
-            "PATCH",
-            f"/sandbox/{sandbox_id}",
-            json={"timeout_minutes": timeout_minutes},
-        )
-        return Sandbox.model_validate(response)
-
     def bulk_delete(
         self,
         sandbox_ids: Optional[List[str]] = None,
@@ -1534,19 +1521,6 @@ class AsyncSandboxClient:
         """Delete a sandbox"""
         response = await self.client.request("DELETE", f"/sandbox/{sandbox_id}")
         return response
-
-    async def extend(self, sandbox_id: str, timeout_minutes: int) -> Sandbox:
-        """Set a new total lifetime for a sandbox.
-
-        timeout_minutes is absolute (minutes from startedAt), not a delta.
-        Capped at 1440.
-        """
-        response = await self.client.request(
-            "PATCH",
-            f"/sandbox/{sandbox_id}",
-            json={"timeout_minutes": timeout_minutes},
-        )
-        return Sandbox.model_validate(response)
 
     async def bulk_delete(
         self,

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -816,50 +816,6 @@ def delete(
 
 
 @app.command(no_args_is_help=True)
-def extend(
-    sandbox_id: str = typer.Argument(..., help="Sandbox ID to extend"),
-    timeout_minutes: int = typer.Option(
-        ...,
-        "--timeout-minutes",
-        "-t",
-        min=1,
-        max=1440,
-        help=(
-            "New total lifetime in minutes, measured from when the sandbox"
-            " started. Absolute, not a delta. Max 1440."
-        ),
-    ),
-) -> None:
-    """Extend the total lifetime of a running sandbox."""
-    try:
-        base_client = APIClient()
-        sandbox_client = SandboxClient(base_client)
-
-        with console.status("[bold blue]Extending sandbox...", spinner="dots"):
-            updated: Sandbox = sandbox_client.extend(sandbox_id, timeout_minutes)
-
-        console.print(
-            f"[green]Extended sandbox {sandbox_id} →"
-            f" total lifetime {updated.timeout_minutes}m[/green]"
-        )
-    except typer.Exit:
-        raise
-    except UnauthorizedError as e:
-        console.print(f"[red]Unauthorized:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except PaymentRequiredError as e:
-        console.print(f"[red]Payment Required:[/red] {str(e)}")
-        raise typer.Exit(1)
-    except APIError as e:
-        console.print(f"[red]Error:[/red] {escape(str(e))}")
-        raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]Unexpected error:[/red] {escape(str(e))}")
-        console.print_exception(show_locals=True)
-        raise typer.Exit(1)
-
-
-@app.command(no_args_is_help=True)
 def logs(sandbox_id: str) -> None:
     """Get logs from a sandbox"""
     try:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes the `extend` API/CLI surface, which is a breaking change for any automation or users relying on extending sandbox timeouts, but does not alter other sandbox operations.
> 
> **Overview**
> Reverts sandbox lifetime extension by removing the `extend` method from both `SandboxClient` and `AsyncSandboxClient`, eliminating the `PATCH /sandbox/{id}` call that updated `timeout_minutes`.
> 
> Also removes the `prime sandbox extend` CLI command and its associated argument validation/output, leaving no CLI entrypoint to extend a running sandbox’s total lifetime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe03c7d28deff8d6192ee0ebbe94054f45dd6b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->