### PR TITLE
feature: expose tailscale sidecar config in rl.toml

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -159,6 +159,7 @@ class RLClient:
         checkpoint_id: Optional[str] = None,
         cluster_name: Optional[str] = None,
         infrastructure_config: Optional[Dict[str, Any]] = None,
+        tailscale_config: Optional[Dict[str, Any]] = None,
         enable_thinking: Optional[bool] = None,
         reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
         run_config: Optional[Dict[str, Any]] = None,
@@ -253,6 +254,9 @@ class RLClient:
             if infrastructure_config:
                 if "compute_size" in infrastructure_config:
                     payload["compute_size"] = infrastructure_config["compute_size"]
+
+            if tailscale_config:
+                payload["tailscale"] = tailscale_config
 
             if enable_thinking is not None:
                 payload["enable_thinking"] = enable_thinking

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -518,8 +518,11 @@ class TailscaleConfig(BaseModel):
     def validate_auth_key(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        if not v.startswith("tskey-auth-"):
-            raise ValueError("auth_key must be a Tailscale auth key starting with 'tskey-auth-'")
+        if not v.startswith(("tskey-auth-", "tskey-client-")):
+            raise ValueError(
+                "auth_key must be a Tailscale auth key (starting with 'tskey-auth-') "
+                "or OAuth client secret (starting with 'tskey-client-')"
+            )
         return v
 
     @model_validator(mode="after")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -490,30 +490,33 @@ class TailscaleConfig(BaseModel):
     """Optional per-run tailscale sidecar (enterprise-only feature).
 
     When enabled, every env-server (training + eval) for this run joins the
-    user's tailnet via a userspace sidecar. The orchestrator and other runs
-    are untouched.
+    user's tailnet via a sidecar. The orchestrator and other runs are
+    untouched.
 
-    The auth key may be supplied via the ``auth_key`` field or, preferably,
+    The auth key must be supplied via the ``auth_key`` field or, preferably,
     via the ``TAILSCALE_AUTH_KEY`` environment variable so the secret never
-    has to live in ``rl.toml``.
+    has to live in ``rl.toml``. Only pre-authenticated keys (``tskey-auth-``)
+    are accepted; OAuth client secrets are not supported. Free-form
+    ``tailscale up`` flags are also not accepted — the platform always
+    boots the sidecar with a locked-down arg set to keep tenant isolation.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = False
     auth_key: str | None = None
-    hostname_prefix: str = "rft"
-    extra_args: str | None = None
+    hostname_prefix: str = "prime-hosted-training"
 
     @field_validator("hostname_prefix")
     @classmethod
     def validate_hostname_prefix(cls, v: str) -> str:
         # Must end in alphanumeric — otherwise the derived sidecar hostname
         # (e.g. f"{prefix}-env-{idx}-{run_id}") would contain consecutive
-        # hyphens which Tailscale rejects.
-        if not re.fullmatch(r"[a-z]([a-z0-9-]{0,14}[a-z0-9])?", v):
+        # hyphens which Tailscale rejects. Length cap matches the platform
+        # (backend/app/packages/rft/k8s_resources/tailscale.py).
+        if not re.fullmatch(r"[a-z]([a-z0-9-]{0,28}[a-z0-9])?", v):
             raise ValueError(
-                "hostname_prefix must be 1-16 chars, lowercase alphanumeric or "
+                "hostname_prefix must be 1-30 chars, lowercase alphanumeric or "
                 "hyphens, starting with a letter and ending with a letter or digit"
             )
         return v
@@ -523,10 +526,10 @@ class TailscaleConfig(BaseModel):
     def validate_auth_key(cls, v: str | None) -> str | None:
         if v is None:
             return v
-        if not v.startswith(("tskey-auth-", "tskey-client-")):
+        if not v.startswith("tskey-auth-"):
             raise ValueError(
-                "auth_key must be a Tailscale auth key (starting with 'tskey-auth-') "
-                "or OAuth client secret (starting with 'tskey-client-')"
+                "auth_key must be a Tailscale pre-authenticated auth key "
+                "(starting with 'tskey-auth-')"
             )
         return v
 
@@ -537,10 +540,8 @@ class TailscaleConfig(BaseModel):
         if self.auth_key is None:
             env_value = os.environ.get("TAILSCALE_AUTH_KEY")
             if env_value:
-                if not env_value.startswith(("tskey-auth-", "tskey-client-")):
-                    raise ValueError(
-                        "TAILSCALE_AUTH_KEY must start with 'tskey-auth-' or 'tskey-client-'"
-                    )
+                if not env_value.startswith("tskey-auth-"):
+                    raise ValueError("TAILSCALE_AUTH_KEY must start with 'tskey-auth-'")
                 self.auth_key = env_value
         if not self.auth_key:
             raise ValueError(
@@ -552,14 +553,11 @@ class TailscaleConfig(BaseModel):
     def to_api_dict(self) -> Dict[str, Any] | None:
         if not self.enabled:
             return None
-        d: Dict[str, Any] = {
+        return {
             "enabled": True,
             "auth_key": self.auth_key,
             "hostname_prefix": self.hostname_prefix,
         }
-        if self.extra_args is not None:
-            d["extra_args"] = self.extra_args
-        return d
 
 
 class RLConfig(BaseModel):

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -531,12 +531,14 @@ class TailscaleConfig(BaseModel):
     def to_api_dict(self) -> Dict[str, Any] | None:
         if not self.enabled:
             return None
-        return {
+        d: Dict[str, Any] = {
             "enabled": True,
             "auth_key": self.auth_key,
             "hostname_prefix": self.hostname_prefix,
-            "extra_args": self.extra_args,
         }
+        if self.extra_args is not None:
+            d["extra_args"] = self.extra_args
+        return d
 
 
 class RLConfig(BaseModel):

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import toml
 import typer
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic import ValidationError as PydanticValidationError
 from rich.markup import escape as rich_escape
 from rich.table import Table
@@ -485,6 +485,60 @@ class InfrastructureConfig(BaseModel):
         return d if d else None
 
 
+class TailscaleConfig(BaseModel):
+    """Optional per-run tailscale sidecar (ADMIN/MANAGER-only on the platform).
+
+    When enabled, every env-server (training + eval) for this run joins the
+    user's tailnet via a userspace sidecar. The orchestrator and other runs
+    are untouched.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = False
+    auth_key: str | None = None
+    hostname_prefix: str = "rft"
+    extra_args: str | None = None
+
+    @field_validator("hostname_prefix")
+    @classmethod
+    def validate_hostname_prefix(cls, v: str) -> str:
+        # Must end in alphanumeric — otherwise the derived sidecar hostname
+        # (e.g. f"{prefix}-env-{idx}-{run_id}") would contain consecutive
+        # hyphens which Tailscale rejects.
+        if not re.fullmatch(r"[a-z]([a-z0-9-]{0,14}[a-z0-9])?", v):
+            raise ValueError(
+                "hostname_prefix must be 1-16 chars, lowercase alphanumeric or "
+                "hyphens, starting with a letter and ending with a letter or digit"
+            )
+        return v
+
+    @field_validator("auth_key")
+    @classmethod
+    def validate_auth_key(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.startswith("tskey-auth-"):
+            raise ValueError("auth_key must be a Tailscale auth key starting with 'tskey-auth-'")
+        return v
+
+    @model_validator(mode="after")
+    def validate_enabled_requires_auth_key(self) -> "TailscaleConfig":
+        if self.enabled and not self.auth_key:
+            raise ValueError("auth_key is required when tailscale.enabled is true")
+        return self
+
+    def to_api_dict(self) -> Dict[str, Any] | None:
+        if not self.enabled:
+            return None
+        return {
+            "enabled": True,
+            "auth_key": self.auth_key,
+            "hostname_prefix": self.hostname_prefix,
+            "extra_args": self.extra_args,
+        }
+
+
 class RLConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -508,6 +562,7 @@ class RLConfig(BaseModel):
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
     adapters: AdaptersConfig = Field(default_factory=AdaptersConfig)
     infrastructure: InfrastructureConfig = Field(default_factory=InfrastructureConfig)
+    tailscale: TailscaleConfig = Field(default_factory=TailscaleConfig)
     run_config: Dict[str, Any] = Field(default_factory=dict)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
@@ -905,6 +960,7 @@ def create_run(
             checkpoint_id=cfg.checkpoint_id,
             cluster_name=cfg.cluster_name,
             infrastructure_config=cfg.infrastructure.to_api_dict(),
+            tailscale_config=cfg.tailscale.to_api_dict(),
             enable_thinking=cfg.sampling.enable_thinking,
             reasoning_effort=cfg.sampling.reasoning_effort,
             run_config=cfg.run_config if cfg.run_config else None,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1,6 +1,7 @@
 """RL (Reinforcement Learning) training commands."""
 
 import json
+import os
 import re
 import time
 from pathlib import Path
@@ -486,11 +487,15 @@ class InfrastructureConfig(BaseModel):
 
 
 class TailscaleConfig(BaseModel):
-    """Optional per-run tailscale sidecar (ADMIN/MANAGER-only on the platform).
+    """Optional per-run tailscale sidecar (enterprise-only feature).
 
     When enabled, every env-server (training + eval) for this run joins the
     user's tailnet via a userspace sidecar. The orchestrator and other runs
     are untouched.
+
+    The auth key may be supplied via the ``auth_key`` field or, preferably,
+    via the ``TAILSCALE_AUTH_KEY`` environment variable so the secret never
+    has to live in ``rl.toml``.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -526,9 +531,22 @@ class TailscaleConfig(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def validate_enabled_requires_auth_key(self) -> "TailscaleConfig":
-        if self.enabled and not self.auth_key:
-            raise ValueError("auth_key is required when tailscale.enabled is true")
+    def fill_auth_key_from_env_and_validate(self) -> "TailscaleConfig":
+        if not self.enabled:
+            return self
+        if self.auth_key is None:
+            env_value = os.environ.get("TAILSCALE_AUTH_KEY")
+            if env_value:
+                if not env_value.startswith(("tskey-auth-", "tskey-client-")):
+                    raise ValueError(
+                        "TAILSCALE_AUTH_KEY must start with 'tskey-auth-' or 'tskey-client-'"
+                    )
+                self.auth_key = env_value
+        if not self.auth_key:
+            raise ValueError(
+                "auth_key is required when tailscale.enabled is true. "
+                "Set [tailscale] auth_key in your config or export TAILSCALE_AUTH_KEY."
+            )
         return self
 
     def to_api_dict(self) -> Dict[str, Any] | None:

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -120,37 +120,34 @@ def test_tailscale_config_disabled_by_default() -> None:
 def test_tailscale_config_enabled_emits_payload(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
-        'model = "dummy"\n'
-        "[tailscale]\n"
-        "enabled = true\n"
-        'auth_key = "tskey-auth-abc123"\n'
-        'hostname_prefix = "rft"\n'
+        'model = "dummy"\n[tailscale]\nenabled = true\nauth_key = "tskey-auth-abc123"\n'
     )
     cfg = load_config(str(config_path))
     assert cfg.tailscale.enabled is True
+    # Default hostname_prefix matches the platform default so the rename
+    # actually lands on CLI-driven runs.
+    assert cfg.tailscale.hostname_prefix == "prime-hosted-training"
     payload = cfg.tailscale.to_api_dict()
-    # Match the file-wide convention: drop unset Optional fields rather than
-    # sending explicit nulls.
     assert payload == {
         "enabled": True,
         "auth_key": "tskey-auth-abc123",
-        "hostname_prefix": "rft",
+        "hostname_prefix": "prime-hosted-training",
     }
 
 
-def test_tailscale_to_api_dict_includes_extra_args_when_set(tmp_path: Path) -> None:
+def test_tailscale_extra_args_field_rejected(tmp_path: Path) -> None:
+    """extra_args is intentionally not exposed — the platform always boots the
+    sidecar with a locked-down arg set for tenant isolation."""
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
         'model = "dummy"\n'
         "[tailscale]\n"
         "enabled = true\n"
         'auth_key = "tskey-auth-abc"\n'
-        'extra_args = "--advertise-tags=tag:rft-debug"\n'
+        'extra_args = "--ssh"\n'
     )
-    cfg = load_config(str(config_path))
-    payload = cfg.tailscale.to_api_dict()
-    assert payload is not None
-    assert payload["extra_args"] == "--advertise-tags=tag:rft-debug"
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
 
 
 def test_tailscale_enabled_without_auth_key_rejected(tmp_path: Path) -> None:
@@ -182,13 +179,16 @@ def test_tailscale_invalid_auth_key_format_rejected(tmp_path: Path) -> None:
         load_config(str(config_path))
 
 
-def test_tailscale_accepts_oauth_client_secret(tmp_path: Path) -> None:
+def test_tailscale_oauth_client_secret_rejected(tmp_path: Path) -> None:
+    """Only pre-authenticated keys (tskey-auth-) are supported. OAuth client
+    secrets (tskey-client-) are rejected because the platform validator
+    only accepts auth keys."""
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
         'model = "dummy"\n[tailscale]\nenabled = true\nauth_key = "tskey-client-abc123"\n'
     )
-    cfg = load_config(str(config_path))
-    assert cfg.tailscale.auth_key == "tskey-client-abc123"
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
 
 
 def test_tailscale_auth_key_from_env(tmp_path: Path, monkeypatch) -> None:

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -189,3 +189,37 @@ def test_tailscale_accepts_oauth_client_secret(tmp_path: Path) -> None:
     )
     cfg = load_config(str(config_path))
     assert cfg.tailscale.auth_key == "tskey-client-abc123"
+
+
+def test_tailscale_auth_key_from_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("TAILSCALE_AUTH_KEY", "tskey-auth-fromenv")
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\n[tailscale]\nenabled = true\n')
+    cfg = load_config(str(config_path))
+    assert cfg.tailscale.auth_key == "tskey-auth-fromenv"
+
+
+def test_tailscale_auth_key_in_config_overrides_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("TAILSCALE_AUTH_KEY", "tskey-auth-fromenv")
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n[tailscale]\nenabled = true\nauth_key = "tskey-auth-fromfile"\n'
+    )
+    cfg = load_config(str(config_path))
+    assert cfg.tailscale.auth_key == "tskey-auth-fromfile"
+
+
+def test_tailscale_env_auth_key_format_validated(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("TAILSCALE_AUTH_KEY", "not-a-real-key")
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\n[tailscale]\nenabled = true\n')
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_tailscale_no_auth_key_anywhere_rejected(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("TAILSCALE_AUTH_KEY", raising=False)
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\n[tailscale]\nenabled = true\n')
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -180,3 +180,12 @@ def test_tailscale_invalid_auth_key_format_rejected(tmp_path: Path) -> None:
     )
     with pytest.raises(typer.Exit):
         load_config(str(config_path))
+
+
+def test_tailscale_accepts_oauth_client_secret(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n[tailscale]\nenabled = true\nauth_key = "tskey-client-abc123"\n'
+    )
+    cfg = load_config(str(config_path))
+    assert cfg.tailscale.auth_key == "tskey-client-abc123"

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -129,12 +129,28 @@ def test_tailscale_config_enabled_emits_payload(tmp_path: Path) -> None:
     cfg = load_config(str(config_path))
     assert cfg.tailscale.enabled is True
     payload = cfg.tailscale.to_api_dict()
+    # Match the file-wide convention: drop unset Optional fields rather than
+    # sending explicit nulls.
     assert payload == {
         "enabled": True,
         "auth_key": "tskey-auth-abc123",
         "hostname_prefix": "rft",
-        "extra_args": None,
     }
+
+
+def test_tailscale_to_api_dict_includes_extra_args_when_set(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n'
+        "[tailscale]\n"
+        "enabled = true\n"
+        'auth_key = "tskey-auth-abc"\n'
+        'extra_args = "--advertise-tags=tag:rft-debug"\n'
+    )
+    cfg = load_config(str(config_path))
+    payload = cfg.tailscale.to_api_dict()
+    assert payload is not None
+    assert payload["extra_args"] == "--advertise-tags=tag:rft-debug"
 
 
 def test_tailscale_enabled_without_auth_key_rejected(tmp_path: Path) -> None:

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -109,3 +109,58 @@ def test_load_config_rejects_top_level_reasoning_effort(tmp_path: Path) -> None:
 
     with pytest.raises(typer.Exit):
         load_config(str(config_path))
+
+
+def test_tailscale_config_disabled_by_default() -> None:
+    cfg = RLConfig(model="dummy")
+    assert cfg.tailscale.enabled is False
+    assert cfg.tailscale.to_api_dict() is None
+
+
+def test_tailscale_config_enabled_emits_payload(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n'
+        "[tailscale]\n"
+        "enabled = true\n"
+        'auth_key = "tskey-auth-abc123"\n'
+        'hostname_prefix = "rft"\n'
+    )
+    cfg = load_config(str(config_path))
+    assert cfg.tailscale.enabled is True
+    payload = cfg.tailscale.to_api_dict()
+    assert payload == {
+        "enabled": True,
+        "auth_key": "tskey-auth-abc123",
+        "hostname_prefix": "rft",
+        "extra_args": None,
+    }
+
+
+def test_tailscale_enabled_without_auth_key_rejected(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\n[tailscale]\nenabled = true\n')
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_tailscale_invalid_hostname_prefix_rejected(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n'
+        "[tailscale]\n"
+        "enabled = true\n"
+        'auth_key = "tskey-auth-abc"\n'
+        'hostname_prefix = "rft-"\n'
+    )
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_tailscale_invalid_auth_key_format_rejected(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n[tailscale]\nenabled = true\nauth_key = "not-a-real-key"\n'
+    )
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))


