### PR TITLE
release: cli 0.5.75

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.74"
+__version__ = "0.5.75"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Version bump to 0.5.75.

Includes the tailscale sidecar config support in #568 (drop ssh/extra_args + tskey-client-, sync hostname prefix default with platform).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a version-string bump only, with no functional code changes.
> 
> **Overview**
> Updates `prime_cli.__version__` from `0.5.74` to `0.5.75` for the CLI release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9682e25f9daa061cce9a0b01a52ed1d7de6e6ab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->