### PR TITLE
ENG-3454 Add prime fork command

### DIFF
--- a/packages/prime/src/prime_cli/commands/fork.py
+++ b/packages/prime/src/prime_cli/commands/fork.py
@@ -17,7 +17,7 @@ def _parse_fork_source(environment: str) -> Tuple[str, str]:
     if "@" in environment:
         raise ValueError("Forking a specific version is not supported; omit the @version suffix")
 
-    parts = environment.split("/", 1)
+    parts = environment.split("/")
     if len(parts) != 2 or not parts[0] or not parts[1]:
         raise ValueError("Invalid environment format. Expected: owner/name")
 

--- a/packages/prime/src/prime_cli/commands/fork.py
+++ b/packages/prime/src/prime_cli/commands/fork.py
@@ -1,0 +1,90 @@
+from typing import Dict, Optional, Tuple
+
+import typer
+
+from ..client import APIClient, APIError
+from ..utils import get_console, json_output_help, output_data_as_json, validate_output_format
+
+console = get_console()
+
+FORK_JSON_HELP = json_output_help(
+    ". = {success, message, environment_id, version_id, name, owner, slug}",
+)
+
+
+def _parse_fork_source(environment: str) -> Tuple[str, str]:
+    """Parse a fork source slug in owner/name format."""
+    if "@" in environment:
+        raise ValueError("Forking a specific version is not supported; omit the @version suffix")
+
+    parts = environment.split("/", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError("Invalid environment format. Expected: owner/name")
+
+    return parts[0], parts[1]
+
+
+def _build_fork_payload(client: APIClient, team: Optional[str]) -> Dict[str, str]:
+    """Build the fork request payload from CLI flags and configured context."""
+    if team:
+        return {"team_slug": team}
+    if client.config.team_id:
+        return {"team_id": client.config.team_id}
+    return {}
+
+
+def fork(
+    environment: str = typer.Argument(
+        ...,
+        help="Public environment to fork, in owner/name format",
+    ),
+    team: Optional[str] = typer.Option(
+        None,
+        "--team",
+        "-t",
+        help="Team slug to fork into (uses configured team ID if omitted)",
+    ),
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table or json",
+    ),
+) -> None:
+    """Fork a public environment into your Prime Intellect namespace."""
+    validate_output_format(output, console)
+
+    try:
+        owner, name = _parse_fork_source(environment)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        client = APIClient()
+        payload = _build_fork_payload(client, team)
+        response = client.post(f"/environmentshub/{owner}/{name}/fork", json=payload)
+        data = response.get("data", response)
+
+        if output == "json":
+            output_data_as_json(data, console)
+            return
+
+        slug = data.get("slug")
+        environment_id = data.get("environment_id")
+        version_id = data.get("version_id")
+
+        console.print(f"[green]✓ Forked {environment} to {slug}[/green]")
+        console.print(f"Environment ID: [dim]{environment_id}[/dim]")
+        console.print(f"Version ID: [dim]{version_id}[/dim]")
+        console.print("\nNext steps:")
+        console.print(f"  prime env pull {slug}")
+        console.print(
+            "  # edit the pulled environment, then run `prime env push` from that directory"
+        )
+    except APIError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error: {e}[/red]")
+        raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -11,6 +11,8 @@ from .commands.disks import app as disks_app
 from .commands.env import app as env_app
 from .commands.evals import app as evals_app
 from .commands.feedback import app as feedback_app
+from .commands.fork import FORK_JSON_HELP
+from .commands.fork import fork as fork_command
 from .commands.gepa import app as gepa_app
 from .commands.images import app as images_app
 from .commands.inference import app as inference_app