### PR DESCRIPTION
Pairs with platform PR https://github.com/PrimeIntellect-ai/platform/pull/1694 — adds a `[tailscale]` block to `rl.toml` so admins/managers can opt a run's env servers onto their tailnet.

- New `TailscaleConfig` model with `enabled`, `auth_key`, `hostname_prefix`, `extra_args`. Validators reject malformed auth keys and trailing-hyphen prefixes.
- Threaded through `create_run()` payload as the `tailscale` field.
- Sample TOML:

```toml
[tailscale]
enabled = true
auth_key = "tskey-auth-..."
hostname_prefix = "rft"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new run-creation payload fields and secret handling (`TAILSCALE_AUTH_KEY`/`auth_key`), which could affect run startup if validation or API expectations diverge. Scope is localized to RL CLI config parsing and request construction.
> 
> **Overview**
> Adds support for configuring an optional per-run Tailscale sidecar via a new `[tailscale]` block in `rl.toml` (with validation and optional `TAILSCALE_AUTH_KEY` env fallback) so env-server pods can join a user tailnet.
> 
> Threads this config through the CLI run creation flow by extending `RLClient.create_run()` to accept `tailscale_config` and emit a `tailscale` field in the `/rft/runs` payload, with new tests covering defaults, validation failures, and env-var precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45e5570185eff1238e7c9e09d0d4ec94634f9edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->