### PR TITLE
Shorten price column headers in prime rl models

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1052,12 +1052,15 @@ def list_models(
             console.print("[dim]This could mean no healthy RL clusters are running.[/dim]")
             return
 
-        table = Table(title="Prime RL — Models")
+        table = Table(
+            title="Prime RL — Models",
+            caption="[dim]Prices per 1M tokens[/dim]",
+        )
         table.add_column("Model", style="cyan")
         table.add_column("Status")
-        table.add_column("Training $/M tok", style="green", justify="right")
-        table.add_column("Inference In $/M tok", style="green", justify="right")
-        table.add_column("Inference Out $/M tok", style="green", justify="right")
+        table.add_column("Input", style="green", justify="right")
+        table.add_column("Output", style="green", justify="right")
+        table.add_column("Train", style="green", justify="right")
 
         for model in models:
             if model.at_capacity:
@@ -1067,9 +1070,9 @@ def list_models(
             table.add_row(
                 model.name,
                 status,
-                format_price_per_mtok(model.training_price_per_mtok) or "-",
                 format_price_per_mtok(model.inference_input_price_per_mtok) or "-",
                 format_price_per_mtok(model.inference_output_price_per_mtok) or "-",
+                format_price_per_mtok(model.training_price_per_mtok) or "-",
             )
 
         console.print(table)


### PR DESCRIPTION
- Renames `Training $/M tok`, `Inference In $/M tok`, `Inference Out $/M tok` to `Train`, `Input`, `Output`
- Adds `Prices per 1M tokens` caption so context isn't lost
- Reorders columns to Input / Output / Train

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CLI presentation change (column labels/order and caption) with no impact to API calls or data handling.
> 
> **Overview**
> Updates `prime rl models` table output to **shorten price column headers** and **reorder** them to `Input`/`Output`/`Train`.
> 
> Adds a table caption (`Prices per 1M tokens`) so the unit context remains visible despite the shorter headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb23b73c351cc334bb4e18d3244405d396f106be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->