### PR TITLE
Release prime CLI 0.5.78

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.77"
+__version__ = "0.5.78"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -20,6 +20,13 @@ class RLModel(BaseModel):
     inference_output_price_per_mtok: Optional[float] = Field(
         None, alias="inferenceOutputPricePerMtok"
     )
+    list_training_price_per_mtok: Optional[float] = Field(None, alias="listTrainingPricePerMtok")
+    list_inference_input_price_per_mtok: Optional[float] = Field(
+        None, alias="listInferenceInputPricePerMtok"
+    )
+    list_inference_output_price_per_mtok: Optional[float] = Field(
+        None, alias="listInferenceOutputPricePerMtok"
+    )
     effective_training_price_per_mtok: Optional[float] = Field(
         None, alias="effectiveTrainingPricePerMtok"
     )

--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -40,6 +40,24 @@ class RLModel(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    def resolve_prices(self, category: str) -> tuple[Optional[float], Optional[float]]:
+        """Return ``(list_price, effective_price)`` for ``category``.
+
+        Categories: ``training``, ``inference_input``, ``inference_output``.
+
+        Post-swap backends populate ``list_*`` with the un-discounted price and
+        the legacy ``*_price_per_mtok`` with the effective (charged) price.
+        Pre-swap backends omit ``list_*`` and keep ``legacy = list``,
+        ``effective = charged``.
+        """
+        list_attr = f"list_{category}_price_per_mtok"
+        legacy_attr = f"{category}_price_per_mtok"
+        effective_attr = f"effective_{category}_price_per_mtok"
+        list_value = getattr(self, list_attr)
+        if list_value is not None:
+            return list_value, getattr(self, legacy_attr)
+        return getattr(self, legacy_attr), getattr(self, effective_attr)
+
 
 class RLRun(BaseModel):
     """RL Training Run."""

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1094,7 +1094,6 @@ def list_models(
 
         table = Table(
             title="Hosted Training - Models",
-            caption="[dim]Prices per 1M tokens[/dim]",
         )
         table.add_column("Model", style="cyan")
         table.add_column("Status")
@@ -1139,10 +1138,12 @@ def list_models(
             if model.promo_label and model.promo_label not in promo_labels:
                 promo_labels.append(model.promo_label)
 
-        console.print(table)
+        caption_lines = ["[dim]Prices per 1M tokens[/dim]"]
         if promo_labels:
             joined = ", ".join(rich_escape(label) for label in promo_labels)
-            console.print(f"[bold yellow]{joined}[/bold yellow]", justify="center")
+            caption_lines.append(f"[bold yellow]{joined}[/bold yellow]")
+        table.caption = "\n".join(caption_lines)
+        console.print(table)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -842,6 +842,14 @@ def create_run(
         rl_client = RLClient(api_client)
         app_config = Config()
 
+        # Kick off pricing fetch in the background so it overlaps with summary
+        # rendering and the action-status checks below.
+        from concurrent.futures import ThreadPoolExecutor
+
+        _pricing_executor = ThreadPoolExecutor(max_workers=1)
+        pricing_future = _pricing_executor.submit(rl_client.list_models, team_id=app_config.team_id)
+        _pricing_executor.shutdown(wait=False)
+
         # Show configuration in organized sections
         console.print("[white]Configuration:[/white]\n")
 
@@ -941,8 +949,8 @@ def create_run(
         # Pricing (best-effort — skipped silently if /rft/models is unreachable
         # or doesn't include the chosen model)
         try:
-            available = rl_client.list_models(team_id=app_config.team_id)
-        except APIError:
+            available = pricing_future.result()
+        except Exception:
             available = []
         priced = next((m for m in available if m.name == cfg.model), None)
         if priced is not None:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -955,24 +955,9 @@ def create_run(
             available = []
         priced = next((m for m in available if m.name == cfg.model), None)
         if priced is not None:
-            if priced.list_training_price_per_mtok is not None:
-                list_train = priced.list_training_price_per_mtok
-                eff_train = priced.training_price_per_mtok
-            else:
-                list_train = priced.training_price_per_mtok
-                eff_train = priced.effective_training_price_per_mtok
-            if priced.list_inference_input_price_per_mtok is not None:
-                list_input = priced.list_inference_input_price_per_mtok
-                eff_input = priced.inference_input_price_per_mtok
-            else:
-                list_input = priced.inference_input_price_per_mtok
-                eff_input = priced.effective_inference_input_price_per_mtok
-            if priced.list_inference_output_price_per_mtok is not None:
-                list_output = priced.list_inference_output_price_per_mtok
-                eff_output = priced.inference_output_price_per_mtok
-            else:
-                list_output = priced.inference_output_price_per_mtok
-                eff_output = priced.effective_inference_output_price_per_mtok
+            list_train, eff_train = priced.resolve_prices("training")
+            list_input, eff_input = priced.resolve_prices("inference_input")
+            list_output, eff_output = priced.resolve_prices("inference_output")
             console.print(
                 "\n[cyan]Pricing[/cyan] [dim](per 1M tokens, charged on actual usage)[/dim]"
             )
@@ -1168,27 +1153,9 @@ def list_models(
                 status = "[red]At Capacity[/red]"
             else:
                 status = "[green]Available[/green]"
-            # Post-swap backends populate list_* with the un-discounted price
-            # and the legacy *_price_per_mtok with the effective (charged) price.
-            # Pre-swap backends omit list_* and keep legacy=list, effective=charged.
-            if model.list_training_price_per_mtok is not None:
-                list_train = model.list_training_price_per_mtok
-                eff_train = model.training_price_per_mtok
-            else:
-                list_train = model.training_price_per_mtok
-                eff_train = model.effective_training_price_per_mtok
-            if model.list_inference_input_price_per_mtok is not None:
-                list_input = model.list_inference_input_price_per_mtok
-                eff_input = model.inference_input_price_per_mtok
-            else:
-                list_input = model.inference_input_price_per_mtok
-                eff_input = model.effective_inference_input_price_per_mtok
-            if model.list_inference_output_price_per_mtok is not None:
-                list_output = model.list_inference_output_price_per_mtok
-                eff_output = model.inference_output_price_per_mtok
-            else:
-                list_output = model.inference_output_price_per_mtok
-                eff_output = model.effective_inference_output_price_per_mtok
+            list_train, eff_train = model.resolve_prices("training")
+            list_input, eff_input = model.resolve_prices("inference_input")
+            list_output, eff_output = model.resolve_prices("inference_output")
             table.add_row(
                 model.name,
                 status,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -843,12 +843,23 @@ def create_run(
         app_config = Config()
 
         # Kick off pricing fetch in the background so it overlaps with summary
-        # rendering and the action-status checks below.
-        from concurrent.futures import ThreadPoolExecutor
+        # rendering and the action-status checks below. Daemon thread so a slow
+        # /rft/models can't outlive the command (ThreadPoolExecutor workers are
+        # joined at interpreter exit, which would defeat the timeout cap below).
+        import threading
 
-        _pricing_executor = ThreadPoolExecutor(max_workers=1)
-        pricing_future = _pricing_executor.submit(rl_client.list_models, team_id=app_config.team_id)
-        _pricing_executor.shutdown(wait=False)
+        pricing_state: Dict[str, Any] = {"models": None, "error": None}
+        pricing_done = threading.Event()
+
+        def _fetch_pricing() -> None:
+            try:
+                pricing_state["models"] = rl_client.list_models(team_id=app_config.team_id)
+            except Exception as exc:
+                pricing_state["error"] = exc
+            finally:
+                pricing_done.set()
+
+        threading.Thread(target=_fetch_pricing, daemon=True).start()
 
         # Show configuration in organized sections
         console.print("[white]Configuration:[/white]\n")
@@ -949,9 +960,9 @@ def create_run(
         # Pricing (best-effort — skipped silently if /rft/models is unreachable,
         # times out, or doesn't include the chosen model. 8s cap so a slow
         # endpoint can't gate the confirmation prompt.)
-        try:
-            available = pricing_future.result(timeout=8)
-        except Exception:
+        if pricing_done.wait(timeout=8) and pricing_state["error"] is None:
+            available = pricing_state["models"] or []
+        else:
             available = []
         priced = next((m for m in available if m.name == cfg.model), None)
         if priced is not None:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -946,10 +946,11 @@ def create_run(
             console.print("\n[cyan]Secrets[/cyan]")
             console.print(f"  Keys: {', '.join(secrets.keys())}")
 
-        # Pricing (best-effort — skipped silently if /rft/models is unreachable
-        # or doesn't include the chosen model)
+        # Pricing (best-effort — skipped silently if /rft/models is unreachable,
+        # times out, or doesn't include the chosen model. 8s cap so a slow
+        # endpoint can't gate the confirmation prompt.)
         try:
-            available = pricing_future.result()
+            available = pricing_future.result(timeout=8)
         except Exception:
             available = []
         priced = next((m for m in available if m.name == cfg.model), None)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1133,7 +1133,7 @@ def list_models(
         console.print(table)
         if promo_labels:
             joined = ", ".join(rich_escape(label) for label in promo_labels)
-            console.print(f"[bold yellow]{joined}[/bold yellow]")
+            console.print(f"[bold yellow]{joined}[/bold yellow]", justify="center")
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -967,12 +967,20 @@ def create_run(
             console.print(
                 "\n[cyan]Pricing[/cyan] [dim](per 1M tokens, charged on actual usage)[/dim]"
             )
-            train_str = format_promo_price(list_train, eff_train) or "-"
-            input_str = format_promo_price(list_input, eff_input) or "-"
-            output_str = format_promo_price(list_output, eff_output) or "-"
-            console.print(f"  Training:         {train_str}")
-            console.print(f"  Inference Input:  {input_str}")
-            console.print(f"  Inference Output: {output_str}")
+
+            def _format(list_p: Any, eff_p: Any) -> str:
+                charged = eff_p if eff_p is not None else list_p
+                if charged is None:
+                    return "-"
+                if float(charged) == 0:
+                    if list_p is not None and float(list_p) > float(charged):
+                        return format_promo_price(list_p, eff_p) or "[bold green]Free[/bold green]"
+                    return "[bold green]Free[/bold green]"
+                return format_promo_price(list_p, eff_p) or "-"
+
+            console.print(f"  Training:         {_format(list_train, eff_train)}")
+            console.print(f"  Inference Input:  {_format(list_input, eff_input)}")
+            console.print(f"  Inference Output: {_format(list_output, eff_output)}")
             if priced.promo_label:
                 console.print(f"  [bold yellow]{rich_escape(priced.promo_label)}[/bold yellow]")
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -938,6 +938,44 @@ def create_run(
             console.print("\n[cyan]Secrets[/cyan]")
             console.print(f"  Keys: {', '.join(secrets.keys())}")
 
+        # Pricing (best-effort — skipped silently if /rft/models is unreachable
+        # or doesn't include the chosen model)
+        try:
+            available = rl_client.list_models(team_id=app_config.team_id)
+        except APIError:
+            available = []
+        priced = next((m for m in available if m.name == cfg.model), None)
+        if priced is not None:
+            if priced.list_training_price_per_mtok is not None:
+                list_train = priced.list_training_price_per_mtok
+                eff_train = priced.training_price_per_mtok
+            else:
+                list_train = priced.training_price_per_mtok
+                eff_train = priced.effective_training_price_per_mtok
+            if priced.list_inference_input_price_per_mtok is not None:
+                list_input = priced.list_inference_input_price_per_mtok
+                eff_input = priced.inference_input_price_per_mtok
+            else:
+                list_input = priced.inference_input_price_per_mtok
+                eff_input = priced.effective_inference_input_price_per_mtok
+            if priced.list_inference_output_price_per_mtok is not None:
+                list_output = priced.list_inference_output_price_per_mtok
+                eff_output = priced.inference_output_price_per_mtok
+            else:
+                list_output = priced.inference_output_price_per_mtok
+                eff_output = priced.effective_inference_output_price_per_mtok
+            console.print(
+                "\n[cyan]Pricing[/cyan] [dim](per 1M tokens, charged on actual usage)[/dim]"
+            )
+            train_str = format_promo_price(list_train, eff_train) or "-"
+            input_str = format_promo_price(list_input, eff_input) or "-"
+            output_str = format_promo_price(list_output, eff_output) or "-"
+            console.print(f"  Training:         {train_str}")
+            console.print(f"  Inference Input:  {input_str}")
+            console.print(f"  Inference Output: {output_str}")
+            if priced.promo_label:
+                console.print(f"  [bold yellow]{rich_escape(priced.promo_label)}[/bold yellow]")
+
         console.print()
 
         # Check action status for hub environments

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1108,24 +1108,33 @@ def list_models(
                 status = "[red]At Capacity[/red]"
             else:
                 status = "[green]Available[/green]"
+            # Post-swap backends populate list_* with the un-discounted price
+            # and the legacy *_price_per_mtok with the effective (charged) price.
+            # Pre-swap backends omit list_* and keep legacy=list, effective=charged.
+            if model.list_training_price_per_mtok is not None:
+                list_train = model.list_training_price_per_mtok
+                eff_train = model.training_price_per_mtok
+            else:
+                list_train = model.training_price_per_mtok
+                eff_train = model.effective_training_price_per_mtok
+            if model.list_inference_input_price_per_mtok is not None:
+                list_input = model.list_inference_input_price_per_mtok
+                eff_input = model.inference_input_price_per_mtok
+            else:
+                list_input = model.inference_input_price_per_mtok
+                eff_input = model.effective_inference_input_price_per_mtok
+            if model.list_inference_output_price_per_mtok is not None:
+                list_output = model.list_inference_output_price_per_mtok
+                eff_output = model.inference_output_price_per_mtok
+            else:
+                list_output = model.inference_output_price_per_mtok
+                eff_output = model.effective_inference_output_price_per_mtok
             table.add_row(
                 model.name,
                 status,
-                format_promo_price(
-                    model.inference_input_price_per_mtok,
-                    model.effective_inference_input_price_per_mtok,
-                )
-                or "-",
-                format_promo_price(
-                    model.inference_output_price_per_mtok,
-                    model.effective_inference_output_price_per_mtok,
-                )
-                or "-",
-                format_promo_price(
-                    model.training_price_per_mtok,
-                    model.effective_training_price_per_mtok,
-                )
-                or "-",
+                format_promo_price(list_input, eff_input) or "-",
+                format_promo_price(list_output, eff_output) or "-",
+                format_promo_price(list_train, eff_train) or "-",
             )
             if model.promo_label and model.promo_label not in promo_labels:
                 promo_labels.append(model.promo_label)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -34,6 +34,7 @@ from ..utils.formatters import (
     format_promo_price,
     strip_ansi,
 )
+from ..utils.prompt import confirm_or_skip
 
 console = get_console()
 
@@ -786,6 +787,7 @@ def create_run(
         "--skip-action-check",
         help="Skip action status check and run even if environment action failed.",
     ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Launch a Hosted Training run from a config file.
 
@@ -985,6 +987,10 @@ def create_run(
                 raise typer.Exit(1)
 
             console.print()
+
+        if not confirm_or_skip("Launch this Hosted Training run?", yes, default=True):
+            console.print("\nRun cancelled")
+            return
 
         console.print("[dim]Creating Hosted Training run...[/dim]\n")
 

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -236,6 +236,46 @@ def test_models_promo_label_deduplicated_across_models(
     assert plain.count("shared promo") == 1
 
 
+def test_models_table_renders_promo_with_list_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-swap backend: legacy fields hold effective price, list_* hold list price."""
+    payload = {
+        "models": [
+            {
+                "name": "qwen/qwen3-8b",
+                "atCapacity": False,
+                "trainingPricePerMtok": 0.0,
+                "inferenceInputPricePerMtok": 0.0,
+                "inferenceOutputPricePerMtok": 0.0,
+                "listTrainingPricePerMtok": 0.5,
+                "listInferenceInputPricePerMtok": 1.0,
+                "listInferenceOutputPricePerMtok": 3.0,
+                "effectiveTrainingPricePerMtok": 0.0,
+                "effectiveInferenceInputPricePerMtok": 0.0,
+                "effectiveInferenceOutputPricePerMtok": 0.0,
+                "promoLabel": "Free RFT week",
+            },
+        ]
+    }
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        return payload
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["rl", "models"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "→" in plain
+    assert "FREE" in plain
+    assert "$0.5" in plain
+    assert "$1" in plain
+    assert "$3" in plain
+    assert plain.count("Free RFT week") == 1
+
+
 def test_models_json_includes_effective_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
         return _promo_payload()


### PR DESCRIPTION
Bumps prime CLI to 0.5.78. Includes RFT promo discount rendering (#584).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes CLI run launch flow (new confirmation gate and background pricing fetch thread) and pricing display logic, which could affect user UX and command latency but not core auth/data handling.
> 
> **Overview**
> Bumps the Prime CLI version to `0.5.78` and updates Hosted Training model pricing to support promo discounts across *pre/post backend pricing field swaps*.
> 
> `RLModel` now accepts `list*PricePerMtok` fields and centralizes selection of **list vs charged** prices via `resolve_prices()`, which is then used by `train/rl models` table rendering and by `prime train` run preview to show a best-effort pricing section (with promo labels) before launch.
> 
> The `prime train` run command adds a confirmation prompt (skippable via `--yes/-y`) and fetches model pricing asynchronously with an 8s cap so slow `/rft/models` calls don’t block launching; tests were extended to cover the new `list_*` promo rendering path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2df3c47ce6d26cbdce6da06e7a703e1e15a01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->