### PR TITLE
Lazy-load verifiers imports in evals command (3x faster startup)

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -44,26 +44,9 @@ from ..verifiers_bridge import (
 
 console = get_console()
 
-
-def _lazy(module_path: str, name: str):
-    def stub(*args, **kwargs):
-        import importlib
-
-        fn = getattr(importlib.import_module(module_path), name)
-        globals()[name] = fn
-        return fn(*args, **kwargs)
-
-    stub.__name__ = name
-    return stub
-
-
-build_extra_headers = _lazy("verifiers.cli.commands.eval", "build_extra_headers")
-build_parser = _lazy("verifiers.cli.commands.eval", "build_parser")
-merge_sampling_args = _lazy("verifiers.cli.commands.eval", "merge_sampling_args")
-load_endpoints = _lazy("verifiers.utils.eval_utils", "load_endpoints")
-load_toml_config = _lazy("verifiers.utils.eval_utils", "load_toml_config")
-resolve_endpoints_file = _lazy("verifiers.utils.eval_utils", "resolve_endpoints_file")
-
+# verifiers.* must be imported inside functions (not at module top): top-level
+# imports drag in huggingface_hub/datasets/pyarrow/pandas/numpy and triple
+# `prime --version` startup time. Same convention as the rest of prime_cli.
 
 LIST_EVALS_JSON_HELP = json_output_help(
     ".evaluations[] = {evaluation_id|id, environment_names[], model_name, status, metadata}",
@@ -270,6 +253,8 @@ def _validate_json_object_field(merged: dict[str, Any], field_name: str) -> None
 
 
 def _coerce_hosted_headers(raw: dict[str, Any]) -> list[str] | None:
+    from verifiers.cli.commands.eval import build_extra_headers
+
     try:
         normalized = build_extra_headers(raw)
     except ValueError as exc:
@@ -284,6 +269,8 @@ def _coerce_hosted_headers(raw: dict[str, Any]) -> list[str] | None:
 def _parse_verifiers_eval_namespace(
     environment: str, passthrough_args: list[str], sampling_args: Optional[str]
 ) -> tuple[argparse.Namespace, set[str], dict[str, str]]:
+    from verifiers.cli.commands.eval import build_parser
+
     argv = [environment, *passthrough_args]
     if sampling_args is not None:
         argv.extend(["--sampling-args", sampling_args])
@@ -379,6 +366,15 @@ def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) 
     if "endpoints_path" in raw_config and not endpoints_path_obj.is_absolute():
         endpoints_path = str((config_path.parent / endpoints_path_obj).resolve())
 
+    try:
+        from verifiers.utils.eval_utils import load_endpoints, resolve_endpoints_file
+    except ImportError as exc:
+        console.print(
+            "[red]Error:[/red] verifiers is required to resolve `endpoint_id`. "
+            "Install the `verifiers` package or use `model` instead."
+        )
+        raise typer.Exit(1) from exc
+
     resolved_endpoints_file = resolve_endpoints_file(endpoints_path)
     if resolved_endpoints_file is None or resolved_endpoints_file.suffix != ".toml":
         console.print(
@@ -409,6 +405,8 @@ def _resolve_hosted_config_model(raw_config: dict[str, Any], config_path: Path) 
 def _validate_single_hosted_eval_config(
     merged: dict[str, Any], config_path: Path
 ) -> dict[str, Any]:
+    from verifiers.cli.commands.eval import merge_sampling_args
+
     unsupported_fields = sorted(
         field_name for field_name in merged if field_name not in HOSTED_SUPPORTED_TOML_FIELDS
     )
@@ -466,6 +464,8 @@ def _validate_single_hosted_eval_config(
 
 
 def _load_hosted_eval_configs(config_path_str: str) -> list[dict[str, Any]]:
+    from verifiers.utils.eval_utils import load_toml_config
+
     config_path = Path(config_path_str)
     try:
         loaded_configs = load_toml_config(
@@ -1533,6 +1533,8 @@ def run_eval_cmd(
             else:
                 console.print("[red]Error:[/red] `sampling_args` must be a JSON object")
                 raise typer.Exit(1)
+            from verifiers.cli.commands.eval import merge_sampling_args
+
             effective_sampling_args = (
                 merge_sampling_args(
                     base_sampling_args,

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -11,16 +11,6 @@ from click.core import ParameterSource
 from prime_evals import EvalsAPIError, EvalsClient, InvalidEvaluationError
 from rich.syntax import Syntax
 from rich.table import Table
-from verifiers.cli.commands.eval import (
-    build_extra_headers,
-    build_parser,
-    merge_sampling_args,
-)
-from verifiers.utils.eval_utils import (
-    load_endpoints,
-    load_toml_config,
-    resolve_endpoints_file,
-)
 
 from ..client import APIClient, APIError
 from ..core import Config
@@ -53,6 +43,27 @@ from ..verifiers_bridge import (
 )
 
 console = get_console()
+
+
+def _lazy(module_path: str, name: str):
+    def stub(*args, **kwargs):
+        import importlib
+
+        fn = getattr(importlib.import_module(module_path), name)
+        globals()[name] = fn
+        return fn(*args, **kwargs)
+
+    stub.__name__ = name
+    return stub
+
+
+build_extra_headers = _lazy("verifiers.cli.commands.eval", "build_extra_headers")
+build_parser = _lazy("verifiers.cli.commands.eval", "build_parser")
+merge_sampling_args = _lazy("verifiers.cli.commands.eval", "merge_sampling_args")
+load_endpoints = _lazy("verifiers.utils.eval_utils", "load_endpoints")
+load_toml_config = _lazy("verifiers.utils.eval_utils", "load_toml_config")
+resolve_endpoints_file = _lazy("verifiers.utils.eval_utils", "resolve_endpoints_file")
+
 
 LIST_EVALS_JSON_HELP = json_output_help(
     ".evaluations[] = {evaluation_id|id, environment_names[], model_name, status, metadata}",

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1200,10 +1200,10 @@ env_id = "gsm8k"
         }
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals.resolve_endpoints_file",
+        "verifiers.utils.eval_utils.resolve_endpoints_file",
         fake_resolve_endpoints_file,
     )
-    monkeypatch.setattr("prime_cli.commands.evals.load_endpoints", fake_load_endpoints)
+    monkeypatch.setattr("verifiers.utils.eval_utils.load_endpoints", fake_load_endpoints)
 
     loaded = _load_hosted_eval_configs(str(config_path))[0]
 
@@ -1226,11 +1226,11 @@ endpoint_id = "test-endpoint"
     )
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals.resolve_endpoints_file",
+        "verifiers.utils.eval_utils.resolve_endpoints_file",
         lambda path: Path(path),
     )
     monkeypatch.setattr(
-        "prime_cli.commands.evals.load_endpoints",
+        "verifiers.utils.eval_utils.load_endpoints",
         lambda path: {
             "test-endpoint": [
                 {
@@ -1262,11 +1262,11 @@ model = "anthropic/claude-sonnet-4"
     )
 
     monkeypatch.setattr(
-        "prime_cli.commands.evals.resolve_endpoints_file",
+        "verifiers.utils.eval_utils.resolve_endpoints_file",
         lambda path: (_ for _ in ()).throw(AssertionError("should not resolve endpoint_id")),
     )
     monkeypatch.setattr(
-        "prime_cli.commands.evals.load_endpoints",
+        "verifiers.utils.eval_utils.load_endpoints",
         lambda path: (_ for _ in ()).throw(AssertionError("should not load endpoints")),
     )
 


### PR DESCRIPTION
`prime --version` got ~3x slower (190ms → 580ms) starting in #513, which lifted six `verifiers.*` imports to the top of `commands/evals.py`. Those transitively pull in `huggingface_hub` → `datasets` → `pyarrow` + `pandas` + `numpy` + `aiohttp` on every prime invocation, including `--version`, `--help`, and shell tab-completion.

- Move imports inline into the 6 functions that use them
- Matches the convention v0.5.50 of this file already followed (and every other module in prime_cli)
- `prime --version` back to ~200ms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily refactors import timing to reduce CLI startup overhead; behavior changes are limited to clearer `verifiers`-missing errors when resolving `endpoint_id`.
> 
> **Overview**
> Improves `prime eval` CLI startup time by **removing top-level `verifiers.*` imports** from `commands/evals.py` and **lazy-loading** them inside the handful of functions that need them.
> 
> Adds a targeted `ImportError` handler when `endpoint_id` resolution requires `verifiers`, and updates hosted-eval tests to monkeypatch `verifiers.utils.eval_utils.*` directly now that those symbols are no longer imported into `prime_cli.commands.evals`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57faddd27a1c0f45f558a99def1fc0b87e835eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->