### PR TITLE
release: cli 0.5.73

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.72"
+__version__ = "0.5.73"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime-cli to 0.5.73.

Includes #563 (`prime rl logs -c env-server` + `prime rl components`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump that only updates the exported `__version__` string; no runtime behavior changes beyond reporting the new version.
> 
> **Overview**
> Bumps the Prime Intellect CLI package version from `0.5.72` to `0.5.73` by updating `prime_cli.__version__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d429519f36d65558b5d1907386ef0634a174f536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->