### PR TITLE
sandbox regions

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -58,6 +58,7 @@ class Sandbox(BaseModel):
     user_id: Optional[str] = Field(None, alias="userId")
     team_id: Optional[str] = Field(None, alias="teamId")
     kubernetes_job_id: Optional[str] = Field(None, alias="kubernetesJobId")
+    region: Optional[str] = None
     registry_credentials_id: Optional[str] = Field(default=None, alias="registryCredentialsId")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -93,6 +94,7 @@ class CreateSandboxRequest(BaseModel):
     secrets: Optional[Dict[str, str]] = None
     labels: List[str] = Field(default_factory=list)
     team_id: Optional[str] = None
+    region: Optional[str] = None
     advanced_configs: Optional[AdvancedConfigs] = None
     registry_credentials_id: Optional[str] = None
 

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -26,7 +26,20 @@ def test_create_sandbox_request_defaults():
     assert request.gpu_type is None
     assert request.vm is False
     assert request.timeout_minutes == 60
+    assert request.region is None
     assert request.labels == []
+
+
+def test_create_sandbox_request_accepts_region():
+    """Test region is accepted for multi-cluster sandbox creation"""
+    request = CreateSandboxRequest(
+        name="regional-sandbox",
+        docker_image="python:3.11-slim",
+        region="eu-west",
+    )
+
+    assert request.region == "eu-west"
+    assert request.model_dump(exclude_none=True)["region"] == "eu-west"
 
 
 def test_create_sandbox_request_requires_gpu_type_for_gpu_count():
@@ -117,6 +130,7 @@ def test_sandbox_model_with_alias():
         "labels": ["test"],
         "createdAt": "2024-01-01T00:00:00Z",
         "updatedAt": "2024-01-01T00:00:00Z",
+        "region": "eu-west",
     }
 
     sandbox = Sandbox.model_validate(data)
@@ -128,3 +142,4 @@ def test_sandbox_model_with_alias():
     assert sandbox.status == "RUNNING"
     assert sandbox.gpu_type == "H100_80GB"
     assert sandbox.vm is True
+    assert sandbox.region == "eu-west"

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -89,6 +89,7 @@ def _format_sandbox_for_list(sandbox: Sandbox) -> Dict[str, Any]:
         "image": sandbox.docker_image,
         "status": sandbox.status,
         "resources": format_resources(sandbox.cpu_cores, sandbox.memory_gb, sandbox.gpu_count),
+        "region": getattr(sandbox, "region", None),
         "labels": ", ".join(sandbox.labels) if sandbox.labels else "-",  # For table output
         "labels_list": sandbox.labels,  # For JSON output
         "created_at": iso_timestamp(sandbox.created_at),  # For JSON output
@@ -118,6 +119,7 @@ def _format_sandbox_for_details(sandbox: Sandbox) -> Dict[str, Any]:
         "created_at": iso_timestamp(sandbox.created_at),
         "user_id": sandbox.user_id,
         "team_id": sandbox.team_id,
+        "region": getattr(sandbox, "region", None),
         "registry_credentials_id": getattr(sandbox, "registry_credentials_id", None),
     }
 
@@ -212,6 +214,7 @@ def list_sandboxes_cmd(
                     "image": sandbox_data["image"],
                     "status": sandbox_data["status"],
                     "resources": sandbox_data["resources"],
+                    "region": sandbox_data["region"],
                     "labels": sandbox_data["labels_list"],
                     "created_at": sandbox_data["created_at"],
                 }
@@ -329,6 +332,8 @@ def get(
 
             table.add_row("User ID", sandbox_data["user_id"] or "N/A")
             table.add_row("Team ID", sandbox_data["team_id"] or "Personal")
+            if sandbox_data.get("region"):
+                table.add_row("Region", sandbox_data["region"])
             if sandbox_data.get("registry_credentials_id"):
                 table.add_row(
                     "Registry Credentials",
@@ -400,6 +405,11 @@ def create(
     timeout_minutes: int = typer.Option(60, help="Timeout in minutes"),
     team_id: Optional[str] = typer.Option(
         None, help="Team ID (uses config team_id if not specified)"
+    ),
+    region: Optional[str] = typer.Option(
+        None,
+        "--region",
+        help="Sandbox cluster region (for example: us, eu-west). Uses backend default if omitted.",
     ),
     registry_credentials_id: Optional[str] = typer.Option(
         None,
@@ -508,6 +518,7 @@ def create(
             secrets=secrets_vars if secrets_vars else None,
             labels=labels if labels else [],
             team_id=team_id,
+            region=region,
             registry_credentials_id=registry_credentials_id,
         )
 
@@ -524,6 +535,7 @@ def create(
         console.print(f"Network Access: {network_status}")
         console.print(f"Timeout: {timeout_minutes} minutes")
         console.print(f"Team: {team_id or 'Personal'}")
+        console.print(f"Region: {region or 'Backend default'}")
         if registry_credentials_id:
             console.print(f"Registry Credentials: {registry_credentials_id}")
         if labels:

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -116,6 +116,37 @@ def test_sandbox_create_accepts_docker_image_for_gpu(monkeypatch: pytest.MonkeyP
     assert captured["request"].vm is True
 
 
+def test_sandbox_create_accepts_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    captured: dict[str, Any] = {}
+
+    def mock_create(self: Any, request: Any) -> Any:
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-eu-west")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "python:3.11-slim",
+            "--region",
+            "eu-west",
+            "--yes",
+        ],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Successfully created sandbox sbx-eu-west" in output
+    assert "Region: eu-west" in output
+    assert captured["request"].region == "eu-west"
+
+
 def test_sandbox_create_requires_gpu_type(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive, optional field plumbing and output changes; main risk is compatibility if the backend rejects or ignores the new `region` parameter.
> 
> **Overview**
> Adds optional `region` support end-to-end for sandboxes. The sandboxes SDK models now accept/return a `region` field on `Sandbox` and `CreateSandboxRequest`, and the CLI wires through a new `--region` flag on `prime sandbox create` while also displaying region in `sandbox list` (JSON) and `sandbox get` output.
> 
> Tests are updated to cover region defaults/serialization in the models and to assert the CLI forwards `--region` into the create request and prints it in the configuration summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196cb1bd23feb3e9a3af88c81e0a2a613dd55990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->