@@ -40,6 +42,7 @@ app = PlainTyper(
 # Lab commands
 app.add_typer(lab_app, name="lab", rich_help_panel="Lab")
 app.add_typer(env_app, name="env", rich_help_panel="Lab")
+app.command("fork", rich_help_panel="Lab", epilog=FORK_JSON_HELP)(fork_command)
 app.add_typer(evals_app, name="eval", rich_help_panel="Lab")
 app.add_typer(gepa_app, name="gepa", rich_help_panel="Lab")
 app.add_typer(rl_app, name="rl", rich_help_panel="Lab")

--- a/packages/prime/tests/test_fork.py
+++ b/packages/prime/tests/test_fork.py
@@ -1,0 +1,110 @@
+import json
+from types import SimpleNamespace
+
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {
+    "PRIME_API_KEY": "test-token",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+}
+
+
+def _fork_response() -> dict:
+    return {
+        "data": {
+            "success": True,
+            "message": "Environment forked successfully",
+            "environment_id": "env-fork",
+            "version_id": "version-fork",
+            "name": "gsm8k",
+            "owner": {"type": "user", "name": "alice"},
+            "slug": "alice/gsm8k",
+        }
+    }
+
+
+def test_prime_fork_posts_to_environment_fork_endpoint(monkeypatch):
+    captured = {}
+
+    class DummyAPIClient:
+        config = SimpleNamespace(team_id=None)
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return _fork_response()
+
+    monkeypatch.setattr("prime_cli.commands.fork.APIClient", DummyAPIClient)
+
+    result = runner.invoke(app, ["fork", "openai/gsm8k"], env=TEST_ENV)
+
+    assert result.exit_code == 0
+    assert captured == {
+        "endpoint": "/environmentshub/openai/gsm8k/fork",
+        "json": {},
+    }
+    assert "Forked openai/gsm8k to alice/gsm8k" in result.output
+    assert "prime env pull alice/gsm8k" in result.output
+
+
+def test_prime_fork_uses_configured_team_id(monkeypatch):
+    captured = {}
+
+    class DummyAPIClient:
+        config = SimpleNamespace(team_id="configured-team")
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return _fork_response()
+
+    monkeypatch.setattr("prime_cli.commands.fork.APIClient", DummyAPIClient)
+
+    result = runner.invoke(app, ["fork", "openai/gsm8k"], env=TEST_ENV)
+
+    assert result.exit_code == 0
+    assert captured == {
+        "endpoint": "/environmentshub/openai/gsm8k/fork",
+        "json": {"team_id": "configured-team"},
+    }
+
+
+def test_prime_fork_team_slug_overrides_configured_team_id(monkeypatch):
+    captured = {}
+
+    class DummyAPIClient:
+        config = SimpleNamespace(team_id="configured-team")
+
+        def post(self, endpoint, json=None):
+            captured["endpoint"] = endpoint
+            captured["json"] = json
+            return _fork_response()
+
+    monkeypatch.setattr("prime_cli.commands.fork.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["fork", "openai/gsm8k", "--team", "research", "--output", "json"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "endpoint": "/environmentshub/openai/gsm8k/fork",
+        "json": {"team_slug": "research"},
+    }
+    assert json.loads(result.output)["slug"] == "alice/gsm8k"
+
+
+def test_prime_fork_rejects_versioned_sources():
+    result = runner.invoke(
+        app,
+        ["fork", "openai/gsm8k@0.1.0"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Forking a specific version is not supported" in result.output

--- a/packages/prime/tests/test_fork.py
+++ b/packages/prime/tests/test_fork.py
@@ -108,3 +108,22 @@ def test_prime_fork_rejects_versioned_sources():
 
     assert result.exit_code == 1
     assert "Forking a specific version is not supported" in result.output
+
+
+def test_prime_fork_rejects_extra_path_segments(monkeypatch):
+    class DummyAPIClient:
+        config = SimpleNamespace(team_id=None)
+
+        def post(self, endpoint, json=None):
+            raise AssertionError("invalid fork source should not call the API")
+
+    monkeypatch.setattr("prime_cli.commands.fork.APIClient", DummyAPIClient)
+
+    result = runner.invoke(
+        app,
+        ["fork", "openai/gsm8k/extra"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid environment format. Expected: owner/name" in result.output


### PR DESCRIPTION
Adds a top-level prime fork command that calls the environments hub fork API.\n\nValidation:\n- python -m ruff check packages/prime/src/prime_cli/commands/fork.py packages/prime/src/prime_cli/main.py packages/prime/tests/test_fork.py\n- python -m pytest packages/prime/tests/test_fork.py -q\n- python -m pytest packages/prime/tests -q (fails on existing eval/hosted-eval tests unrelated to this change)\n\nLinear: https://linear.app/primeintellect/issue/ENG-3454/add-prime-fork-command-to-cli-with-backend-support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive CLI command with input validation and unit tests; only touches command registration and a new POST call to the environments hub fork endpoint.
> 
> **Overview**
> Adds a new top-level `prime fork` command that forks a public environment (`owner/name`) via `POST /environmentshub/{owner}/{name}/fork`, optionally targeting a team via `--team` (or falling back to a configured `team_id`).
> 
> Supports `--output json` for machine-readable output, prints next-step guidance for table output, and rejects invalid sources (version suffixes like `@...` and malformed slugs). Includes tests covering endpoint/payload selection and validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c55bc7178501827406a5c4453bd667bc0d6ea6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->