### PR TITLE
Skip preview list call when --yes is passed in sandbox delete

### DIFF
--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -709,49 +709,58 @@ def delete(
                 scope_user_id = None
                 all_users_flag = True
 
-            total = _preview_bulk_delete_count(
-                sandbox_client,
-                team_id=team_id,
-                user_id=scope_user_id,
-                labels=labels,
-            )
-
-            if total == 0:
-                console.print("[yellow]No sandboxes to delete[/yellow]")
-                if only_mine:
-                    console.print(
-                        "\n[dim]Note: --all/--label only deletes your own"
-                        " sandboxes by default. Use --all-users to delete"
-                        " sandboxes from all team members (requires team"
-                        " admin).[/dim]"
-                    )
-                return
-
-            scope_suffix = "" if only_mine else " across ALL users"
-            if labels:
-                labels_str = ", ".join(labels)
-                count_phrase = (
-                    f"{total} sandbox(es)" if total is not None else "all matching sandboxes"
-                )
-                confirmation_msg = (
-                    f"Are you sure you want to delete {count_phrase}"
-                    f" with labels: {labels_str}{scope_suffix}? This action"
-                    " cannot be undone."
-                )
-                cancel_msg = "Delete cancelled"
+            # Skip the preview list call when --yes is set: it's only used for
+            # the confirmation prompt and zero-match short-circuit, and on
+            # large teams the server-side count(*) takes 10+ seconds. The bulk
+            # delete itself reports the succeeded/failed counts.
+            if yes:
+                total: Optional[int] = None
             else:
-                count_phrase = (
-                    f"ALL {total} sandbox(es)" if total is not None else "EVERY matching sandbox"
+                total = _preview_bulk_delete_count(
+                    sandbox_client,
+                    team_id=team_id,
+                    user_id=scope_user_id,
+                    labels=labels,
                 )
-                confirmation_msg = (
-                    f"Are you sure you want to delete {count_phrase}"
-                    f"{scope_suffix}? This action cannot be undone."
-                )
-                cancel_msg = "Delete all cancelled"
 
-            if not confirm_or_skip(confirmation_msg, yes):
-                console.print(cancel_msg)
-                return
+                if total == 0:
+                    console.print("[yellow]No sandboxes to delete[/yellow]")
+                    if only_mine:
+                        console.print(
+                            "\n[dim]Note: --all/--label only deletes your own"
+                            " sandboxes by default. Use --all-users to delete"
+                            " sandboxes from all team members (requires team"
+                            " admin).[/dim]"
+                        )
+                    return
+
+                scope_suffix = "" if only_mine else " across ALL users"
+                if labels:
+                    labels_str = ", ".join(labels)
+                    count_phrase = (
+                        f"{total} sandbox(es)" if total is not None else "all matching sandboxes"
+                    )
+                    confirmation_msg = (
+                        f"Are you sure you want to delete {count_phrase}"
+                        f" with labels: {labels_str}{scope_suffix}? This action"
+                        " cannot be undone."
+                    )
+                    cancel_msg = "Delete cancelled"
+                else:
+                    count_phrase = (
+                        f"ALL {total} sandbox(es)"
+                        if total is not None
+                        else "EVERY matching sandbox"
+                    )
+                    confirmation_msg = (
+                        f"Are you sure you want to delete {count_phrase}"
+                        f"{scope_suffix}? This action cannot be undone."
+                    )
+                    cancel_msg = "Delete all cancelled"
+
+                if not confirm_or_skip(confirmation_msg, yes):
+                    console.print(cancel_msg)
+                    return
 
             with console.status("[bold blue]Deleting sandboxes...", spinner="dots"):
                 result: BulkDeleteSandboxResponse = sandbox_client.bulk_delete(

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -247,9 +247,8 @@ def test_sandbox_delete_by_label_scopes_to_caller(
 ) -> None:
     """Default --label delete scopes to the caller's user_id server-side.
 
-    The CLI now makes a single ``list(per_page=1)`` call to preview the count,
-    then a single ``bulk_delete`` with the scope/labels — the server does the
-    filtering, so no pagination and no client-side user_id filter.
+    With --yes the CLI skips the preview list call (which can take 10+ seconds
+    on large teams) and goes straight to ``bulk_delete``.
     """
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
@@ -283,12 +282,8 @@ def test_sandbox_delete_by_label_scopes_to_caller(
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
 
-    # Preview call: scoped to caller + labels, only active sandboxes
-    list_kwargs = captured["list_kwargs"]
-    assert list_kwargs["labels"] == ["keep"]
-    assert list_kwargs["user_id"] == "user-1"
-    assert list_kwargs["exclude_terminated"] is True
-    assert list_kwargs["per_page"] == 1
+    # Preview list call is skipped under --yes
+    assert "list_kwargs" not in captured
 
     # Delete call: server-side scope, no client-side ID list
     bulk_kwargs = captured["bulk_delete_kwargs"]
@@ -336,10 +331,8 @@ def test_sandbox_delete_by_label_all_users_passes_admin_scope(
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
 
-    list_kwargs = captured["list_kwargs"]
-    assert list_kwargs["labels"] == ["archive"]
-    assert list_kwargs["exclude_terminated"] is True
-    assert list_kwargs["user_id"] is None
+    # Preview list call is skipped under --yes
+    assert "list_kwargs" not in captured
 
     bulk_kwargs = captured["bulk_delete_kwargs"]
     assert bulk_kwargs["labels"] == ["archive"]


### PR DESCRIPTION
## Summary
- `prime sandbox delete --label X --yes` was hitting `GET /api/v1/sandbox` for a count the user never sees (the prompt is skipped)
- That preview call's `count(*)` takes 10+ seconds on large teams, so the command felt hung
- Skip the preview entirely under `--yes` and surface bulk_delete's succeeded/failed counts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI behavior change: it only bypasses the pre-delete preview/count request when confirmations are already skipped, leaving the actual `bulk_delete` call and scoping unchanged.
> 
> **Overview**
> Speeds up `prime sandbox delete` for `--all`/`--label` operations when `--yes` is provided by skipping the preview `list(per_page=1)` count request that was only used for confirmation/zero-match short-circuiting.
> 
> Updates tests to assert the preview `list` call is not made under `--yes` (both default user-scoped deletes and `--all-users`), while still verifying the correct `bulk_delete` parameters and output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29af7c070da084717341fc9490739e86a2c266f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->