### PR TITLE
Release prime CLI 0.5.77

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.76"
+__version__ = "0.5.77"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bump prime CLI to 0.5.77.

- show training and inference prices in `prime rl models` (#578)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8849d3da4cbcde9842a28317632f8d82a21dcaa0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->