### PR TITLE
show training and inference prices in 'prime rl models'

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -13,6 +13,13 @@ class RLModel(BaseModel):
 
     name: str = Field(..., description="Model name")
     at_capacity: bool = Field(False, alias="atCapacity")
+    training_price_per_mtok: Optional[float] = Field(None, alias="trainingPricePerMtok")
+    inference_input_price_per_mtok: Optional[float] = Field(
+        None, alias="inferenceInputPricePerMtok"
+    )
+    inference_output_price_per_mtok: Optional[float] = Field(
+        None, alias="inferenceOutputPricePerMtok"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -15,6 +15,7 @@ from ..utils import (
     output_data_as_json,
     validate_output_format,
 )
+from ..utils.formatters import format_price_per_mtok
 
 app = PlainTyper(
     help="Run and manage Prime Inference\n\n"
@@ -37,17 +38,6 @@ def _fmt_created(val: str) -> str:
         return _dt.datetime.fromtimestamp(ts, _dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     except Exception:
         return val or ""
-
-
-def _fmt_price(x) -> str:
-    """Format USD per 1M tokens (mtok) for display."""
-    if x is None:
-        return ""
-    try:
-        f = float(x)
-        return f"${f:.6f}".rstrip("0").rstrip(".")
-    except Exception:
-        return str(x)
 
 
 @app.command("models", epilog=MODELS_JSON_HELP)
@@ -94,8 +84,8 @@ def list_models(
             table.add_row(
                 mid,
                 created,
-                _fmt_price(pin),
-                _fmt_price(pout),
+                format_price_per_mtok(pin),
+                format_price_per_mtok(pout),
             )
 
         console.print(table)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -29,7 +29,7 @@ from ..utils import (
 )
 from ..utils.env_metadata import find_environment_metadata
 from ..utils.env_vars import EnvParseError, collect_env_vars
-from ..utils.formatters import format_file_size, strip_ansi
+from ..utils.formatters import format_file_size, format_price_per_mtok, strip_ansi
 
 console = get_console()
 
@@ -39,7 +39,8 @@ RL_RUN_JSON_HELP = json_output_help(
 )
 
 RL_MODELS_JSON_HELP = json_output_help(
-    ".models[] = {name, at_capacity}",
+    ".models[] = {name, at_capacity, training_price_per_mtok, "
+    "inference_input_price_per_mtok, inference_output_price_per_mtok}",
 )
 
 RL_LIST_JSON_HELP = json_output_help(
@@ -1054,13 +1055,22 @@ def list_models(
         table = Table(title="Prime RL — Models")
         table.add_column("Model", style="cyan")
         table.add_column("Status")
+        table.add_column("Training $/M tok", style="green", justify="right")
+        table.add_column("Inference In $/M tok", style="green", justify="right")
+        table.add_column("Inference Out $/M tok", style="green", justify="right")
 
         for model in models:
             if model.at_capacity:
                 status = "[red]At Capacity[/red]"
             else:
                 status = "[green]Available[/green]"
-            table.add_row(model.name, status)
+            table.add_row(
+                model.name,
+                status,
+                format_price_per_mtok(model.training_price_per_mtok) or "-",
+                format_price_per_mtok(model.inference_input_price_per_mtok) or "-",
+                format_price_per_mtok(model.inference_output_price_per_mtok) or "-",
+            )
 
         console.print(table)
 

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -45,6 +45,17 @@ def format_price(value: float) -> str:
     return f"${value:.2f}"
 
 
+def format_price_per_mtok(value: Any) -> str:
+    """Format USD per 1M tokens for display, trimming trailing zeros."""
+    if value is None:
+        return ""
+    try:
+        f = float(value)
+        return f"${f:.6f}".rstrip("0").rstrip(".")
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def format_resources(cpu_cores: float, memory_gb: float, gpu_count: int = 0) -> str:
     """Format resource specifications as compact string."""
     resources = f"{cpu_cores:g}CPU/{memory_gb:g}GB"

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -1,0 +1,90 @@
+"""Tests for `prime rl models` — focused on price column rendering."""
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+
+def _models_payload() -> Dict[str, Any]:
+    return {
+        "models": [
+            {
+                "name": "qwen/qwen3-8b",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.5,
+                "inferenceInputPricePerMtok": 1.0,
+                "inferenceOutputPricePerMtok": 3.0,
+            },
+            {
+                "name": "openai/gpt-oss-20b",
+                "atCapacity": True,
+                "trainingPricePerMtok": None,
+                "inferenceInputPricePerMtok": None,
+                "inferenceOutputPricePerMtok": None,
+            },
+        ]
+    }
+
+
+def _mock_get_factory(calls: List[str]):
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        calls.append(endpoint)
+        if endpoint == "/rft/models":
+            return _models_payload()
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    return mock_get
+
+
+def test_models_table_renders_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: List[str] = []
+    monkeypatch.setattr("prime_cli.core.APIClient.get", _mock_get_factory(calls))
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    assert "qwen/qwen3-8b" in result.output
+    assert "$0.5" in result.output
+    assert "$1" in result.output
+    assert "$3" in result.output
+    # Null pricing renders as a dash.
+    assert "-" in result.output
+    assert calls == ["/rft/models"]
+
+
+def test_models_json_includes_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("prime_cli.core.APIClient.get", _mock_get_factory([]))
+
+    result = CliRunner().invoke(app, ["rl", "models", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["models"][0]["training_price_per_mtok"] == 0.5
+    assert data["models"][0]["inference_input_price_per_mtok"] == 1.0
+    assert data["models"][0]["inference_output_price_per_mtok"] == 3.0
+    assert data["models"][1]["training_price_per_mtok"] is None
+
+
+def test_models_handles_backend_without_pricing_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Older backends may not return the pricing fields at all."""
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return {"models": [{"name": "qwen/qwen3-8b", "atCapacity": False}]}
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    assert "qwen/qwen3-8b" in result.output


### PR DESCRIPTION
The `/rft/models` response carries pricing fields per model — the CLI was dropping them.

- Adds three columns to the table: Training, Inference In, Inference Out ($/M tok)
- Extends `RLModel` with the matching optional fields; falls back to `-` when the backend omits them
- Extracts the per-mtok price formatter from `inference.py` to `utils.formatters` so both commands share it
- Adds `tests/test_rl_models.py`

Pairs with platform PR https://github.com/PrimeIntellect-ai/platform/pull/1745 (which fixes which cluster's price gets surfaced when a model lives on multiple clusters).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e67cada398cc5ce9d176b7c3d6ee488b8465afc5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->