### PR TITLE
Add `prime inference chat` for quick model testing

### DIFF
--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -193,7 +193,8 @@ def chat(
             _print_stream(stream_result)  # type: ignore[arg-type]
             return
 
-        raw = client.chat_completion(payload)
+        with console.status(f"[bold blue]Waiting for {model}...", spinner="dots"):
+            raw = client.chat_completion(payload)
         if not isinstance(raw, dict):
             console.print("[red]Error:[/red] unexpected non-JSON response from inference.")
             raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -163,6 +163,10 @@ def chat(
         console.print(f"[red]Error:[/red] invalid output format '{output}'. Supported: text, json")
         raise typer.Exit(1)
 
+    if stream and output == "json":
+        console.print("[red]Error:[/red] --stream is not supported with --output json.")
+        raise typer.Exit(1)
+
     if message is None:
         if sys.stdin.isatty():
             console.print("[red]Error:[/red] no message provided (pass as arg or via stdin).")
@@ -186,9 +190,6 @@ def chat(
     try:
         client = InferenceClient()
         if stream:
-            if output == "json":
-                console.print("[red]Error:[/red] --stream is not supported with --output json.")
-                raise typer.Exit(1)
             stream_result = client.chat_completion(payload, stream=True)
             _print_stream(stream_result)  # type: ignore[arg-type]
             return
@@ -214,6 +215,8 @@ def chat(
             sys.stdout.write("\n")
         sys.stdout.flush()
 
+    except typer.Exit:
+        raise
     except InferenceAPIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import datetime as _dt
+import sys
+from typing import Any, Dict, Iterable, List, Optional, cast
 
 import typer
 from rich.table import Table
@@ -97,6 +99,119 @@ def list_models(
             )
 
         console.print(table)
+
+    except InferenceAPIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]Unexpected error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+CHAT_JSON_HELP = json_output_help(
+    "Full chat completion response: {id, model, choices[], usage?, ...}",
+    "Each choice has .message.content with the assistant reply",
+)
+
+
+def _build_messages(message: str, system: Optional[str]) -> List[Dict[str, str]]:
+    messages: List[Dict[str, str]] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": message})
+    return messages
+
+
+def _print_stream(chunks: Iterable[Dict[str, Any]]) -> None:
+    for chunk in chunks:
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+        delta = choices[0].get("delta") or {}
+        piece = delta.get("content")
+        if piece:
+            sys.stdout.write(piece)
+            sys.stdout.flush()
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+@app.command("chat", epilog=CHAT_JSON_HELP)
+def chat(
+    model: str = typer.Argument(..., help="Model id (see `prime inference models`)"),
+    message: Optional[str] = typer.Argument(
+        None, help="User message. If omitted, reads from stdin."
+    ),
+    system: Optional[str] = typer.Option(None, "--system", "-s", help="System prompt"),
+    stream: bool = typer.Option(False, "--stream", help="Stream tokens as they arrive"),
+    temperature: Optional[float] = typer.Option(
+        None, "--temperature", "-t", help="Sampling temperature"
+    ),
+    max_tokens: Optional[int] = typer.Option(
+        None, "--max-tokens", help="Maximum tokens to generate"
+    ),
+    output: str = typer.Option("text", "--output", "-o", help="text|json"),
+) -> None:
+    """Send a one-shot chat message to a Prime Inference model.
+
+    Examples:
+      prime inference chat <model-id> "say hi"
+      echo "explain RL in one line" | prime inference chat <model-id>
+      prime inference chat <model-id> "hi" --stream
+    """
+    if output not in ("text", "json"):
+        console.print(f"[red]Error:[/red] invalid output format '{output}'. Supported: text, json")
+        raise typer.Exit(1)
+
+    if message is None:
+        if sys.stdin.isatty():
+            console.print("[red]Error:[/red] no message provided (pass as arg or via stdin).")
+            raise typer.Exit(1)
+        message = sys.stdin.read().strip()
+        if not message:
+            console.print("[red]Error:[/red] empty message from stdin.")
+            raise typer.Exit(1)
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": _build_messages(message, system),
+    }
+    if temperature is not None:
+        payload["temperature"] = temperature
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if stream:
+        payload["stream"] = True
+
+    try:
+        client = InferenceClient()
+        if stream:
+            if output == "json":
+                console.print("[red]Error:[/red] --stream is not supported with --output json.")
+                raise typer.Exit(1)
+            stream_result = client.chat_completion(payload, stream=True)
+            _print_stream(stream_result)  # type: ignore[arg-type]
+            return
+
+        raw = client.chat_completion(payload)
+        if not isinstance(raw, dict):
+            console.print("[red]Error:[/red] unexpected non-JSON response from inference.")
+            raise typer.Exit(1)
+        result = cast(Dict[str, Any], raw)
+
+        if output == "json":
+            output_data_as_json(result, console)
+            return
+
+        choices = result.get("choices") or []
+        if not choices:
+            console.print("[yellow]No choices returned.[/yellow]")
+            return
+        content = (choices[0].get("message") or {}).get("content") or ""
+        sys.stdout.write(content)
+        if not content.endswith("\n"):
+            sys.stdout.write("\n")
+        sys.stdout.flush()
 
     except InferenceAPIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/tests/test_inference_chat.py
+++ b/packages/prime/tests/test_inference_chat.py
@@ -1,0 +1,194 @@
+"""Tests for `prime inference chat`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from prime_cli.api.inference import InferenceAPIError
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+TEST_ENV: Dict[str, str] = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "NO_COLOR": "1",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+}
+
+
+class DummyClient:
+    """Records the last payload and returns canned responses."""
+
+    last_payload: Dict[str, Any] = {}
+    last_stream: bool = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def chat_completion(self, payload: Dict[str, Any], stream: bool = False):
+        DummyClient.last_payload = payload
+        DummyClient.last_stream = stream
+        if stream:
+            return iter(
+                [
+                    {"choices": [{"delta": {"content": "hel"}}]},
+                    {"choices": [{"delta": {"content": "lo"}}]},
+                ]
+            )
+        return {
+            "id": "chatcmpl-1",
+            "model": payload["model"],
+            "choices": [
+                {"message": {"role": "assistant", "content": "hi there"}, "finish_reason": "stop"}
+            ],
+        }
+
+
+def test_chat_prints_assistant_text(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model", "say hi"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "hi there" in result.output
+    assert DummyClient.last_payload["model"] == "some-model"
+    assert DummyClient.last_payload["messages"] == [{"role": "user", "content": "say hi"}]
+    assert "stream" not in DummyClient.last_payload
+
+
+def test_chat_includes_system_prompt(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model", "say hi", "--system", "be terse"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    messages: List[Dict[str, str]] = DummyClient.last_payload["messages"]
+    assert messages[0] == {"role": "system", "content": "be terse"}
+    assert messages[1] == {"role": "user", "content": "say hi"}
+
+
+def test_chat_passes_sampling_options(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "inference",
+            "chat",
+            "some-model",
+            "hi",
+            "--temperature",
+            "0.2",
+            "--max-tokens",
+            "16",
+        ],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert DummyClient.last_payload["temperature"] == 0.2
+    assert DummyClient.last_payload["max_tokens"] == 16
+
+
+def test_chat_streams_tokens(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model", "hi", "--stream"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert DummyClient.last_stream is True
+    assert DummyClient.last_payload.get("stream") is True
+    assert "hello" in result.output
+
+
+def test_chat_json_output(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model", "hi", "--output", "json"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"id": "chatcmpl-1"' in result.output
+    assert '"hi there"' in result.output
+
+
+def test_chat_stream_with_json_errors(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model", "hi", "--stream", "--output", "json"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "not supported" in result.output
+
+
+def test_chat_reports_api_error(monkeypatch):
+    class FailingClient(DummyClient):
+        def chat_completion(self, payload, stream=False):
+            raise InferenceAPIError("boom")
+
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", FailingClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model", "hi"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "boom" in result.output
+
+
+def test_chat_reads_message_from_stdin(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model"],
+        input="hi from stdin\n",
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert DummyClient.last_payload["messages"] == [{"role": "user", "content": "hi from stdin"}]
+
+
+def test_chat_rejects_empty_stdin(monkeypatch):
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inference", "chat", "some-model"],
+        input="",
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 1
+    assert "empty message" in result.output


### PR DESCRIPTION
Quick way to test a Prime Inference model from the CLI without writing a curl.

- `prime inference chat <model> "say hi"` — one-shot reply
- `--system`, `--temperature`, `--max-tokens` for tuning
- `--stream` for token-by-token output
- `--output json` for the raw response
- reads from stdin if no message arg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI subcommand and tests without changing existing inference API behavior; main risk is minor UX/edge-case handling around stdin/streamed output.
> 
> **Overview**
> Adds **new `prime inference chat`** command to send a single user message to an inference model, optionally including a system prompt and sampling controls (`--temperature`, `--max-tokens`).
> 
> Supports *token streaming* (`--stream`) via incremental stdout writes and *raw response output* (`--output json`), with validation and clear error messages for invalid combinations and missing/empty stdin input.
> 
> Introduces a new `test_inference_chat.py` suite covering payload formation, streaming behavior, JSON output, stdin reading, and API error propagation via a dummy `InferenceClient`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd7b5883f0d7dea58f1af5e99a4e6d7f6aa60d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->