### PR TITLE
Skip live eval tests by default

### DIFF
--- a/packages/prime/tests/test_env_eval.py
+++ b/packages/prime/tests/test_env_eval.py
@@ -9,6 +9,11 @@ import pytest
 # Use a small/fast model for testing
 TEST_MODEL = "deepseek/deepseek-chat"
 
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PRIME_RUN_LIVE_EVAL_TESTS") != "1" or not os.environ.get("PRIME_API_KEY"),
+    reason="Set PRIME_RUN_LIVE_EVAL_TESTS=1 and PRIME_API_KEY to run live eval tests.",
+)
+
 
 @pytest.fixture(scope="module")
 def install_math_env():


### PR DESCRIPTION
## Summary\n- make the live Prime Inference eval tests opt-in via PRIME_RUN_LIVE_EVAL_TESTS=1\n- keep the regular prime unit test job offline and deterministic\n\n## Tests\n- cd packages/prime && uv run pytest tests/test_env_eval.py -q\n- cd packages/prime && uv run pytest tests/ -q\n\nNote: origin does not have a develop branch, so this PR is based on latest origin/main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d9a0628bc457889da48374f84d8ee1494dbd4345. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->