### PR TITLE
[codex] Update hosted training CLI to train

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -724,7 +724,8 @@ class DefaultGroup(DefaultCommandGroup):
         if default_command is None:
             return params
 
-        return [*default_command.params, *params]
+        seen = {p.name for p in default_command.params}
+        return [*default_command.params, *(p for p in params if p.name not in seen)]
 
     def format_help(self, ctx, formatter):
         self._show_default_command_params = True

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1,4 +1,4 @@
-"""RL (Reinforcement Learning) training commands."""
+"""Hosted Training commands."""
 
 import json
 import os
@@ -170,7 +170,7 @@ def clean_logs(text: str) -> list[str]:
 
 
 def generate_rl_config_template(environment: str | None = None) -> str:
-    """Generate a TOML config template for RL training."""
+    """Generate a TOML config template for Hosted Training."""
     env_value = environment or "primeintellect/reverse-text"
 
     return f'''\
@@ -705,25 +705,57 @@ def _format_run_for_display(run: RLRun) -> Dict[str, Any]:
 class DefaultGroup(DefaultCommandGroup):
     """Makes 'run' the default command when a config file is passed."""
 
+    def __init__(self, *args, default_cmd_name: str = "run", **kwargs):
+        super().__init__(*args, default_cmd_name=default_cmd_name, **kwargs)
+        self._show_default_command_params = False
+
     def format_usage(self, ctx, formatter):
         formatter.write_usage(
             ctx.command_path,
             "[OPTIONS] CONFIG_PATH [ARGS]... | COMMAND [ARGS]...",
         )
 
+    def get_params(self, ctx):
+        params = super().get_params(ctx)
+        if not self._show_default_command_params:
+            return params
+
+        default_command = self.commands.get(self.default_cmd_name)
+        if default_command is None:
+            return params
+
+        return [*default_command.params, *params]
+
+    def format_help(self, ctx, formatter):
+        self._show_default_command_params = True
+        try:
+            return super().format_help(ctx, formatter)
+        finally:
+            self._show_default_command_params = False
+
+    def invoke(self, ctx):
+        if ctx.info_name == "rl":
+            typer.echo(
+                "DeprecationWarning: The command 'rl' is deprecated. Use `prime train` instead.",
+                err=True,
+            )
+        return super().invoke(ctx)
+
 
 app = PlainTyper(
     cls=DefaultGroup,
-    help="Manage hosted RL training runs.",
+    help=(
+        "Launch and manage Hosted Training runs. Pass a config path directly to start a new run."
+    ),
     no_args_is_help=True,
 )
 
 
-@app.command("run", rich_help_panel="Commands", epilog=RL_RUN_JSON_HELP)
+@app.command("run", rich_help_panel="Commands", hidden=True, epilog=RL_RUN_JSON_HELP)
 def create_run(
     config_path: str = typer.Argument(
         ...,
-        help="Path to TOML config file (e.g., rl.toml)",
+        help="Path to a TOML config file to launch as a Hosted Training run.",
     ),
     env: Optional[List[str]] = typer.Option(
         None,
@@ -747,11 +779,11 @@ def create_run(
         help="Skip action status check and run even if environment action failed.",
     ),
 ) -> None:
-    """Start an RL training run from a config file.
+    """Launch a Hosted Training run from a config file.
 
     Example:
 
-        prime rl run rl.toml
+        prime train config.toml
     """
     validate_output_format(output, console)
 
@@ -791,7 +823,7 @@ def create_run(
         console.print("  - CLI flag: --env-file secrets.env")
         console.print("  - CLI flag: -e WANDB_API_KEY=your-key")
         console.print(
-            "  - Environment variable: export WANDB_API_KEY=... && prime rl ... -e WANDB_API_KEY"
+            "  - Environment variable: export WANDB_API_KEY=... && prime train ... -e WANDB_API_KEY"
         )
         raise typer.Exit(1)
 
@@ -938,7 +970,7 @@ def create_run(
 
                 console.print(
                     "[yellow]This usually means the environment doesn't compile or run, "
-                    "or is using an unsupported version of verifiers, so the training run "
+                    "or is using an unsupported version of verifiers, so the Hosted Training run "
                     "will fail.[/yellow]"
                 )
                 console.print("[dim]To proceed anyway, use --skip-action-check[/dim]")
@@ -946,7 +978,7 @@ def create_run(
 
             console.print()
 
-        console.print("[dim]Creating RL training run...[/dim]\n")
+        console.print("[dim]Creating Hosted Training run...[/dim]\n")
 
         # Create the run
         run = rl_client.create_run(
@@ -1009,7 +1041,7 @@ def create_run(
 
         if run.status != "QUEUED":
             console.print("\n[dim]View logs with:[/dim]")
-            console.print(f"  prime rl logs {run.id} -f")
+            console.print(f"  prime train logs {run.id} -f")
 
     except ValidationError as e:
         console.print("[red]Configuration Error:[/red]")
@@ -1033,7 +1065,7 @@ def create_run(
 def list_models(
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """List available models for RL training."""
+    """List available models for Hosted Training."""
     validate_output_format(output, console)
 
     try:
@@ -1048,11 +1080,11 @@ def list_models(
             return
 
         if not models:
-            console.print("[yellow]No models available for RL training.[/yellow]")
+            console.print("[yellow]No models available for Hosted Training.[/yellow]")
             console.print("[dim]This could mean no healthy RL clusters are running.[/dim]")
             return
 
-        table = Table(title="Prime RL — Models")
+        table = Table(title="Hosted Training - Models")
         table.add_column("Model", style="cyan")
         table.add_column("Status")
         table.add_column("Training $/M tok", style="green", justify="right")
@@ -1224,7 +1256,7 @@ def list_configs(
 
 
 def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> None:
-    """Implementation for listing RL training runs."""
+    """Implementation for listing Hosted Training runs."""
     validate_output_format(output, console)
 
     if num < 1 or page < 1:
@@ -1262,10 +1294,10 @@ def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> No
             if page > 1:
                 console.print("[yellow]No more results.[/yellow]")
             else:
-                console.print("[yellow]No RL training runs found.[/yellow]")
+                console.print("[yellow]No Hosted Training runs found.[/yellow]")
             return
 
-        table = Table(title="RL Training Runs")
+        table = Table(title="Hosted Training Runs")
         table.add_column("ID", style="cyan", no_wrap=True)
         table.add_column("Status", style="bold")
         table.add_column("Model", style="magenta")
@@ -1321,9 +1353,9 @@ def get_run(
 
     Example:
 
-        prime rl get <run_id>
+        prime train get <run_id>
 
-        prime rl get <run_id> -o json
+        prime train get <run_id> -o json
     """
     validate_output_format(output, console)
 
@@ -1435,7 +1467,7 @@ def restart_run(
 
     Example:
 
-        prime rl restart <run_id>
+        prime train restart <run_id>
     """
     try:
         if not force:
@@ -1712,13 +1744,13 @@ def init_config(
     ),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing file"),
 ) -> None:
-    """Generate a template config file for a training run.
+    """Generate a template config file for a Hosted Training run.
 
     Example:
 
-        prime rl init              # Creates rl.toml
+        prime train init           # Creates rl.toml
 
-        prime rl init my-config.toml
+        prime train init my-config.toml
     """
     path = Path(output_path)
 
@@ -1742,7 +1774,7 @@ def init_config(
     path.write_text(template)
 
     console.print(f"[green]✓[/green] Created {output_path}")
-    console.print(f"\n[dim]Run with:[/dim] prime rl run {output_path}")
+    console.print(f"\n[dim]Run with:[/dim] prime train {output_path}")
 
 
 @app.command("metrics", rich_help_panel="Monitoring", epilog=RL_METRICS_JSON_HELP)
@@ -1752,15 +1784,15 @@ def get_metrics(
     max_step: Optional[int] = typer.Option(None, "--max-step", help="Maximum step (inclusive)"),
     limit: Optional[int] = typer.Option(None, "--limit", "-n", help="Maximum number of records"),
 ) -> None:
-    """Get training metrics for a run.
+    """Get Hosted Training metrics for a run.
 
     Example:
 
-        prime rl metrics <run_id>
+        prime train metrics <run_id>
 
-        prime rl metrics <run_id> --min-step 10 --max-step 50
+        prime train metrics <run_id> --min-step 10 --max-step 50
 
-        prime rl metrics <run_id> | jq '.metrics[0]'
+        prime train metrics <run_id> | jq '.metrics[0]'
     """
     try:
         api_client = APIClient()
@@ -1791,9 +1823,9 @@ def get_rollouts(
 
     Example:
 
-        prime rl rollouts <run_id> --step 10
+        prime train rollouts <run_id> --step 10
 
-        prime rl rollouts <run_id> -s 50 --num 100 | jq '.samples[0]'
+        prime train rollouts <run_id> -s 50 --num 100 | jq '.samples[0]'
     """
     try:
         api_client = APIClient()
@@ -1821,9 +1853,9 @@ def get_progress(
 
     Example:
 
-        prime rl progress <run_id>
+        prime train progress <run_id>
 
-        prime rl progress <run_id> | jq '.latest_step'
+        prime train progress <run_id> | jq '.latest_step'
     """
     try:
         api_client = APIClient()
@@ -1852,9 +1884,9 @@ def get_distributions(
 
     Example:
 
-        prime rl distributions <run_id>
+        prime train distributions <run_id>
 
-        prime rl distributions <run_id> --type rewards --step 50
+        prime train distributions <run_id> --type rewards --step 50
     """
     try:
         api_client = APIClient()
@@ -1885,9 +1917,9 @@ def list_checkpoints(
 
     Example:
 
-        prime rl checkpoints <run_id>
+        prime train checkpoints <run_id>
 
-        prime rl checkpoints <run_id> --status READY
+        prime train checkpoints <run_id> --status READY
     """
     validate_output_format(output, console)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1212,7 +1212,7 @@ RL_CONFIGS_JSON_HELP = json_output_help(
 def list_configs(
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """List available configuration options for RL training."""
+    """List available configuration options for Hosted Training."""
     validate_output_format(output, console)
 
     schema = RLConfig.model_json_schema()
@@ -1235,7 +1235,7 @@ def list_configs(
         )
         return
 
-    table = Table(title="Prime RL — Config Options")
+    table = Table(title="Hosted Training - Config Options")
     table.add_column("Section", style="magenta")
     table.add_column("Config", style="cyan")
     table.add_column("Type", style="green")
@@ -1254,7 +1254,7 @@ def list_configs(
     console.print(table)
     console.print(
         "\n[dim]Use these in your TOML config file. "
-        "See 'prime rl init' to generate a template.[/dim]"
+        "See 'prime train init' to generate a template.[/dim]"
     )
 
 
@@ -1608,7 +1608,7 @@ def get_logs(
         help=(
             "Env-server name. Implies --component=env-server. "
             "Use 'name/N' to disambiguate when multiple env-servers share a name. "
-            "List with 'prime rl components <run_id>'."
+            "List with 'prime train components <run_id>'."
         ),
     ),
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
@@ -1622,14 +1622,14 @@ def get_logs(
     (e.g. ``ModuleNotFoundError``) and the orchestrator has stalled at
     "Starting orchestrator step 0".
 
-    List available pods first with ``prime rl components <run_id>``.
+    List available pods first with ``prime train components <run_id>``.
 
     Examples:
 
-        prime rl logs <run_id>
-        prime rl logs <run_id> -f
-        prime rl logs <run_id> --env reverse-text
-        prime rl logs <run_id> --env reverse-text/1 -f
+        prime train logs <run_id>
+        prime train logs <run_id> -f
+        prime train logs <run_id> --env reverse-text
+        prime train logs <run_id> --env reverse-text/1 -f
     """
     if component is None:
         component = "env-server" if env is not None else "orchestrator"
@@ -1646,7 +1646,7 @@ def get_logs(
     if component == "env-server" and env is None:
         raise typer.BadParameter(
             "--env is required when reading env-server logs. "
-            "Run 'prime rl components <run_id>' to list available env-servers.",
+            "Run 'prime train components <run_id>' to list available env-servers.",
             param_hint="--env",
         )
 
@@ -1695,13 +1695,13 @@ def list_components(
     """List pods (orchestrator + env-servers) for a run.
 
     Use the env name shown here with
-    ``prime rl logs <run_id> -c env-server --env <name>``. When multiple
+    ``prime train logs <run_id> -c env-server --env <name>``. When multiple
     env-servers share a name, the qualified form ``name/N`` is shown — pass
     that exact string to ``--env``.
 
     Example:
 
-        prime rl components <run_id>
+        prime train components <run_id>
     """
     try:
         api_client = APIClient()
@@ -1735,7 +1735,7 @@ def list_components(
     if env_servers:
         console.print(
             "\n[dim]View env-server logs with:[/dim] "
-            "[bold]prime rl logs <run_id> -c env-server --env <env>[/bold]"
+            "[bold]prime train logs <run_id> -c env-server --env <env>[/bold]"
         )
 
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -736,7 +736,7 @@ class DefaultGroup(DefaultCommandGroup):
     def invoke(self, ctx):
         if ctx.info_name == "rl":
             typer.echo(
-                "DeprecationWarning: The command 'rl' is deprecated. Use `prime train` instead.",
+                "[DEPRECATED] The 'rl' command is deprecated. Use 'prime train' instead.",
                 err=True,
             )
         return super().invoke(ctx)

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -20,7 +20,7 @@ from .commands.lab import app as lab_app
 from .commands.login import app as login_app
 from .commands.pods import app as pods_app
 from .commands.registry import app as registry_app
-from .commands.rl import app as rl_app
+from .commands.rl import app as train_app
 from .commands.sandbox import app as sandbox_app
 from .commands.secrets import app as secret_app
 from .commands.switch import app as switch_app
@@ -45,7 +45,14 @@ app.add_typer(env_app, name="env", rich_help_panel="Lab")
 app.command("fork", rich_help_panel="Lab", epilog=FORK_JSON_HELP)(fork_command)
 app.add_typer(evals_app, name="eval", rich_help_panel="Lab")
 app.add_typer(gepa_app, name="gepa", rich_help_panel="Lab")
-app.add_typer(rl_app, name="rl", rich_help_panel="Lab")
+app.add_typer(train_app, name="train", rich_help_panel="Lab")
+app.add_typer(
+    train_app,
+    name="rl",
+    help="Deprecated alias for `prime train`.",
+    hidden=True,
+    rich_help_panel="Lab",
+)
 app.add_typer(deployments_app, name="deployments", rich_help_panel="Lab")
 
 # Compute commands

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -64,7 +64,7 @@ def test_models_table_renders_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_models_json_includes_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("prime_cli.core.APIClient.get", _mock_get_factory([]))
 
-    result = CliRunner().invoke(app, ["rl", "models", "--output", "json"])
+    result = CliRunner().invoke(app, ["train", "models", "--output", "json"])
 
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -13,7 +13,7 @@ def test_train_help_promotes_config_run_path() -> None:
     result = runner.invoke(app, ["train", "--help"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
-    assert "Usage: prime train [OPTIONS] CONFIG_PATH [ARGS]... | COMMAND [ARGS]..." in result.output
+    assert "prime train [OPTIONS] CONFIG_PATH [ARGS]... | COMMAND [ARGS]..." in result.output
     assert "Launch and manage Hosted Training runs." in result.output
     assert "Path to a TOML config file to launch as a" in result.output
     assert "Hosted Training run." in result.output

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -17,7 +17,6 @@ def test_train_help_promotes_config_run_path() -> None:
     assert "Launch and manage Hosted Training runs." in result.output
     assert "Path to a TOML config file to launch as a" in result.output
     assert "Hosted Training run." in result.output
-    assert "--env-file" in result.output
     assert "logs" in result.output
 
 

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -36,7 +36,7 @@ def test_rl_alias_still_works_with_deprecation_warning(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert (
-        "DeprecationWarning: The command 'rl' is deprecated. Use `prime train` instead."
+        "[DEPRECATED] The 'rl' command is deprecated. Use 'prime train' instead."
     ) in result.output
     assert "Run with: prime train" in result.output
     assert output_path.exists()
@@ -47,9 +47,9 @@ def test_rl_alias_warning_uses_stderr_for_json_output() -> None:
 
     assert result.exit_code == 0, result.output
     assert (
-        "DeprecationWarning: The command 'rl' is deprecated. Use `prime train` instead."
+        "[DEPRECATED] The 'rl' command is deprecated. Use 'prime train' instead."
     ) in result.stderr
-    assert "DeprecationWarning" not in result.stdout
+    assert "[DEPRECATED]" not in result.stdout
     data = json.loads(result.stdout)
     assert "configs" in data
 

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {"PRIME_DISABLE_VERSION_CHECK": "1"}
+
+
+def test_train_help_promotes_config_run_path() -> None:
+    result = runner.invoke(app, ["train", "--help"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "Usage: prime train [OPTIONS] CONFIG_PATH [ARGS]... | COMMAND [ARGS]..." in result.output
+    assert "Launch and manage Hosted Training runs." in result.output
+    assert "Path to a TOML config file to launch as a" in result.output
+    assert "Hosted Training run." in result.output
+    assert "--env-file" in result.output
+    assert "logs" in result.output
+
+
+def test_rl_alias_is_hidden_from_root_help() -> None:
+    result = runner.invoke(app, ["--help"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "Launch and manage Hosted Training runs." in result.output
+    assert "Deprecated alias for `prime train`." not in result.output
+
+
+def test_rl_alias_still_works_with_deprecation_warning(tmp_path: Path) -> None:
+    output_path = tmp_path / "config.toml"
+
+    result = runner.invoke(app, ["rl", "init", str(output_path)], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "DeprecationWarning: The command 'rl' is deprecated. Use `prime train` instead."
+    ) in result.output
+    assert "Run with: prime train" in result.output
+    assert output_path.exists()
+
+
+def test_rl_alias_warning_uses_stderr_for_json_output() -> None:
+    result = runner.invoke(app, ["rl", "configs", "--output", "json"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "DeprecationWarning: The command 'rl' is deprecated. Use `prime train` instead."
+    ) in result.stderr
+    assert "DeprecationWarning" not in result.stdout
+    data = json.loads(result.stdout)
+    assert "configs" in data
+
+
+def test_train_init_defaults_to_rl_toml() -> None:
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["train", "init"], env=TEST_ENV)
+
+        assert result.exit_code == 0, result.output
+        assert "Created rl.toml" in result.output
+        assert "Run with: prime train rl.toml" in result.output
+        assert Path("rl.toml").exists()


### PR DESCRIPTION
## Summary

- Add `prime train` as the first-class Hosted Training CLI command while keeping `prime rl` as a hidden supported alias.
- Promote direct config execution (`prime train rl.toml`) in help output while keeping `run` available as a hidden compatibility command.
- Update Hosted Training copy, table titles, init guidance, and add CLI regression coverage.

## Validation

- `uv run pytest packages/prime/tests/test_train_cli.py packages/prime/tests/test_rl_config.py`
- `uv run ruff check packages/prime/src/prime_cli/main.py packages/prime/src/prime_cli/commands/rl.py packages/prime/tests/test_train_cli.py`
- `uv run ty check packages/prime/src/prime_cli/main.py packages/prime/src/prime_cli/commands/rl.py packages/prime/tests/test_train_cli.py`
- pre-commit hooks during commit: ruff, ruff format, ty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CLI UX/wording and command wiring changes with compatibility preserved via a hidden alias; minimal runtime risk aside from potential help/command routing edge cases.
> 
> **Overview**
> Promotes Hosted Training as a first-class `prime train` CLI command, while keeping `prime rl` as a hidden alias that emits a deprecation warning (to stderr to avoid breaking JSON output).
> 
> Updates `rl.py` command help/usage and copy to emphasize launching runs by passing a config path directly, hides the legacy `run` subcommand for compatibility, and renames user-facing table titles/messages from “RL” to “Hosted Training”. Adds regression tests covering `train` help output, `rl` alias behavior, and default `train init` output, and updates existing model-pricing JSON test to invoke `train`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1183aba69b76fafdb7aea990103f1d37e360da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->