### PR TITLE
release: cli 0.5.71

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.70"
+__version__ = "0.5.71"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump CLI to 0.5.71.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change that updates the package version string with no behavior changes.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.5.70` to `0.5.71` in `__init__.py` for the CLI release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 670919a7945af31795d24d24fa9b7fd8b73f3bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->