### PR TITLE
Move enable_thinking and reasoning_effort under [sampling]

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -188,16 +188,16 @@ rollouts_per_example = 8
 # Optional: warm-start from an existing checkpoint
 # checkpoint_id = "..."
 
-# Optional: hosted RL reasoning controls (mutually exclusive)
-# enable_thinking = false    # supported models: Qwen3.5, Nemotron
-# reasoning_effort = "high"  # supported models: GPT-OSS ("low" | "medium" | "high")
-
 [sampling]
 max_tokens = 2048
 # temperature = 0.7
 # repetition_penalty = 1.0
 # min_tokens = 0
 # seed = 42
+
+# Optional: hosted RL reasoning controls (mutually exclusive)
+# enable_thinking = false    # supported models: Qwen3.5, Nemotron
+# reasoning_effort = "high"  # supported models: GPT-OSS ("low" | "medium" | "high")
 
 # Optional: temperature scheduling (use instead of temperature)
 # [sampling.temp_scheduler]
@@ -350,6 +350,14 @@ class SamplingConfig(BaseModel):
     seed: int | None = None
     temp_scheduler: TemperatureSchedulerConfig | None = None
     extra_body: Dict[str, Any] | None = None
+    enable_thinking: bool | None = None
+    reasoning_effort: Literal["low", "medium", "high"] | None = None
+
+    @model_validator(mode="after")
+    def _reasoning_controls_mutually_exclusive(self) -> "SamplingConfig":
+        if self.enable_thinking is not None and self.reasoning_effort is not None:
+            raise ValueError("enable_thinking and reasoning_effort cannot both be set")
+        return self
 
 
 class EvalConfig(BaseModel):
@@ -500,17 +508,9 @@ class RLConfig(BaseModel):
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
-    enable_thinking: bool | None = None
-    reasoning_effort: Literal["low", "medium", "high"] | None = None
     run_config: Dict[str, Any] = Field(default_factory=dict)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
-
-    @model_validator(mode="after")
-    def _reasoning_controls_mutually_exclusive(self) -> "RLConfig":
-        if self.enable_thinking is not None and self.reasoning_effort is not None:
-            raise ValueError("enable_thinking and reasoning_effort cannot both be set")
-        return self
 
 
 def _format_validation_errors(errors: list[Any]) -> list[str]:
@@ -706,10 +706,6 @@ def create_run(
         console.print(f"  Environments: {', '.join(e.id for e in cfg.env)}")
         if app_config.team_id:
             console.print(f"  Team:         {app_config.team_id}")
-        if cfg.enable_thinking is not None:
-            console.print(f"  Enable Thinking:  {cfg.enable_thinking}")
-        if cfg.reasoning_effort is not None:
-            console.print(f"  Reasoning Effort: {cfg.reasoning_effort}")
 
         # Training
         console.print("\n[cyan]Training[/cyan]")
@@ -736,6 +732,8 @@ def create_run(
             or cfg.sampling.seed is not None
             or cfg.sampling.temp_scheduler is not None
             or cfg.sampling.extra_body is not None
+            or cfg.sampling.enable_thinking is not None
+            or cfg.sampling.reasoning_effort is not None
         )
         if has_sampling:
             console.print("\n[cyan]Sampling[/cyan]")
@@ -755,6 +753,10 @@ def create_run(
                 console.print(f"  Temp Scheduler:      {sched}")
             if cfg.sampling.extra_body is not None:
                 console.print(f"  Extra Body:          {cfg.sampling.extra_body}")
+            if cfg.sampling.enable_thinking is not None:
+                console.print(f"  Enable Thinking:     {cfg.sampling.enable_thinking}")
+            if cfg.sampling.reasoning_effort is not None:
+                console.print(f"  Reasoning Effort:    {cfg.sampling.reasoning_effort}")
 
         # W&B
         if cfg.wandb.entity or cfg.wandb.project:
@@ -877,8 +879,8 @@ def create_run(
             checkpoint_id=cfg.checkpoint_id,
             cluster_name=cfg.cluster_name,
             infrastructure_config=cfg.infrastructure.to_api_dict(),
-            enable_thinking=cfg.enable_thinking,
-            reasoning_effort=cfg.reasoning_effort,
+            enable_thinking=cfg.sampling.enable_thinking,
+            reasoning_effort=cfg.sampling.reasoning_effort,
             run_config=cfg.run_config if cfg.run_config else None,
         )
 

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -70,31 +70,42 @@ def test_flatten_config_schema_preserves_optional_array_item_types() -> None:
     assert rows["buffer.env_ratios"] == "list[number]"
 
 
-def test_load_config_accepts_top_level_reasoning_effort(tmp_path: Path) -> None:
+def test_load_config_accepts_sampling_reasoning_effort(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
-    config_path.write_text('model = "openai/gpt-oss-20b"\nreasoning_effort = "high"\n')
+    config_path.write_text('model = "openai/gpt-oss-20b"\n[sampling]\nreasoning_effort = "high"\n')
 
     cfg = load_config(str(config_path))
 
-    assert cfg.reasoning_effort == "high"
-    assert cfg.enable_thinking is None
+    assert cfg.sampling.reasoning_effort == "high"
+    assert cfg.sampling.enable_thinking is None
 
 
-def test_load_config_accepts_top_level_enable_thinking(tmp_path: Path) -> None:
+def test_load_config_accepts_sampling_enable_thinking(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
-    config_path.write_text('model = "Qwen/Qwen3.5-35B-A3B"\nenable_thinking = false\n')
+    config_path.write_text('model = "Qwen/Qwen3.5-35B-A3B"\n[sampling]\nenable_thinking = false\n')
 
     cfg = load_config(str(config_path))
 
-    assert cfg.enable_thinking is False
-    assert cfg.reasoning_effort is None
+    assert cfg.sampling.enable_thinking is False
+    assert cfg.sampling.reasoning_effort is None
 
 
 def test_load_config_rejects_both_reasoning_controls(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
-        'model = "openai/gpt-oss-20b"\nenable_thinking = false\nreasoning_effort = "low"\n'
+        'model = "openai/gpt-oss-20b"\n'
+        "[sampling]\n"
+        "enable_thinking = false\n"
+        'reasoning_effort = "low"\n'
     )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_top_level_reasoning_effort(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "openai/gpt-oss-20b"\nreasoning_effort = "high"\n')
 
     with pytest.raises(typer.Exit):
         load_config(str(config_path))


### PR DESCRIPTION
Follow-up to #526. These belong under `[sampling]` alongside other sampling controls, not at top level.

- `RLConfig.enable_thinking` / `reasoning_effort` → `SamplingConfig`
- Mutual-exclusion validator moves with them
- Run summary shows them in the Sampling section
- Template + tests updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the RL TOML config schema: existing configs using top-level `enable_thinking`/`reasoning_effort` will now fail validation and must be moved under `[sampling]`. Runtime behavior is otherwise unchanged aside from where values are read and displayed.
> 
> **Overview**
> Moves hosted RL reasoning controls (`enable_thinking`, `reasoning_effort`) from top-level `RLConfig` into `SamplingConfig` under `[sampling]`, including relocating the mutual-exclusion validator.
> 
> Updates the generated config template, CLI run summary output (now shown in the *Sampling* section), and the `create_run` API payload mapping to read these values from `cfg.sampling`. Tests are updated to require `[sampling]` usage and add coverage that top-level `reasoning_effort` is rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc1cda8a26ba8523d66e3fc82c9d2c97811ef87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->