### PR TITLE
release: cli 0.5.70

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.69"
+__version__ = "0.5.70"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump Prime CLI version to `0.5.70` for the next release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version-string bump only with no functional or behavioral changes.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.69` to `0.5.70` in `prime_cli/__init__.py` for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70676bb8daaaec5438b8b3c69d5344ab61096fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->