### PR TITLE
Show failure analysis in prime rl get for FAILED runs

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -60,6 +60,10 @@ class RLRun(BaseModel):
     created_at: datetime = Field(..., alias="createdAt")
     updated_at: datetime = Field(..., alias="updatedAt")
 
+    # Automated failure classification (only set for terminal FAILED runs).
+    # Stored as a dict to stay forward-compatible if the API adds new fields.
+    failure_analysis: Optional[Dict[str, Any]] = Field(None, alias="failureAnalysis")
+
     model_config = ConfigDict(populate_by_name=True)
 
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -584,7 +584,7 @@ def _render_failure_analysis(analysis: Dict[str, Any]) -> None:
     The backend only returns this for RUN_ISSUE classifications, so we don't
     surface the internal classifier tag — just the diagnosis itself.
     """
-    root_cause = analysis.get("root_cause")
+    root_cause = analysis.get("rootCause")
     evidence = analysis.get("evidence")
     if not root_cause and not (isinstance(evidence, list) and evidence):
         return

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -578,30 +578,26 @@ def _get_status_color(status: str) -> str:
     return RUN_STATUS_COLORS.get(status.upper(), "white")
 
 
-FAILURE_TAG_COLORS = {
-    "PLATFORM_ISSUE": "red",
-    "RUN_ISSUE": "yellow",
-    "UNCLASSIFIED": "white",
-}
-
-
 def _render_failure_analysis(analysis: Dict[str, Any]) -> None:
-    """Render the automated failure-classifier output below run details."""
-    tag = analysis.get("user_tag") or "UNCLASSIFIED"
-    color = FAILURE_TAG_COLORS.get(tag, "white")
-    confidence = analysis.get("confidence")
-    tag_line = f"[{color}]{tag}[/{color}]"
-    if isinstance(confidence, (int, float)):
-        tag_line += f" [dim](confidence {confidence * 100:.0f}%)[/dim]"
+    """Render the automated failure-classifier output below run details.
 
-    console.print("\n[bold]Failure Analysis[/bold]")
-    console.print(f"  Tag: {tag_line}")
-
+    The backend only returns this for RUN_ISSUE classifications, so we don't
+    surface the internal classifier tag — just the diagnosis itself.
+    """
     root_cause = analysis.get("root_cause")
+    evidence = analysis.get("evidence")
+    if not root_cause and not (isinstance(evidence, list) and evidence):
+        return
+
+    header = "\n[bold]Failure Analysis[/bold]"
+    confidence = analysis.get("confidence")
+    if isinstance(confidence, (int, float)):
+        header += f" [dim](confidence {confidence * 100:.0f}%)[/dim]"
+    console.print(header)
+
     if root_cause:
         console.print(f"  Root Cause: {rich_escape(str(root_cause))}")
 
-    evidence = analysis.get("evidence")
     if isinstance(evidence, list) and evidence:
         console.print("  Evidence:")
         for line in evidence:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -578,6 +578,36 @@ def _get_status_color(status: str) -> str:
     return RUN_STATUS_COLORS.get(status.upper(), "white")
 
 
+FAILURE_TAG_COLORS = {
+    "PLATFORM_ISSUE": "red",
+    "RUN_ISSUE": "yellow",
+    "UNCLASSIFIED": "white",
+}
+
+
+def _render_failure_analysis(analysis: Dict[str, Any]) -> None:
+    """Render the automated failure-classifier output below run details."""
+    tag = analysis.get("user_tag") or "UNCLASSIFIED"
+    color = FAILURE_TAG_COLORS.get(tag, "white")
+    confidence = analysis.get("confidence")
+    tag_line = f"[{color}]{tag}[/{color}]"
+    if isinstance(confidence, (int, float)):
+        tag_line += f" [dim](confidence {confidence * 100:.0f}%)[/dim]"
+
+    console.print("\n[bold]Failure Analysis[/bold]")
+    console.print(f"  Tag: {tag_line}")
+
+    root_cause = analysis.get("root_cause")
+    if root_cause:
+        console.print(f"  Root Cause: {rich_escape(str(root_cause))}")
+
+    evidence = analysis.get("evidence")
+    if isinstance(evidence, list) and evidence:
+        console.print("  Evidence:")
+        for line in evidence:
+            console.print(f"    - [dim]{rich_escape(str(line))}[/dim]")
+
+
 def _format_run_for_display(run: RLRun) -> Dict[str, Any]:
     created_at = run.created_at.strftime("%Y-%m-%d %H:%M") if run.created_at else ""
     env_names = [
@@ -1251,6 +1281,9 @@ def get_run(
             console.print(f"  Completed: [dim]{run.completed_at.strftime('%Y-%m-%d %H:%M')}[/dim]")
         if run.error_message:
             console.print(f"  Error: [red]{run.error_message}[/red]")
+
+        if run.failure_analysis:
+            _render_failure_analysis(run.failure_analysis)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")


### PR DESCRIPTION
Surfaces the automated failure classifier diagnosis in `prime rl get <id>` so CLI users see the same root-cause analysis the dashboard shows.

- Renders root cause + evidence (with confidence) when present
- Only shown for failures the classifier attributes to the run itself — the backend filters to RUN_ISSUE; PLATFORM_ISSUE / UNCLASSIFIED diagnoses aren't user-actionable so they're not surfaced
- No classifier tag in output — internal vocabulary, not user-facing

Depends on platform PR #1642 which exposes the field and applies the RUN_ISSUE filter.