### PR TITLE
release: cli 0.5.69

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.68"
+__version__ = "0.5.69"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
bumps cli to 0.5.69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the `prime_cli` package version string with no functional code changes.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.68` to `0.5.69` in `prime_cli/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d86dfcad9a04538f18aaff54b7d7e52eef8b440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->