### PR TITLE
Show reason when RL run is queued

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -51,6 +51,7 @@ class RLRun(BaseModel):
 
     # Queue info
     runs_ahead: Optional[int] = Field(None, alias="runsAhead")
+    queue_reason: Optional[str] = Field(None, alias="queueReason")
 
     # Timestamps
     started_at: Optional[datetime] = Field(None, alias="startedAt")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -893,6 +893,8 @@ def create_run(
             if run.runs_ahead is not None:
                 queue_msg += f" (~{run.runs_ahead} runs ahead)"
             console.print(f"[yellow]{queue_msg}[/yellow]")
+            if run.queue_reason:
+                console.print(f"[yellow]Reason:[/yellow] {run.queue_reason}")
             console.print("[dim]The run will start automatically when capacity is available.[/dim]")
         else:
             console.print("[green]✓ Run created successfully![/green]")


### PR DESCRIPTION
Surface the \`queueReason\` the backend now returns on CreateRunResponse so users know *why* their run went into the queue.

Paired with platform PR #1641.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional response field and prints it only when present, without changing request/queueing behavior.
> 
> **Overview**
> Surfaces backend-provided queue context in the RL CLI.
> 
> Adds `queue_reason` (`queueReason`) to the `RLRun` API model and, when a newly created run is `QUEUED`, prints the reason alongside the existing queued message (including `runs_ahead` when available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b534902b63b86bc0671c4d2ccdd642068697f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->