### PR TITLE
feature: render RFT promo discount in prime train models

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -20,6 +20,16 @@ class RLModel(BaseModel):
     inference_output_price_per_mtok: Optional[float] = Field(
         None, alias="inferenceOutputPricePerMtok"
     )
+    effective_training_price_per_mtok: Optional[float] = Field(
+        None, alias="effectiveTrainingPricePerMtok"
+    )
+    effective_inference_input_price_per_mtok: Optional[float] = Field(
+        None, alias="effectiveInferenceInputPricePerMtok"
+    )
+    effective_inference_output_price_per_mtok: Optional[float] = Field(
+        None, alias="effectiveInferenceOutputPricePerMtok"
+    )
+    promo_label: Optional[str] = Field(None, alias="promoLabel")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -29,7 +29,11 @@ from ..utils import (
 )
 from ..utils.env_metadata import find_environment_metadata
 from ..utils.env_vars import EnvParseError, collect_env_vars
-from ..utils.formatters import format_file_size, format_price_per_mtok, strip_ansi
+from ..utils.formatters import (
+    format_file_size,
+    format_promo_price,
+    strip_ansi,
+)
 
 console = get_console()
 
@@ -40,7 +44,10 @@ RL_RUN_JSON_HELP = json_output_help(
 
 RL_MODELS_JSON_HELP = json_output_help(
     ".models[] = {name, at_capacity, training_price_per_mtok, "
-    "inference_input_price_per_mtok, inference_output_price_per_mtok}",
+    "inference_input_price_per_mtok, inference_output_price_per_mtok, "
+    "effective_training_price_per_mtok?, "
+    "effective_inference_input_price_per_mtok?, "
+    "effective_inference_output_price_per_mtok?, promo_label?}",
 )
 
 RL_LIST_JSON_HELP = json_output_help(
@@ -1095,6 +1102,7 @@ def list_models(
         table.add_column("Output", style="green", justify="right")
         table.add_column("Train", style="green", justify="right")
 
+        promo_labels: List[str] = []
         for model in models:
             if model.at_capacity:
                 status = "[red]At Capacity[/red]"
@@ -1103,12 +1111,28 @@ def list_models(
             table.add_row(
                 model.name,
                 status,
-                format_price_per_mtok(model.inference_input_price_per_mtok) or "-",
-                format_price_per_mtok(model.inference_output_price_per_mtok) or "-",
-                format_price_per_mtok(model.training_price_per_mtok) or "-",
+                format_promo_price(
+                    model.inference_input_price_per_mtok,
+                    model.effective_inference_input_price_per_mtok,
+                )
+                or "-",
+                format_promo_price(
+                    model.inference_output_price_per_mtok,
+                    model.effective_inference_output_price_per_mtok,
+                )
+                or "-",
+                format_promo_price(
+                    model.training_price_per_mtok,
+                    model.effective_training_price_per_mtok,
+                )
+                or "-",
             )
+            if model.promo_label and model.promo_label not in promo_labels:
+                promo_labels.append(model.promo_label)
 
         console.print(table)
+        for label in promo_labels:
+            console.print(f"[bold yellow]{rich_escape(label)}[/bold yellow]")
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1092,19 +1092,9 @@ def list_models(
             console.print("[dim]This could mean no healthy RL clusters are running.[/dim]")
             return
 
-        promo_labels: List[str] = []
-        for model in models:
-            if model.promo_label and model.promo_label not in promo_labels:
-                promo_labels.append(model.promo_label)
-
-        caption = "[dim]Prices per 1M tokens[/dim]"
-        if promo_labels:
-            joined = ", ".join(rich_escape(label) for label in promo_labels)
-            caption += f" [dim]• Active discount: {joined}[/dim]"
-
         table = Table(
             title="Hosted Training - Models",
-            caption=caption,
+            caption="[dim]Prices per 1M tokens[/dim]",
         )
         table.add_column("Model", style="cyan")
         table.add_column("Status")
@@ -1112,6 +1102,7 @@ def list_models(
         table.add_column("Output", style="green", justify="right")
         table.add_column("Train", style="green", justify="right")
 
+        promo_labels: List[str] = []
         for model in models:
             if model.at_capacity:
                 status = "[red]At Capacity[/red]"
@@ -1136,8 +1127,13 @@ def list_models(
                 )
                 or "-",
             )
+            if model.promo_label and model.promo_label not in promo_labels:
+                promo_labels.append(model.promo_label)
 
         console.print(table)
+        if promo_labels:
+            joined = ", ".join(rich_escape(label) for label in promo_labels)
+            console.print(f"[bold yellow]{joined}[/bold yellow]")
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1092,9 +1092,19 @@ def list_models(
             console.print("[dim]This could mean no healthy RL clusters are running.[/dim]")
             return
 
+        promo_labels: List[str] = []
+        for model in models:
+            if model.promo_label and model.promo_label not in promo_labels:
+                promo_labels.append(model.promo_label)
+
+        caption = "[dim]Prices per 1M tokens[/dim]"
+        if promo_labels:
+            joined = ", ".join(rich_escape(label) for label in promo_labels)
+            caption += f" [dim]• Active discount: {joined}[/dim]"
+
         table = Table(
             title="Hosted Training - Models",
-            caption="[dim]Prices per 1M tokens[/dim]",
+            caption=caption,
         )
         table.add_column("Model", style="cyan")
         table.add_column("Status")
@@ -1102,7 +1112,6 @@ def list_models(
         table.add_column("Output", style="green", justify="right")
         table.add_column("Train", style="green", justify="right")
 
-        promo_labels: List[str] = []
         for model in models:
             if model.at_capacity:
                 status = "[red]At Capacity[/red]"
@@ -1127,12 +1136,8 @@ def list_models(
                 )
                 or "-",
             )
-            if model.promo_label and model.promo_label not in promo_labels:
-                promo_labels.append(model.promo_label)
 
         console.print(table)
-        for label in promo_labels:
-            console.print(f"[bold yellow]{rich_escape(label)}[/bold yellow]")
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -56,6 +56,30 @@ def format_price_per_mtok(value: Any) -> str:
         return str(value)
 
 
+def format_promo_price(original: Any, effective: Any) -> str:
+    """Format a price cell with optional promo strikethrough.
+
+    Returns rich-markup text that the table renderer auto-parses. When
+    no discount applies, falls back to ``format_price_per_mtok``.
+    """
+    if effective is None:
+        return format_price_per_mtok(original)
+
+    try:
+        original_f = float(original) if original is not None else None
+        effective_f = float(effective)
+    except (TypeError, ValueError):
+        return format_price_per_mtok(original)
+
+    if original_f is None or original_f <= 0 or effective_f >= original_f:
+        return format_price_per_mtok(original)
+
+    struck = format_price_per_mtok(original_f)
+    if effective_f == 0:
+        return f"[strike dim]{struck}[/strike dim] [bold green]FREE[/bold green]"
+    return f"[strike dim]{struck}[/strike dim] {format_price_per_mtok(effective_f)}"
+
+
 def format_resources(cpu_cores: float, memory_gb: float, gpu_count: int = 0) -> str:
     """Format resource specifications as compact string."""
     resources = f"{cpu_cores:g}CPU/{memory_gb:g}GB"

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -79,7 +79,7 @@ def format_promo_price(original: Any, effective: Any) -> str:
         new_str = "[bold green]FREE[/bold green]"
     else:
         new_str = f"[bold green]{format_price_per_mtok(effective_f)}[/bold green]"
-    return f"[dim]{original_str}[/dim] → {new_str}"
+    return f"[strike dim]{original_str}[/strike dim] → {new_str}"
 
 
 def format_resources(cpu_cores: float, memory_gb: float, gpu_count: int = 0) -> str:

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -57,7 +57,7 @@ def format_price_per_mtok(value: Any) -> str:
 
 
 def format_promo_price(original: Any, effective: Any) -> str:
-    """Format a price cell with optional promo strikethrough.
+    """Format a price cell, showing ``original → effective`` when discounted.
 
     Returns rich-markup text that the table renderer auto-parses. When
     no discount applies, falls back to ``format_price_per_mtok``.
@@ -74,10 +74,12 @@ def format_promo_price(original: Any, effective: Any) -> str:
     if original_f is None or original_f <= 0 or effective_f >= original_f:
         return format_price_per_mtok(original)
 
-    struck = format_price_per_mtok(original_f)
+    original_str = format_price_per_mtok(original_f)
     if effective_f == 0:
-        return f"[strike dim]{struck}[/strike dim] [bold green]FREE[/bold green]"
-    return f"[strike dim]{struck}[/strike dim] {format_price_per_mtok(effective_f)}"
+        new_str = "[bold green]FREE[/bold green]"
+    else:
+        new_str = f"[bold green]{format_price_per_mtok(effective_f)}[/bold green]"
+    return f"[dim]{original_str}[/dim] → {new_str}"
 
 
 def format_resources(cpu_cores: float, memory_gb: float, gpu_count: int = 0) -> str:

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -109,7 +109,7 @@ def _promo_payload() -> Dict[str, Any]:
     }
 
 
-def test_models_table_shows_strikethrough_when_promo_active(
+def test_models_table_renders_promo_arrow_and_caption(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
@@ -121,13 +121,14 @@ def test_models_table_shows_strikethrough_when_promo_active(
 
     assert result.exit_code == 0, result.output
     plain = strip_ansi(result.output)
-    # FREE chip is rendered for 100% off categories.
+    # Discounted cells render as "original → effective".
+    assert "→" in plain
     assert "FREE" in plain
-    # Original prices remain visible (struck through in styled output).
     assert "$0.5" in plain
     assert "$1" in plain
     assert "$3" in plain
-    assert "Free RFT week" in plain
+    # Promo label is folded into the caption, not a free-floating line.
+    assert "Active discount: Free RFT week" in plain
 
 
 def test_models_table_no_promo_when_effective_equals_original(

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -127,8 +127,8 @@ def test_models_table_renders_promo_arrow_and_caption(
     assert "$0.5" in plain
     assert "$1" in plain
     assert "$3" in plain
-    # Promo label is folded into the caption, not a free-floating line.
-    assert "Active discount: Free RFT week" in plain
+    # Promo label rendered once below the table.
+    assert plain.count("Free RFT week") == 1
 
 
 def test_models_table_no_promo_when_effective_equals_original(
@@ -192,6 +192,48 @@ def test_models_zero_original_with_promo_does_not_render_free(
     assert result.exit_code == 0, result.output
     plain = strip_ansi(result.output)
     assert "FREE" not in plain
+
+
+def test_models_promo_label_deduplicated_across_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "models": [
+            {
+                "name": "model-a",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.5,
+                "inferenceInputPricePerMtok": 1.0,
+                "inferenceOutputPricePerMtok": 3.0,
+                "effectiveTrainingPricePerMtok": 0.0,
+                "effectiveInferenceInputPricePerMtok": 0.0,
+                "effectiveInferenceOutputPricePerMtok": 0.0,
+                "promoLabel": "shared promo",
+            },
+            {
+                "name": "model-b",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.2,
+                "inferenceInputPricePerMtok": 0.4,
+                "inferenceOutputPricePerMtok": 0.6,
+                "effectiveTrainingPricePerMtok": 0.0,
+                "effectiveInferenceInputPricePerMtok": 0.0,
+                "effectiveInferenceOutputPricePerMtok": 0.0,
+                "promoLabel": "shared promo",
+            },
+        ]
+    }
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert plain.count("shared promo") == 1
 
 
 def test_models_json_includes_effective_fields(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 import pytest
 from prime_cli.main import app
+from prime_cli.utils.formatters import strip_ansi
 from typer.testing import CliRunner
 
 
@@ -88,3 +89,121 @@ def test_models_handles_backend_without_pricing_fields(
 
     assert result.exit_code == 0, result.output
     assert "qwen/qwen3-8b" in result.output
+
+
+def _promo_payload() -> Dict[str, Any]:
+    return {
+        "models": [
+            {
+                "name": "qwen/qwen3-8b",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.5,
+                "inferenceInputPricePerMtok": 1.0,
+                "inferenceOutputPricePerMtok": 3.0,
+                "effectiveTrainingPricePerMtok": 0.0,
+                "effectiveInferenceInputPricePerMtok": 0.0,
+                "effectiveInferenceOutputPricePerMtok": 0.0,
+                "promoLabel": "Free RFT week",
+            },
+        ]
+    }
+
+
+def test_models_table_shows_strikethrough_when_promo_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return _promo_payload()
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    # FREE chip is rendered for 100% off categories.
+    assert "FREE" in plain
+    # Original prices remain visible (struck through in styled output).
+    assert "$0.5" in plain
+    assert "$1" in plain
+    assert "$3" in plain
+    assert "Free RFT week" in plain
+
+
+def test_models_table_no_promo_when_effective_equals_original(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "models": [
+            {
+                "name": "qwen/qwen3-8b",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.5,
+                "inferenceInputPricePerMtok": 1.0,
+                "inferenceOutputPricePerMtok": 3.0,
+                "effectiveTrainingPricePerMtok": 0.5,
+                "effectiveInferenceInputPricePerMtok": 1.0,
+                "effectiveInferenceOutputPricePerMtok": 3.0,
+                "promoLabel": None,
+            }
+        ]
+    }
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "FREE" not in plain
+    assert "$0.5" in plain
+
+
+def test_models_zero_original_with_promo_does_not_render_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "models": [
+            {
+                "name": "qwen/qwen3-8b",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.0,
+                "inferenceInputPricePerMtok": 0.0,
+                "inferenceOutputPricePerMtok": 0.0,
+                "effectiveTrainingPricePerMtok": 0.0,
+                "effectiveInferenceInputPricePerMtok": 0.0,
+                "effectiveInferenceOutputPricePerMtok": 0.0,
+                "promoLabel": None,
+            }
+        ]
+    }
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "FREE" not in plain
+
+
+def test_models_json_includes_effective_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return _promo_payload()
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["train", "models", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["models"][0]["effective_training_price_per_mtok"] == 0.0
+    assert data["models"][0]["effective_inference_input_price_per_mtok"] == 0.0
+    assert data["models"][0]["effective_inference_output_price_per_mtok"] == 0.0
+    assert data["models"][0]["promo_label"] == "Free RFT week"


### PR DESCRIPTION
## Summary
- `prime train models` now shows discounted prices alongside originals (struck through), with a `FREE` chip on 100% off categories
- Reads new `effective_*_price_per_mtok` and `promo_label` fields from `/rft/models`
- Falls back to today's rendering when the backend doesn't return promo fields

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/formatting-only CLI changes with added test coverage and safe fallback when promo fields are absent; minimal impact beyond model listing output.
> 
> **Overview**
> Updates the hosted training models API schema to accept `effective_*_price_per_mtok` and `promo_label` from `/rft/models`, and reflects these fields in CLI JSON output/help.
> 
> Improves `prime train/rl models` table rendering to show discounted pricing as *original → effective* (with strikethrough + `FREE` for 100% off) and prints any promo labels once below the table. Adds `format_promo_price` plus targeted tests covering promo rendering, edge cases, label de-duplication, and JSON field presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dda0a293af75eec038061d727c09f119916f648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->