### PR TITLE
Hide pod name column in `prime rl components`

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1594,9 +1594,8 @@ def list_components(
     table.add_column("Component", style="cyan")
     table.add_column("Env", style="green")
     table.add_column("Status")
-    table.add_column("Pod", style="dim")
 
-    table.add_row("orchestrator", "-", run.status, "-")
+    table.add_row("orchestrator", "-", run.status)
 
     name_counts: Dict[str, int] = {}
     for es in env_servers:
@@ -1608,7 +1607,7 @@ def list_components(
             env_label = f"{es.env_name}/{es.env_index}"
         else:
             env_label = es.env_name or "?"
-        table.add_row("env-server", env_label, es.status, es.pod_name)
+        table.add_row("env-server", env_label, es.status)
 
     console.print(table)
     if env_servers:


### PR DESCRIPTION
Pod names are auto-generated k8s strings that aren't part of the user workflow. Drops the column.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a display-only change to the CLI table output and does not affect API calls or run/log behavior.
> 
> **Overview**
> `prime rl components` no longer displays Kubernetes pod names: the `Pod` column is removed and table rows are updated to omit `pod_name`, leaving only component, env label, and status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20422dd7ce03ba66af8c2e5d2c266e9f38e6f64b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->