### PR TITLE
Read env-server logs via `prime rl logs -c env-server`

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -82,6 +82,17 @@ class RLCheckpoint(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class EnvServerInfo(BaseModel):
+    """Env-server pod info for an RL run."""
+
+    env_name: Optional[str] = Field(None, description="Environment name")
+    env_index: Optional[int] = Field(None, description="Environment server index")
+    pod_name: str = Field(..., description="Kubernetes pod name")
+    status: str = Field(..., description="Pod status")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class RLClient:
     """Client for hosted RL API."""
 
@@ -324,7 +335,7 @@ class RLClient:
             raise APIError(f"Failed to get RL run: {str(e)}")
 
     def get_logs(self, run_id: str, tail_lines: int = 1000) -> str:
-        """Get logs for an RL run."""
+        """Get orchestrator logs for an RL run."""
         try:
             response = self.client.get(
                 f"/rft/runs/{run_id}/logs", params={"tail_lines": tail_lines}
@@ -334,6 +345,39 @@ class RLClient:
             if hasattr(e, "response") and hasattr(e.response, "text"):
                 raise APIError(f"Failed to get RL run logs: {e.response.text}")
             raise APIError(f"Failed to get RL run logs: {str(e)}")
+
+    def list_env_servers(self, run_id: str) -> List[EnvServerInfo]:
+        """List env-server pods for an RL run."""
+        try:
+            response = self.client.get(f"/rft/runs/{run_id}/env-servers")
+            return [EnvServerInfo.model_validate(p) for p in response.get("env_servers", [])]
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(f"Failed to list env servers: {e.response.text}")
+            raise APIError(f"Failed to list env servers: {str(e)}")
+
+    def get_env_server_logs(
+        self,
+        run_id: str,
+        env_name: str,
+        env_index: int = 0,
+        tail_lines: int = 1000,
+    ) -> str:
+        """Get logs for a specific env-server pod of an RL run."""
+        try:
+            response = self.client.get(
+                f"/rft/runs/{run_id}/env-server-logs",
+                params={
+                    "env_name": env_name,
+                    "env_index": env_index,
+                    "tail_lines": tail_lines,
+                },
+            )
+            return response.get("logs", "")
+        except Exception as e:
+            if hasattr(e, "response") and hasattr(e.response, "text"):
+                raise APIError(f"Failed to get env server logs: {e.response.text}")
+            raise APIError(f"Failed to get env server logs: {str(e)}")
 
     def get_metrics(
         self,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -15,7 +15,7 @@ from rich.table import Table
 
 from prime_cli.core import Config
 
-from ..api.rl import RLClient, RLRun
+from ..api.rl import EnvServerInfo, RLClient, RLRun
 from ..client import APIClient, APIError, ValidationError
 from ..utils import (
     DefaultCommandGroup,
@@ -1372,107 +1372,253 @@ def restart_run(
         raise typer.Exit(1)
 
 
+def _print_new_lines(last_lines: list[str], current_lines: list[str]) -> None:
+    """Print only lines in current_lines that aren't in the tail of last_lines.
+
+    Uses suffix-prefix overlap detection to avoid reprinting lines between polls.
+    """
+    if current_lines == last_lines:
+        return
+    if not last_lines:
+        for line in current_lines:
+            console.print(line)
+        return
+    overlap = 0
+    max_overlap = min(len(last_lines), len(current_lines))
+    for i in range(1, max_overlap + 1):
+        if last_lines[-i:] == current_lines[:i]:
+            overlap = i
+    for line in current_lines[overlap:]:
+        console.print(line)
+
+
+def _stream_logs(
+    fetch_fn: Any,
+    tail: int,
+    raw: bool,
+    follow: bool,
+    label: str,
+) -> None:
+    """Common print loop for orchestrator and env-server log fetches."""
+
+    def render(raw_logs: str) -> list[str]:
+        if raw:
+            return raw_logs.splitlines()
+        return clean_logs(raw_logs)
+
+    if follow:
+        console.print(f"[dim]Watching {label} logs... (Ctrl+C to stop)[/dim]\n")
+        last_lines: list[str] = []
+        consecutive_errors = 0
+
+        while True:
+            try:
+                raw_logs = fetch_fn(tail)
+                consecutive_errors = 0
+            except APIError as e:
+                err_str = str(e).lower()
+                if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
+                    console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
+                    time.sleep(10)
+                    continue
+                consecutive_errors += 1
+                if "429" in str(e):
+                    if consecutive_errors >= 3:
+                        console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
+                        time.sleep(30)
+                    else:
+                        time.sleep(10)
+                    continue
+                raise
+
+            current_lines = render(raw_logs)
+            _print_new_lines(last_lines, current_lines)
+            last_lines = current_lines
+            time.sleep(5)
+    else:
+        raw_logs = fetch_fn(tail)
+        rendered = render(raw_logs)
+        if rendered:
+            for line in rendered:
+                console.print(line)
+        else:
+            console.print("[yellow]No logs available yet.[/yellow]")
+
+
+def _handle_logs_api_error(e: APIError) -> None:
+    err_str = str(e).lower()
+    if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
+        msg = "Run has not started yet. Logs will be available once running."
+        console.print(f"[yellow]{msg}[/yellow]")
+        raise typer.Exit(0)
+    console.print(f"[red]Error:[/red] {e}")
+    raise typer.Exit(1)
+
+
+def _parse_env_qualifier(env: str) -> tuple[str, int]:
+    """Parse 'name' or 'name/N' into (env_name, env_index).
+
+    A trailing ``/<int>`` is treated as a replica index; index defaults to 0.
+    """
+    if "/" in env:
+        name, _, idx_str = env.rpartition("/")
+        if not name:
+            raise typer.BadParameter(
+                f"Invalid env qualifier '{env}'. Expected 'name' or 'name/<index>'.",
+                param_hint="--env",
+            )
+        try:
+            return name, int(idx_str)
+        except ValueError:
+            raise typer.BadParameter(
+                f"Invalid env qualifier '{env}'. Expected 'name' or 'name/<index>'.",
+                param_hint="--env",
+            )
+    return env, 0
+
+
 @app.command("logs", rich_help_panel="Monitoring")
 def get_logs(
     run_id: str = typer.Argument(..., help="Run ID to get logs for"),
+    component: str = typer.Option(
+        "orchestrator",
+        "--component",
+        "-c",
+        help="Pod to read logs from: 'orchestrator' (default) or 'env-server'.",
+    ),
+    env: Optional[str] = typer.Option(
+        None,
+        "--env",
+        help=(
+            "Env-server name (required when --component=env-server). "
+            "Use 'name/N' to disambiguate when multiple env-servers share a name. "
+            "List with 'prime rl components <run_id>'."
+        ),
+    ),
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Show raw logs without formatting"),
 ) -> None:
-    """Get logs for a run."""
+    """Get logs for a run.
+
+    Defaults to the orchestrator pod. Pass ``-c env-server --env <name>`` when
+    an env-server is crash-looping (e.g. ``ModuleNotFoundError``) and the
+    orchestrator has stalled at "Starting orchestrator step 0".
+
+    List available pods first with ``prime rl components <run_id>``.
+
+    Examples:
+
+        prime rl logs <run_id>
+        prime rl logs <run_id> -f
+        prime rl logs <run_id> -c env-server --env reverse-text
+        prime rl logs <run_id> -c env-server --env reverse-text/1 -f
+    """
+    if component not in ("orchestrator", "env-server"):
+        raise typer.BadParameter(
+            f"Invalid component '{component}'. Use 'orchestrator' or 'env-server'.",
+            param_hint="--component",
+        )
+    if component == "orchestrator" and env is not None:
+        raise typer.BadParameter(
+            "--env only applies with --component=env-server.",
+            param_hint="--env",
+        )
+    if component == "env-server" and env is None:
+        raise typer.BadParameter(
+            "--env is required when --component=env-server. "
+            "Run 'prime rl components <run_id>' to list available env-servers.",
+            param_hint="--env",
+        )
+
     try:
         api_client = APIClient()
         rl_client = RLClient(api_client)
 
-        if follow:
-            console.print(f"[dim]Watching logs for run {run_id}... (Ctrl+C to stop)[/dim]\n")
-            last_lines: list[str] = []
-            consecutive_errors = 0
+        if component == "orchestrator":
 
-            while True:
-                try:
-                    raw_logs = rl_client.get_logs(run_id, tail_lines=tail)
-                    consecutive_errors = 0
+            def fetch(t: int) -> str:
+                return rl_client.get_logs(run_id, tail_lines=t)
 
-                    if raw:
-                        # Raw mode with overlap detection
-                        current_lines = raw_logs.splitlines()
-                        if current_lines != last_lines:
-                            if not last_lines:
-                                for line in current_lines:
-                                    console.print(line)
-                            else:
-                                # Find new lines by comparing with previous
-                                overlap = 0
-                                max_overlap = min(len(last_lines), len(current_lines))
-                                for i in range(1, max_overlap + 1):
-                                    if last_lines[-i:] == current_lines[:i]:
-                                        overlap = i
-                                for line in current_lines[overlap:]:
-                                    console.print(line)
-                            last_lines = current_lines
-                    else:
-                        # Formatted mode
-                        formatted_lines = clean_logs(raw_logs)
-
-                        if formatted_lines != last_lines:
-                            if not last_lines:
-                                for line in formatted_lines:
-                                    console.print(line)
-                            else:
-                                # Find new lines by comparing with previous
-                                overlap = 0
-                                max_overlap = min(len(last_lines), len(formatted_lines))
-                                for i in range(1, max_overlap + 1):
-                                    if last_lines[-i:] == formatted_lines[:i]:
-                                        overlap = i
-                                for line in formatted_lines[overlap:]:
-                                    console.print(line)
-
-                            last_lines = formatted_lines
-                except APIError as e:
-                    if "404" in str(e) and (
-                        "queued" in str(e).lower() or "pending" in str(e).lower()
-                    ):
-                        console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
-                        time.sleep(10)
-                        continue
-                    consecutive_errors += 1
-                    if "429" in str(e):
-                        if consecutive_errors >= 3:
-                            console.print("[yellow]Rate limited. Waiting 30s...[/yellow]")
-                            time.sleep(30)
-                        else:
-                            time.sleep(10)
-                        continue
-                    raise
-
-                time.sleep(5)
+            label = "orchestrator"
         else:
-            raw_logs = rl_client.get_logs(run_id, tail_lines=tail)
-            if raw:
-                if raw_logs:
-                    console.print(raw_logs)
-                else:
-                    console.print("[yellow]No logs available yet.[/yellow]")
-            else:
-                formatted_lines = clean_logs(raw_logs)
-                if formatted_lines:
-                    for line in formatted_lines:
-                        console.print(line)
-                else:
-                    console.print("[yellow]No logs available yet.[/yellow]")
+            assert env is not None  # narrowed by validation above
+            env_name, env_index = _parse_env_qualifier(env)
+
+            def fetch(t: int) -> str:
+                return rl_client.get_env_server_logs(
+                    run_id,
+                    env_name=env_name,
+                    env_index=env_index,
+                    tail_lines=t,
+                )
+
+            label = f"env-server {env}"
+
+        _stream_logs(
+            fetch_fn=fetch,
+            tail=tail,
+            raw=raw,
+            follow=follow,
+            label=label,
+        )
 
     except KeyboardInterrupt:
         console.print("\n[dim]Stopped watching logs.[/dim]")
     except APIError as e:
-        err_str = str(e).lower()
-        if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
-            msg = "Run has not started yet. Logs will be available once running."
-            console.print(f"[yellow]{msg}[/yellow]")
-            raise typer.Exit(0)
+        _handle_logs_api_error(e)
+
+
+@app.command("components", rich_help_panel="Monitoring")
+def list_components(
+    run_id: str = typer.Argument(..., help="Run ID to list components for"),
+) -> None:
+    """List pods (orchestrator + env-servers) for a run.
+
+    Use the env name shown here with
+    ``prime rl logs <run_id> -c env-server --env <name>``. When multiple
+    env-servers share a name, the qualified form ``name/N`` is shown — pass
+    that exact string to ``--env``.
+
+    Example:
+
+        prime rl components <run_id>
+    """
+    try:
+        api_client = APIClient()
+        rl_client = RLClient(api_client)
+        run = rl_client.get_run(run_id)
+        env_servers: List[EnvServerInfo] = rl_client.list_env_servers(run_id)
+    except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+
+    table = Table(title=f"Components for {run_id}")
+    table.add_column("Component", style="cyan")
+    table.add_column("Env", style="green")
+    table.add_column("Status")
+    table.add_column("Pod", style="dim")
+
+    table.add_row("orchestrator", "-", run.status, "-")
+
+    name_counts: Dict[str, int] = {}
+    for es in env_servers:
+        if es.env_name:
+            name_counts[es.env_name] = name_counts.get(es.env_name, 0) + 1
+
+    for es in env_servers:
+        if es.env_name and name_counts.get(es.env_name, 0) > 1:
+            env_label = f"{es.env_name}/{es.env_index}"
+        else:
+            env_label = es.env_name or "?"
+        table.add_row("env-server", env_label, es.status, es.pod_name)
+
+    console.print(table)
+    if env_servers:
+        console.print(
+            "\n[dim]View env-server logs with:[/dim] "
+            "[bold]prime rl logs <run_id> -c env-server --env <env>[/bold]"
+        )
 
 
 @app.command("init", rich_help_panel="Commands")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1480,17 +1480,20 @@ def _parse_env_qualifier(env: str) -> tuple[str, int]:
 @app.command("logs", rich_help_panel="Monitoring")
 def get_logs(
     run_id: str = typer.Argument(..., help="Run ID to get logs for"),
-    component: str = typer.Option(
-        "orchestrator",
+    component: Optional[str] = typer.Option(
+        None,
         "--component",
         "-c",
-        help="Pod to read logs from: 'orchestrator' (default) or 'env-server'.",
+        help=(
+            "Pod to read logs from: 'orchestrator' (default) or 'env-server'. "
+            "Inferred from --env when omitted."
+        ),
     ),
     env: Optional[str] = typer.Option(
         None,
         "--env",
         help=(
-            "Env-server name (required when --component=env-server). "
+            "Env-server name. Implies --component=env-server. "
             "Use 'name/N' to disambiguate when multiple env-servers share a name. "
             "List with 'prime rl components <run_id>'."
         ),
@@ -1501,9 +1504,10 @@ def get_logs(
 ) -> None:
     """Get logs for a run.
 
-    Defaults to the orchestrator pod. Pass ``-c env-server --env <name>`` when
-    an env-server is crash-looping (e.g. ``ModuleNotFoundError``) and the
-    orchestrator has stalled at "Starting orchestrator step 0".
+    Defaults to the orchestrator pod. Pass ``--env <name>`` to read an
+    env-server pod instead — useful when an env-server is crash-looping
+    (e.g. ``ModuleNotFoundError``) and the orchestrator has stalled at
+    "Starting orchestrator step 0".
 
     List available pods first with ``prime rl components <run_id>``.
 
@@ -1511,22 +1515,24 @@ def get_logs(
 
         prime rl logs <run_id>
         prime rl logs <run_id> -f
-        prime rl logs <run_id> -c env-server --env reverse-text
-        prime rl logs <run_id> -c env-server --env reverse-text/1 -f
+        prime rl logs <run_id> --env reverse-text
+        prime rl logs <run_id> --env reverse-text/1 -f
     """
-    if component not in ("orchestrator", "env-server"):
+    if component is None:
+        component = "env-server" if env is not None else "orchestrator"
+    elif component not in ("orchestrator", "env-server"):
         raise typer.BadParameter(
             f"Invalid component '{component}'. Use 'orchestrator' or 'env-server'.",
             param_hint="--component",
         )
     if component == "orchestrator" and env is not None:
         raise typer.BadParameter(
-            "--env only applies with --component=env-server.",
+            "--env applies only to env-server logs. Drop --component=orchestrator or drop --env.",
             param_hint="--env",
         )
     if component == "env-server" and env is None:
         raise typer.BadParameter(
-            "--env is required when --component=env-server. "
+            "--env is required when reading env-server logs. "
             "Run 'prime rl components <run_id>' to list available env-servers.",
             param_hint="--env",
         )

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1456,24 +1456,15 @@ def _handle_logs_api_error(e: APIError) -> None:
 
 
 def _parse_env_qualifier(env: str) -> tuple[str, int]:
-    """Parse 'name' or 'name/N' into (env_name, env_index).
+    """Parse 'name' or 'name/<int>' into (env_name, env_index).
 
-    A trailing ``/<int>`` is treated as a replica index; index defaults to 0.
+    Only a trailing ``/<int>`` is treated as a replica index. Any other slashes
+    are part of the env name itself (e.g. owner/name IDs like
+    ``primeintellect/reverse-text``).
     """
-    if "/" in env:
-        name, _, idx_str = env.rpartition("/")
-        if not name:
-            raise typer.BadParameter(
-                f"Invalid env qualifier '{env}'. Expected 'name' or 'name/<index>'.",
-                param_hint="--env",
-            )
-        try:
-            return name, int(idx_str)
-        except ValueError:
-            raise typer.BadParameter(
-                f"Invalid env qualifier '{env}'. Expected 'name' or 'name/<index>'.",
-                param_hint="--env",
-            )
+    name, sep, idx_str = env.rpartition("/")
+    if sep and name and idx_str.isdigit():
+        return name, int(idx_str)
     return env, 0
 
 

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -173,17 +173,43 @@ def test_logs_env_server_qualified_name_parses_index(monkeypatch: pytest.MonkeyP
     assert env[0]["env_index"] == 2
 
 
-def test_logs_env_server_bad_qualifier(monkeypatch: pytest.MonkeyPatch) -> None:
-    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
-        raise AssertionError(f"Should not be called: {endpoint}")
+def test_logs_env_server_owner_name_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--env primeintellect/reverse-text` is a valid name, not a qualifier.
 
+    Only a trailing ``/<int>`` should be treated as a replica index.
+    """
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get({"env_server_logs": "ok"}, orch, env, lst)
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
     result = CliRunner().invoke(
         app,
-        ["rl", "logs", RUN_ID, "-c", "env-server", "--env", "reverse-text/abc", "--raw"],
+        ["rl", "logs", RUN_ID, "--env", "primeintellect/reverse-text", "--raw"],
     )
-    assert result.exit_code != 0
+
+    assert result.exit_code == 0, result.output
+    assert env[0]["env_name"] == "primeintellect/reverse-text"
+    assert env[0]["env_index"] == 0
+
+
+def test_logs_env_server_owner_name_with_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--env primeintellect/reverse-text/1` should split at the last slash."""
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get({"env_server_logs": "ok"}, orch, env, lst)
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(
+        app,
+        ["rl", "logs", RUN_ID, "--env", "primeintellect/reverse-text/1", "--raw"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert env[0]["env_name"] == "primeintellect/reverse-text"
+    assert env[0]["env_index"] == 1
 
 
 def test_logs_env_server_requires_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -84,15 +84,35 @@ def test_logs_default_hits_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None
     assert env == []
 
 
-def test_logs_orchestrator_rejects_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`--env` is meaningless for orchestrator logs; must error rather than be ignored."""
+def test_logs_env_flag_alone_infers_env_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passing --env without -c should infer component=env-server."""
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get({"env_server_logs": "inferred line"}, orch, env, lst)
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--env", "reverse-text", "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert "inferred line" in result.output
+    assert orch == []
+    assert len(env) == 1
+    assert env[0]["env_name"] == "reverse-text"
+    assert env[0]["env_index"] == 0
+
+
+def test_logs_explicit_orchestrator_with_env_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit `-c orchestrator --env x` is a real conflict; must error."""
 
     def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
         raise AssertionError(f"Should not be called: {endpoint}")
 
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
-    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--env", "reverse-text"])
+    result = CliRunner().invoke(
+        app, ["rl", "logs", RUN_ID, "-c", "orchestrator", "--env", "reverse-text"]
+    )
     assert result.exit_code != 0
 
 

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -1,0 +1,345 @@
+"""Tests for `prime rl logs` (orchestrator + env-server) and `prime rl components`."""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pytest
+from prime_cli.api.rl import RLClient
+from prime_cli.client import APIError
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+RUN_ID = "rl-run-123"
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("prime_cli.commands.rl.time.sleep", lambda _: None)
+
+
+def _run_payload(status: str = "RUNNING") -> Dict[str, Any]:
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "id": RUN_ID,
+        "name": "demo",
+        "userId": "u1",
+        "status": status,
+        "rolloutsPerExample": 8,
+        "seqLen": 4096,
+        "maxSteps": 100,
+        "batchSize": 32,
+        "baseModel": "some-model",
+        "environments": [{"name": "reverse-text"}],
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def _make_mock_get(
+    responses: Dict[str, Any],
+    orch_calls: List[Dict[str, Any]],
+    env_calls: List[Dict[str, Any]],
+    list_calls: List[Dict[str, Any]],
+):
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        if endpoint == f"/rft/runs/{RUN_ID}":
+            return {"run": _run_payload(responses.get("run_status", "RUNNING"))}
+        if endpoint == f"/rft/runs/{RUN_ID}/logs":
+            orch_calls.append(params or {})
+            return {"logs": responses.get("orchestrator_logs", "")}
+        if endpoint == f"/rft/runs/{RUN_ID}/env-server-logs":
+            env_calls.append(params or {})
+            return {"logs": responses.get("env_server_logs", "")}
+        if endpoint == f"/rft/runs/{RUN_ID}/env-servers":
+            list_calls.append(params or {})
+            return {"env_servers": responses.get("env_servers", [])}
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    return mock_get
+
+
+# ---------- prime rl logs (orchestrator default) ----------
+
+
+def test_logs_default_hits_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get({"orchestrator_logs": "orch-line-1\norch-line-2"}, orch, env, lst)
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert "orch-line-1" in result.output
+    assert "orch-line-2" in result.output
+    assert len(orch) == 1
+    assert orch[0]["tail_lines"] == 1000
+    assert env == []
+
+
+def test_logs_orchestrator_rejects_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--env` is meaningless for orchestrator logs; must error rather than be ignored."""
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise AssertionError(f"Should not be called: {endpoint}")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--env", "reverse-text"])
+    assert result.exit_code != 0
+
+
+# ---------- prime rl logs -c env-server ----------
+
+
+def test_logs_env_server_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get(
+        {"env_server_logs": "ModuleNotFoundError: no module foo"}, orch, env, lst
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "rl",
+            "logs",
+            RUN_ID,
+            "-c",
+            "env-server",
+            "--env",
+            "reverse-text",
+            "--tail",
+            "50",
+            "--raw",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "ModuleNotFoundError" in result.output
+    assert orch == []
+    assert len(env) == 1
+    assert env[0] == {
+        "env_name": "reverse-text",
+        "env_index": 0,
+        "tail_lines": 50,
+    }
+
+
+def test_logs_env_server_qualified_name_parses_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--env reverse-text/2` should split into env_name='reverse-text', env_index=2."""
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get({"env_server_logs": "line"}, orch, env, lst)
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(
+        app,
+        ["rl", "logs", RUN_ID, "-c", "env-server", "--env", "reverse-text/2", "--raw"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert env[0]["env_name"] == "reverse-text"
+    assert env[0]["env_index"] == 2
+
+
+def test_logs_env_server_bad_qualifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise AssertionError(f"Should not be called: {endpoint}")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(
+        app,
+        ["rl", "logs", RUN_ID, "-c", "env-server", "--env", "reverse-text/abc", "--raw"],
+    )
+    assert result.exit_code != 0
+
+
+def test_logs_env_server_requires_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise AssertionError(f"Should not be called: {endpoint}")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "-c", "env-server"])
+    assert result.exit_code != 0
+    assert "--env" in result.output or "env" in result.output.lower()
+
+
+def test_logs_invalid_component(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise AssertionError(f"Should not be called: {endpoint}")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "-c", "trainer"])
+    assert result.exit_code != 0
+
+
+def test_logs_run_not_started(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Queued runs return 404 with 'queued'; CLI should exit 0 with a friendly message."""
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        raise APIError("Failed to get RL run logs: 404 run is queued")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert "has not started yet" in result.output
+
+
+def test_logs_env_server_follow_dedupes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Follow-mode polls and avoids reprinting overlapping tail lines."""
+    call_count = {"n": 0}
+
+    def mock_get_env_server_logs(
+        self: Any,
+        run_id: str,
+        env_name: str,
+        env_index: int = 0,
+        tail_lines: int = 1000,
+    ) -> str:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return "line-1\nline-2"
+        if call_count["n"] == 2:
+            return "line-2\nline-3"
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(RLClient, "get_env_server_logs", mock_get_env_server_logs)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "rl",
+            "logs",
+            RUN_ID,
+            "-c",
+            "env-server",
+            "--env",
+            "reverse-text",
+            "--follow",
+            "--raw",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("line-1") == 1
+    assert result.output.count("line-2") == 1
+    assert result.output.count("line-3") == 1
+    assert call_count["n"] >= 2
+
+
+# ---------- prime rl components ----------
+
+
+def test_components_lists_orchestrator_and_env_servers(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get(
+        {
+            "run_status": "RUNNING",
+            "env_servers": [
+                {
+                    "env_name": "reverse-text",
+                    "env_index": 0,
+                    "pod_name": "rft-rl-run-123-env-reverse-text-0",
+                    "status": "Running",
+                },
+                {
+                    "env_name": "opencode-math",
+                    "env_index": 0,
+                    "pod_name": "rft-rl-run-123-env-opencode-math-0",
+                    "status": "CrashLoopBackOff",
+                },
+            ],
+        },
+        orch,
+        env,
+        lst,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "components", RUN_ID])
+
+    assert result.exit_code == 0, result.output
+    out = " ".join(result.output.split())
+    assert "orchestrator" in out
+    assert "RUNNING" in out
+    assert "reverse-text" in out
+    assert "opencode-math" in out
+    assert "CrashLoopBackOff" in out
+    # No qualifier when env names are unique.
+    assert "reverse-text/" not in out
+    assert "opencode-math/" not in out
+    assert len(lst) == 1
+
+
+def test_components_qualifies_duplicate_env_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the same env name appears twice, the listing must show 'name/N'."""
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get(
+        {
+            "run_status": "RUNNING",
+            "env_servers": [
+                {
+                    "env_name": "reverse-text",
+                    "env_index": 0,
+                    "pod_name": "rft-x-env-reverse-text-0",
+                    "status": "Running",
+                },
+                {
+                    "env_name": "reverse-text",
+                    "env_index": 1,
+                    "pod_name": "rft-x-env-reverse-text-1",
+                    "status": "Running",
+                },
+            ],
+        },
+        orch,
+        env,
+        lst,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "components", RUN_ID])
+
+    assert result.exit_code == 0, result.output
+    out = " ".join(result.output.split())
+    assert "reverse-text/0" in out
+    assert "reverse-text/1" in out
+
+
+def test_components_empty_env_servers(monkeypatch: pytest.MonkeyPatch) -> None:
+    orch: List[Dict[str, Any]] = []
+    env: List[Dict[str, Any]] = []
+    lst: List[Dict[str, Any]] = []
+    mock_get = _make_mock_get(
+        {"run_status": "QUEUED", "env_servers": []},
+        orch,
+        env,
+        lst,
+    )
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "components", RUN_ID])
+
+    assert result.exit_code == 0, result.output
+    assert "orchestrator" in result.output
+    assert "QUEUED" in result.output


### PR DESCRIPTION
Adds `--component`/`-c` to `prime rl logs` plus a new `prime rl components` listing.

- `prime rl logs <id>` — orchestrator (unchanged)
- `prime rl logs <id> -c env-server --env <name>` — env-server pod
- `prime rl logs <id> -c env-server --env <name>/<index>` — disambiguate dupes
- `prime rl components <id>` — list pods

Single `logs` command instead of a separate `env-logs` subcommand; alternative to #530.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new CLI monitoring commands/options and two new RL API client methods without changing training or auth flows; primary risk is mismatched API contract for the new endpoints/params.
> 
> **Overview**
> Adds support for reading **env-server pod logs** from `prime rl logs` via new `--component/-c` and `--env` options (including `name/N` replica selection), while keeping orchestrator logs as the default.
> 
> Introduces `prime rl components <run_id>` to list the orchestrator + env-server pods (with disambiguated env names when duplicates exist), plus new RL API client support for `GET /rft/runs/{id}/env-servers` and `GET /rft/runs/{id}/env-server-logs`.
> 
> Refactors log streaming into shared helpers with overlap-based deduping for follow mode and adds comprehensive CLI tests covering routing, parsing, error handling, and component listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b7ca0fe965a1452532c5d502253eede9684b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->