### PR TITLE
release: cli 0.5.72

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.71"
+__version__ = "0.5.72"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump CLI to 0.5.72.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bump in `prime_cli/__init__.py` with no functional or behavioral changes.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.71` to `0.5.72`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d76136c6061d0d6da2c81921a888cf1e638786d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->