### PR TITLE
feature: prime usage command for live token + price tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ venv/
 ENV/
 test_env/
 .DS_Store
+.claude/worktrees/

--- a/packages/prime/src/prime_cli/api/billing.py
+++ b/packages/prime/src/prime_cli/api/billing.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from prime_cli.core import APIClient, APIError
 
@@ -54,7 +54,14 @@ class BillingClient:
             raise
         except Exception as exc:  # noqa: BLE001
             raise APIError(_format_error("Failed to get run usage", exc)) from exc
-        return RunUsage.model_validate(response)
+
+        try:
+            return RunUsage.model_validate(response)
+        except ValidationError as exc:
+            # Wrap shape drift as APIError so the caller's existing
+            # except-APIError branch surfaces it as a clean CLI error
+            # instead of an unhandled traceback.
+            raise APIError(f"Unexpected /billing/runs/{run_id}/usage response: {exc}") from exc
 
 
 def _format_error(prefix: str, exc: Exception) -> str:

--- a/packages/prime/src/prime_cli/api/billing.py
+++ b/packages/prime/src/prime_cli/api/billing.py
@@ -65,9 +65,14 @@ class BillingClient:
         """Fetch token + cost totals for a single RFT run."""
         try:
             response = self.client.get(f"/billing/runs/{run_id}/usage")
-            return RunUsage.model_validate(response)
+        except APIError:
+            # Let typed APIError subclasses (UnauthorizedError, etc.) propagate
+            # — wrapping them strips the type and the caller's ability to
+            # branch on auth/payment failures.
+            raise
         except Exception as exc:  # noqa: BLE001
             raise APIError(_format_error("Failed to get run usage", exc)) from exc
+        return RunUsage.model_validate(response)
 
     def get_usage_summary(
         self,
@@ -80,9 +85,11 @@ class BillingClient:
             params["teamId"] = team_id
         try:
             response = self.client.get("/billing/usage", params=params)
-            return UsageSummary.model_validate(response)
+        except APIError:
+            raise
         except Exception as exc:  # noqa: BLE001
             raise APIError(_format_error("Failed to get usage summary", exc)) from exc
+        return UsageSummary.model_validate(response)
 
 
 def _format_error(prefix: str, exc: Exception) -> str:

--- a/packages/prime/src/prime_cli/api/billing.py
+++ b/packages/prime/src/prime_cli/api/billing.py
@@ -1,6 +1,6 @@
-"""Billing API client — token usage and cost for RFT runs and overall account areas."""
+"""Billing API client — token usage and cost for an RFT run."""
 
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -37,24 +37,6 @@ class RunUsage(BaseModel):
     record_count: int = 0
 
 
-class AreaUsage(BaseModel):
-    area: str
-    total_cost_usd: float = 0.0
-    training_tokens: int = 0
-    inference_tokens: int = 0
-    inference_requests: int = 0
-
-
-class UsageSummary(BaseModel):
-    period: str
-    start_date: str
-    end_date: str
-    wallet_id: str
-    team_id: Optional[str] = None
-    total_cost_usd: float = 0.0
-    areas: List[AreaUsage]
-
-
 class BillingClient:
     """Thin client for `/api/v1/billing/*` endpoints."""
 
@@ -73,23 +55,6 @@ class BillingClient:
         except Exception as exc:  # noqa: BLE001
             raise APIError(_format_error("Failed to get run usage", exc)) from exc
         return RunUsage.model_validate(response)
-
-    def get_usage_summary(
-        self,
-        period: str = "this_month",
-        team_id: Optional[str] = None,
-    ) -> UsageSummary:
-        """Fetch aggregated tokens + cost per billing area for a period."""
-        params: Dict[str, Any] = {"period": period}
-        if team_id:
-            params["teamId"] = team_id
-        try:
-            response = self.client.get("/billing/usage", params=params)
-        except APIError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            raise APIError(_format_error("Failed to get usage summary", exc)) from exc
-        return UsageSummary.model_validate(response)
 
 
 def _format_error(prefix: str, exc: Exception) -> str:

--- a/packages/prime/src/prime_cli/api/billing.py
+++ b/packages/prime/src/prime_cli/api/billing.py
@@ -1,0 +1,91 @@
+"""Billing API client — token usage and cost for RFT runs and overall account areas."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from prime_cli.core import APIClient, APIError
+
+
+class RunUsageBreakdown(BaseModel):
+    tokens: int = 0
+    input_tokens: int = Field(0, alias="input_tokens")
+    output_tokens: int = Field(0, alias="output_tokens")
+    cost_usd: float = Field(0.0, alias="cost_usd")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class RunPricing(BaseModel):
+    training_per_mtok: Optional[float] = Field(None, alias="training_per_mtok")
+    inference_input_per_mtok: Optional[float] = Field(None, alias="inference_input_per_mtok")
+    inference_output_per_mtok: Optional[float] = Field(None, alias="inference_output_per_mtok")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class RunUsage(BaseModel):
+    run_id: str
+    run_name: Optional[str] = None
+    base_model: Optional[str] = None
+    status: Optional[str] = None
+    training: RunUsageBreakdown
+    inference: RunUsageBreakdown
+    total_tokens: int = 0
+    total_cost_usd: float = 0.0
+    pricing: RunPricing
+    record_count: int = 0
+
+
+class AreaUsage(BaseModel):
+    area: str
+    total_cost_usd: float = 0.0
+    training_tokens: int = 0
+    inference_tokens: int = 0
+    inference_requests: int = 0
+
+
+class UsageSummary(BaseModel):
+    period: str
+    start_date: str
+    end_date: str
+    wallet_id: str
+    team_id: Optional[str] = None
+    total_cost_usd: float = 0.0
+    areas: List[AreaUsage]
+
+
+class BillingClient:
+    """Thin client for `/api/v1/billing/*` endpoints."""
+
+    def __init__(self, client: APIClient) -> None:
+        self.client = client
+
+    def get_run_usage(self, run_id: str) -> RunUsage:
+        """Fetch token + cost totals for a single RFT run."""
+        try:
+            response = self.client.get(f"/billing/runs/{run_id}/usage")
+            return RunUsage.model_validate(response)
+        except Exception as exc:  # noqa: BLE001
+            raise APIError(_format_error("Failed to get run usage", exc)) from exc
+
+    def get_usage_summary(
+        self,
+        period: str = "this_month",
+        team_id: Optional[str] = None,
+    ) -> UsageSummary:
+        """Fetch aggregated tokens + cost per billing area for a period."""
+        params: Dict[str, Any] = {"period": period}
+        if team_id:
+            params["teamId"] = team_id
+        try:
+            response = self.client.get("/billing/usage", params=params)
+            return UsageSummary.model_validate(response)
+        except Exception as exc:  # noqa: BLE001
+            raise APIError(_format_error("Failed to get usage summary", exc)) from exc
+
+
+def _format_error(prefix: str, exc: Exception) -> str:
+    response = getattr(exc, "response", None)
+    text = getattr(response, "text", None) if response is not None else None
+    return f"{prefix}: {text}" if text else f"{prefix}: {exc}"

--- a/packages/prime/src/prime_cli/api/wallet.py
+++ b/packages/prime/src/prime_cli/api/wallet.py
@@ -1,0 +1,63 @@
+"""Wallet API client — current balance + recent billing rows."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from prime_cli.core import APIClient, APIError
+
+
+class BillingEntry(BaseModel):
+    id: str
+    created_at: datetime
+    updated_at: datetime
+    last_billed_at: Optional[datetime] = None
+    amount_usd: float
+    currency: str
+    resource_type: str
+    resource_id: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class Wallet(BaseModel):
+    wallet_id: str
+    team_id: Optional[str] = None
+    balance_usd: float = 0.0
+    currency: str
+    total_billings: int = 0
+    recent_billings: List[BillingEntry] = Field(default_factory=list)
+
+
+class WalletClient:
+    """Thin client for `/api/v1/wallet`."""
+
+    def __init__(self, client: APIClient) -> None:
+        self.client = client
+
+    def get(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+        team_id: Optional[str] = None,
+    ) -> Wallet:
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if team_id:
+            params["teamId"] = team_id
+        try:
+            response = self.client.get("/wallet", params=params)
+        except APIError:
+            # Let typed APIError subclasses (UnauthorizedError, etc.) propagate
+            # — wrapping them strips the type and the caller's ability to
+            # branch on auth/payment failures.
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise APIError(_format_error("Failed to get wallet", exc)) from exc
+        return Wallet.model_validate(response)
+
+
+def _format_error(prefix: str, exc: Exception) -> str:
+    response = getattr(exc, "response", None)
+    text = getattr(response, "text", None) if response is not None else None
+    return f"{prefix}: {text}" if text else f"{prefix}: {exc}"

--- a/packages/prime/src/prime_cli/api/wallet.py
+++ b/packages/prime/src/prime_cli/api/wallet.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from prime_cli.core import APIClient, APIError
 
@@ -54,7 +54,14 @@ class WalletClient:
             raise
         except Exception as exc:  # noqa: BLE001
             raise APIError(_format_error("Failed to get wallet", exc)) from exc
-        return Wallet.model_validate(response)
+
+        try:
+            return Wallet.model_validate(response)
+        except ValidationError as exc:
+            # Wrap shape drift as APIError so the caller's existing
+            # except-APIError branch surfaces it as a clean CLI error
+            # instead of an unhandled traceback.
+            raise APIError(f"Unexpected /billing/wallet response: {exc}") from exc
 
 
 def _format_error(prefix: str, exc: Exception) -> str:

--- a/packages/prime/src/prime_cli/api/wallet.py
+++ b/packages/prime/src/prime_cli/api/wallet.py
@@ -31,7 +31,7 @@ class Wallet(BaseModel):
 
 
 class WalletClient:
-    """Thin client for `/api/v1/wallet`."""
+    """Thin client for `/api/v1/billing/wallet`."""
 
     def __init__(self, client: APIClient) -> None:
         self.client = client
@@ -46,7 +46,7 @@ class WalletClient:
         if team_id:
             params["teamId"] = team_id
         try:
-            response = self.client.get("/wallet", params=params)
+            response = self.client.get("/billing/wallet", params=params)
         except APIError:
             # Let typed APIError subclasses (UnauthorizedError, etc.) propagate
             # — wrapping them strips the type and the caller's ability to

--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -3038,7 +3038,12 @@ def _install_single_environment(env_slug: str, tool: str = "uv", prerelease: boo
         return False
 
     cmd_parts = _build_install_command(
-        name, target_version, simple_index_url, wheel_url, tool, url_dependencies=url_dependencies,
+        name,
+        target_version,
+        simple_index_url,
+        wheel_url,
+        tool,
+        url_dependencies=url_dependencies,
         prerelease=prerelease,
     )
     if not cmd_parts:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -35,6 +35,7 @@ from ..utils.formatters import (
     strip_ansi,
 )
 from ..utils.prompt import confirm_or_skip
+from .usage import RUN_USAGE_JSON_HELP, run_usage_command
 
 console = get_console()
 
@@ -2044,3 +2045,9 @@ def list_checkpoints(
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+
+
+# `prime train usage` — token usage and price for one run; lives next to the
+# other run-scoped monitoring commands. Implemented in commands/usage.py and
+# also re-exposed as the top-level `prime usage` summary command.
+app.command("usage", rich_help_panel="Monitoring", epilog=RUN_USAGE_JSON_HELP)(run_usage_command)

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -165,10 +165,14 @@ def run_usage_command(
     billing = BillingClient(APIClient())
 
     if not watch:
+        # In JSON mode, errors must go to stderr so stdout stays strictly
+        # JSON for agents piping through `jq`. Watch-mode JSON already does
+        # this — keep one-shot consistent.
+        err_console = get_console(stderr=True) if output == "json" else console
         try:
             usage = billing.get_run_usage(run_id)
         except APIError as exc:
-            console.print(f"[red]Error: {exc}[/red]")
+            err_console.print(f"[red]Error: {exc}[/red]")
             raise typer.Exit(1) from exc
 
         if output == "json":

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional
 
 import typer
 from rich.live import Live
+from rich.markup import escape as rich_escape
 from rich.table import Table
 
 from prime_cli.api.billing import (
@@ -83,9 +84,13 @@ def _summary_json(summary: UsageSummary) -> Dict[str, Any]:
 
 
 def _build_run_usage_table(usage: RunUsage) -> Table:
-    title = f"Run Usage — {usage.run_name or usage.run_id}"
+    # Rich parses table titles as markup, so values from the API (run_name,
+    # status) must be escaped before interpolation — otherwise a stray
+    # "[bold]" or similar in those strings would be interpreted as markup.
+    name = rich_escape(usage.run_name or usage.run_id)
+    title = f"Run Usage — {name}"
     if usage.status:
-        title += f"  [{usage.status}]"
+        title += f"  [{rich_escape(usage.status)}]"
 
     table = build_table(
         title,
@@ -136,7 +141,11 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
 
 
 def _build_summary_table(summary: UsageSummary) -> Table:
-    title = f"Usage Summary — {summary.period} ({summary.start_date} → {summary.end_date})"
+    # Escape API-supplied strings to keep them out of Rich's markup parser.
+    period = rich_escape(summary.period)
+    start = rich_escape(summary.start_date)
+    end = rich_escape(summary.end_date)
+    title = f"Usage Summary — {period} ({start} → {end})"
     table = build_table(
         title,
         [

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -1,0 +1,292 @@
+"""`prime usage` — token usage and price for RFT runs and the wider account.
+
+Mirrors the platform billing/analytics view (excluding sandbox) so an agent can
+poll a run's running cost without scraping the dashboard.
+"""
+
+import time
+from typing import Any, Dict, Optional
+
+import typer
+from rich.live import Live
+from rich.table import Table
+
+from prime_cli.api.billing import (
+    AreaUsage,
+    BillingClient,
+    RunUsage,
+    UsageSummary,
+)
+from prime_cli.core import APIClient, APIError
+from prime_cli.utils import (
+    PlainTyper,
+    build_table,
+    get_console,
+    is_plain_mode,
+    json_output_help,
+    output_data_as_json,
+    validate_output_format,
+)
+from prime_cli.utils.formatters import format_price_per_mtok
+
+app = PlainTyper(help="View token usage and price (excludes sandbox)", no_args_is_help=True)
+console = get_console()
+
+
+VALID_PERIODS = ("7_days", "this_month", "last_month", "6_months")
+
+RUN_USAGE_JSON_HELP = json_output_help(
+    ". = {run_id, run_name?, base_model?, status?, total_tokens, "
+    "total_cost_usd, record_count, "
+    "training: {tokens, input_tokens, output_tokens, cost_usd}, "
+    "inference: {tokens, input_tokens, output_tokens, cost_usd}, "
+    "pricing: {training_per_mtok?, inference_input_per_mtok?, "
+    "inference_output_per_mtok?}}"
+)
+
+USAGE_SUMMARY_JSON_HELP = json_output_help(
+    ". = {period, start_date, end_date, wallet_id, team_id?, total_cost_usd, "
+    "areas: [{area, total_cost_usd, training_tokens, inference_tokens, "
+    "inference_requests}]}"
+)
+
+
+def _format_tokens(value: int) -> str:
+    """Render token counts compactly: 1234 → '1.23K', 1_500_000 → '1.50M'."""
+    if value <= 0:
+        return "0"
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.2f}M"
+    if value >= 1_000:
+        return f"{value / 1_000:.2f}K"
+    return str(value)
+
+
+def _format_usd(value: float) -> str:
+    if value == 0:
+        return "$0.00"
+    if abs(value) < 0.01:
+        return f"${value:.4f}"
+    return f"${value:.2f}"
+
+
+def _run_usage_json(usage: RunUsage) -> Dict[str, Any]:
+    """Convert RunUsage into a stable JSON shape for the CLI surface."""
+    return usage.model_dump()
+
+
+def _summary_json(summary: UsageSummary) -> Dict[str, Any]:
+    return summary.model_dump()
+
+
+def _build_run_usage_table(usage: RunUsage) -> Table:
+    title = f"Run Usage — {usage.run_name or usage.run_id}"
+    if usage.status:
+        title += f"  [{usage.status}]"
+
+    table = build_table(
+        title,
+        [
+            ("Bucket", "cyan"),
+            ("Tokens", "white"),
+            ("Input tokens", "white"),
+            ("Output tokens", "white"),
+            ("Cost", "green"),
+            ("Price / Mtok", "magenta"),
+        ],
+        show_lines=False,
+    )
+
+    table.add_row(
+        "Training",
+        _format_tokens(usage.training.tokens),
+        "-",
+        "-",
+        _format_usd(usage.training.cost_usd),
+        format_price_per_mtok(usage.pricing.training_per_mtok) or "-",
+    )
+    table.add_row(
+        "Inference (input)",
+        "-",
+        _format_tokens(usage.inference.input_tokens),
+        "-",
+        "",
+        format_price_per_mtok(usage.pricing.inference_input_per_mtok) or "-",
+    )
+    table.add_row(
+        "Inference (output)",
+        "-",
+        "-",
+        _format_tokens(usage.inference.output_tokens),
+        _format_usd(usage.inference.cost_usd),
+        format_price_per_mtok(usage.pricing.inference_output_per_mtok) or "-",
+    )
+    table.add_row(
+        "[bold]Total[/bold]",
+        f"[bold]{_format_tokens(usage.total_tokens)}[/bold]",
+        "",
+        "",
+        f"[bold]{_format_usd(usage.total_cost_usd)}[/bold]",
+        "",
+    )
+    return table
+
+
+def _build_summary_table(summary: UsageSummary) -> Table:
+    title = f"Usage Summary — {summary.period} ({summary.start_date} → {summary.end_date})"
+    table = build_table(
+        title,
+        [
+            ("Area", "cyan"),
+            ("Tokens / Requests", "white"),
+            ("Cost", "green"),
+        ],
+        show_lines=False,
+    )
+
+    for area in summary.areas:
+        table.add_row(
+            area.area.title(),
+            _format_area_metric(area),
+            _format_usd(area.total_cost_usd),
+        )
+
+    table.add_row(
+        "[bold]Total[/bold]",
+        "",
+        f"[bold]{_format_usd(summary.total_cost_usd)}[/bold]",
+    )
+    return table
+
+
+def _format_area_metric(area: AreaUsage) -> str:
+    if area.area == "training":
+        train = _format_tokens(area.training_tokens)
+        infer = _format_tokens(area.inference_tokens)
+        return f"train {train} / inf {infer}"
+    if area.area == "inference":
+        return f"{area.inference_requests} req"
+    return "-"
+
+
+@app.command("run", epilog=RUN_USAGE_JSON_HELP)
+def run_usage(
+    run_id: str = typer.Argument(..., help="RFT run ID (e.g. rft_..."),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    watch: bool = typer.Option(
+        False, "--watch", "-w", help="Poll continuously and update in place"
+    ),
+    interval: int = typer.Option(
+        30,
+        "--interval",
+        "-n",
+        min=2,
+        help="Seconds between polls when --watch is set",
+    ),
+) -> None:
+    """Show token usage and price for a single RFT run."""
+    validate_output_format(output, console)
+
+    billing = BillingClient(APIClient())
+
+    try:
+        usage = billing.get_run_usage(run_id)
+    except APIError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    if not watch:
+        if output == "json":
+            output_data_as_json(_run_usage_json(usage), console)
+            return
+        console.print(_build_run_usage_table(usage))
+        return
+
+    if output == "json":
+        # JSON watch mode emits one JSON object per tick — agent-friendly.
+        _watch_json(billing.get_run_usage, run_id, interval, _run_usage_json)
+        return
+
+    if is_plain_mode():
+        # Plain mode: print one snapshot per tick instead of a Live re-render
+        # so output stays append-only and grep-able.
+        _watch_plain(billing.get_run_usage, run_id, interval, _build_run_usage_table)
+        return
+
+    _watch_live(billing.get_run_usage, run_id, interval, _build_run_usage_table)
+
+
+@app.command("summary", epilog=USAGE_SUMMARY_JSON_HELP)
+def summary(
+    period: str = typer.Option(
+        "this_month",
+        "--period",
+        "-p",
+        help=f"Time window. One of: {', '.join(VALID_PERIODS)}",
+    ),
+    team: Optional[str] = typer.Option(
+        None, "--team", "-t", help="Team ID (defaults to personal wallet)"
+    ),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Show aggregated tokens + cost per billing area (sandbox excluded)."""
+    validate_output_format(output, console)
+
+    if period not in VALID_PERIODS:
+        console.print(
+            f"[red]Error: invalid --period '{period}'. "
+            f"Expected one of: {', '.join(VALID_PERIODS)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    billing = BillingClient(APIClient())
+
+    try:
+        result = billing.get_usage_summary(period=period, team_id=team)
+    except APIError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    if output == "json":
+        output_data_as_json(_summary_json(result), console)
+        return
+
+    console.print(_build_summary_table(result))
+
+
+def _watch_live(fetch, run_id, interval, render):
+    try:
+        with Live(render(fetch(run_id)), console=console, refresh_per_second=4) as live:
+            while True:
+                time.sleep(interval)
+                live.update(render(fetch(run_id)))
+    except KeyboardInterrupt:
+        console.print("\n[dim]Stopped.[/dim]")
+    except APIError as exc:
+        console.print(f"[red]Error during watch: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
+def _watch_plain(fetch, run_id, interval, render):
+    try:
+        while True:
+            console.print(render(fetch(run_id)))
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        console.print("\nStopped.")
+    except APIError as exc:
+        console.print(f"[red]Error during watch: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
+def _watch_json(fetch, run_id, interval, to_json):
+    try:
+        while True:
+            output_data_as_json(to_json(fetch(run_id)), console)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        # Don't print to stdout — would corrupt the JSON stream.
+        return
+    except APIError as exc:
+        console.print(f"[red]Error during watch: {exc}[/red]")
+        raise typer.Exit(1) from exc

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -62,11 +62,10 @@ def _run_usage_json(usage: RunUsage) -> dict:
 
 
 def _build_run_usage_table(usage: RunUsage) -> Table:
-    # Rich parses table titles as markup, so values from the API (run_name,
-    # status) must be escaped before interpolation — otherwise a stray
-    # "[bold]" or similar in those strings would be interpreted as markup.
-    name = rich_escape(usage.run_name or usage.run_id)
-    title = f"Run Usage — {name}"
+    # Title stays short (run id + status) so long run names don't wrap and
+    # mangle the table header. The descriptive name + base model live in
+    # the caption below the table.
+    title = f"Run Usage — {rich_escape(usage.run_id)}"
     if usage.status:
         title += f"  [{rich_escape(usage.status)}]"
 
@@ -75,34 +74,37 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
         [
             ("Bucket", "cyan"),
             ("Tokens", "white"),
-            ("Input tokens", "white"),
-            ("Output tokens", "white"),
             ("Cost", "green"),
             ("Price / Mtok", "magenta"),
         ],
         show_lines=False,
     )
 
+    caption_parts: list[str] = []
+    if usage.run_name and usage.run_name != usage.run_id:
+        caption_parts.append(rich_escape(usage.run_name))
+    if usage.base_model:
+        caption_parts.append(f"model: {rich_escape(usage.base_model)}")
+    if caption_parts:
+        table.caption = "[dim]" + "  •  ".join(caption_parts) + "[/dim]"
+
     table.add_row(
         "Training",
         _format_tokens(usage.training.tokens),
-        "-",
-        "-",
         _format_usd(usage.training.cost_usd),
         format_price_per_mtok(usage.pricing.training_per_mtok) or "-",
     )
+    # Inference cost is a single combined number (input + output charges)
+    # — render it on the output row and leave the input row's Cost blank
+    # so the column doesn't double-count.
     table.add_row(
         "Inference (input)",
-        "-",
         _format_tokens(usage.inference.input_tokens),
-        "-",
         "",
         format_price_per_mtok(usage.pricing.inference_input_per_mtok) or "-",
     )
     table.add_row(
         "Inference (output)",
-        "-",
-        "-",
         _format_tokens(usage.inference.output_tokens),
         _format_usd(usage.inference.cost_usd),
         format_price_per_mtok(usage.pricing.inference_output_per_mtok) or "-",
@@ -110,8 +112,6 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
     table.add_row(
         "[bold]Total[/bold]",
         f"[bold]{_format_tokens(usage.total_tokens)}[/bold]",
-        "",
-        "",
         f"[bold]{_format_usd(usage.total_cost_usd)}[/bold]",
         "",
     )

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -23,7 +23,7 @@ from prime_cli.utils import (
     output_data_as_json,
     validate_output_format,
 )
-from prime_cli.utils.formatters import format_price_per_mtok
+from prime_cli.utils.formatters import format_price_per_mtok, format_usd
 
 console = get_console()
 
@@ -58,14 +58,6 @@ def _derived_cost(tokens: int, price_per_mtok: float | None) -> float | None:
     if price_per_mtok is None:
         return None
     return float(tokens) * price_per_mtok / 1_000_000
-
-
-def _format_usd(value: float) -> str:
-    if value == 0:
-        return "$0.00"
-    if abs(value) < 0.01:
-        return f"${value:.4f}"
-    return f"${value:.2f}"
 
 
 def _run_usage_json(usage: RunUsage) -> dict:
@@ -110,25 +102,25 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
     table.add_row(
         "Training",
         _format_tokens(usage.training.tokens),
-        _format_usd(usage.training.cost_usd),
+        format_usd(usage.training.cost_usd),
         format_price_per_mtok(usage.pricing.training_per_mtok) or "-",
     )
     table.add_row(
         "Inference (input)",
         _format_tokens(usage.inference.input_tokens),
-        _format_usd(in_cost) if in_cost is not None else "-",
+        format_usd(in_cost) if in_cost is not None else "-",
         format_price_per_mtok(usage.pricing.inference_input_per_mtok) or "-",
     )
     table.add_row(
         "Inference (output)",
         _format_tokens(usage.inference.output_tokens),
-        _format_usd(out_cost) if out_cost is not None else "-",
+        format_usd(out_cost) if out_cost is not None else "-",
         format_price_per_mtok(usage.pricing.inference_output_per_mtok) or "-",
     )
     table.add_row(
         "[bold]Total[/bold]",
         f"[bold]{_format_tokens(usage.total_tokens)}[/bold]",
-        f"[bold]{_format_usd(usage.total_cost_usd)}[/bold]",
+        f"[bold]{format_usd(usage.total_cost_usd)}[/bold]",
         "",
     )
     return table

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -189,19 +189,20 @@ def run_usage(
 
     billing = BillingClient(APIClient())
 
-    try:
-        usage = billing.get_run_usage(run_id)
-    except APIError as exc:
-        console.print(f"[red]Error: {exc}[/red]")
-        raise typer.Exit(1) from exc
-
     if not watch:
+        try:
+            usage = billing.get_run_usage(run_id)
+        except APIError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            raise typer.Exit(1) from exc
+
         if output == "json":
             output_data_as_json(_run_usage_json(usage), console)
             return
         console.print(_build_run_usage_table(usage))
         return
 
+    # Watch mode: the watcher does the first fetch itself — no eager call.
     if output == "json":
         # JSON watch mode emits one JSON object per tick — agent-friendly.
         _watch_json(billing.get_run_usage, run_id, interval, _run_usage_json)
@@ -280,13 +281,16 @@ def _watch_plain(fetch, run_id, interval, render):
 
 
 def _watch_json(fetch, run_id, interval, to_json):
+    # JSON watch streams one object per tick to stdout — keep stdout strictly
+    # JSON so agents can parse it with `jq -c` or similar. All diagnostics
+    # (errors, interrupts) go to stderr to avoid corrupting the stream.
+    err_console = get_console(stderr=True)
     try:
         while True:
             output_data_as_json(to_json(fetch(run_id)), console)
             time.sleep(interval)
     except KeyboardInterrupt:
-        # Don't print to stdout — would corrupt the JSON stream.
         return
     except APIError as exc:
-        console.print(f"[red]Error during watch: {exc}[/red]")
+        err_console.print(f"[red]Error during watch: {exc}[/red]")
         raise typer.Exit(1) from exc

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -90,13 +90,16 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
         show_lines=False,
     )
 
-    caption_parts: list[str] = []
+    # Each piece of metadata goes on its own caption line. Joining with a
+    # separator lets Rich wrap mid-label (e.g. "model:" at the end of one
+    # line, the value alone on the next) when the model name is long.
+    caption_lines: list[str] = []
     if usage.run_name and usage.run_name != usage.run_id:
-        caption_parts.append(rich_escape(usage.run_name))
+        caption_lines.append(rich_escape(usage.run_name))
     if usage.base_model:
-        caption_parts.append(f"model: {rich_escape(usage.base_model)}")
-    if caption_parts:
-        table.caption = "[dim]" + "  •  ".join(caption_parts) + "[/dim]"
+        caption_lines.append(f"model: {rich_escape(usage.base_model)}")
+    if caption_lines:
+        table.caption = "[dim]" + "\n".join(caption_lines) + "[/dim]"
 
     # Per-row inference cost is derived from tokens × the *same* snapshotted
     # rate that produced RFTUsage.cost on the backend, so the two derived

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -61,7 +61,9 @@ def _derived_cost(tokens: int, price_per_mtok: float | None) -> float | None:
 
 
 def _run_usage_json(usage: RunUsage) -> dict:
-    return usage.model_dump()
+    # mode="json" emits canonical JSON (ISO-8601 datetimes etc.) instead of
+    # Python-native types that fall back to repr() at serialization time.
+    return usage.model_dump(mode="json")
 
 
 def _build_run_usage_table(usage: RunUsage) -> Table:

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -1,7 +1,13 @@
-"""`prime usage` — token usage and price for RFT runs and the wider account.
+"""Token usage and price commands.
 
-Mirrors the platform billing/analytics view (excluding sandbox) so an agent can
-poll a run's running cost without scraping the dashboard.
+Two entry points are exported:
+
+- ``run_usage_command`` — registered as ``prime train usage`` in
+  ``commands/rl.py`` (sits next to ``train logs``, ``train metrics``, etc.).
+- ``summary_command`` — registered as the top-level ``prime usage`` so the
+  account-wide billing roll-up has its own ergonomic command (no subgroup).
+
+Both mirror the platform billing/analytics view, with sandbox excluded.
 """
 
 import time
@@ -19,7 +25,6 @@ from prime_cli.api.billing import (
 )
 from prime_cli.core import APIClient, APIError
 from prime_cli.utils import (
-    PlainTyper,
     build_table,
     get_console,
     is_plain_mode,
@@ -29,7 +34,6 @@ from prime_cli.utils import (
 )
 from prime_cli.utils.formatters import format_price_per_mtok
 
-app = PlainTyper(help="View token usage and price (excludes sandbox)", no_args_is_help=True)
 console = get_console()
 
 
@@ -71,7 +75,6 @@ def _format_usd(value: float) -> str:
 
 
 def _run_usage_json(usage: RunUsage) -> Dict[str, Any]:
-    """Convert RunUsage into a stable JSON shape for the CLI surface."""
     return usage.model_dump()
 
 
@@ -169,8 +172,7 @@ def _format_area_metric(area: AreaUsage) -> str:
     return "-"
 
 
-@app.command("run", epilog=RUN_USAGE_JSON_HELP)
-def run_usage(
+def run_usage_command(
     run_id: str = typer.Argument(..., help="RFT run ID (e.g. rft_..."),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
     watch: bool = typer.Option(
@@ -184,7 +186,16 @@ def run_usage(
         help="Seconds between polls when --watch is set",
     ),
 ) -> None:
-    """Show token usage and price for a single RFT run."""
+    """Show token usage and price for a single training run.
+
+    Example:
+
+        prime train usage <run_id>
+
+        prime train usage <run_id> --watch --interval 15
+
+        prime train usage <run_id> --output json
+    """
     validate_output_format(output, console)
 
     billing = BillingClient(APIClient())
@@ -204,21 +215,17 @@ def run_usage(
 
     # Watch mode: the watcher does the first fetch itself — no eager call.
     if output == "json":
-        # JSON watch mode emits one JSON object per tick — agent-friendly.
         _watch_json(billing.get_run_usage, run_id, interval, _run_usage_json)
         return
 
     if is_plain_mode():
-        # Plain mode: print one snapshot per tick instead of a Live re-render
-        # so output stays append-only and grep-able.
         _watch_plain(billing.get_run_usage, run_id, interval, _build_run_usage_table)
         return
 
     _watch_live(billing.get_run_usage, run_id, interval, _build_run_usage_table)
 
 
-@app.command("summary", epilog=USAGE_SUMMARY_JSON_HELP)
-def summary(
+def summary_command(
     period: str = typer.Option(
         "this_month",
         "--period",
@@ -230,7 +237,17 @@ def summary(
     ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
-    """Show aggregated tokens + cost per billing area (sandbox excluded)."""
+    """Account-wide billing summary (sandbox excluded).
+
+    Mirrors the dashboard analytics view — total tokens + cost per area
+    (training, inference, compute, disks, images) for the chosen period.
+
+    Example:
+
+        prime usage
+
+        prime usage --period 7_days --output json
+    """
     validate_output_format(output, console)
 
     if period not in VALID_PERIODS:

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -1,29 +1,19 @@
-"""Token usage and price commands.
+"""`prime train usage` — token usage and price for a single RFT run.
 
-Two entry points are exported:
-
-- ``run_usage_command`` — registered as ``prime train usage`` in
-  ``commands/rl.py`` (sits next to ``train logs``, ``train metrics``, etc.).
-- ``summary_command`` — registered as the top-level ``prime usage`` so the
-  account-wide billing roll-up has its own ergonomic command (no subgroup).
-
-Both mirror the platform billing/analytics view, with sandbox excluded.
+Registered as a subcommand of ``prime train`` in ``commands/rl.py`` (sits
+next to ``train logs``, ``train metrics``, etc.). Mirrors the per-row data
+the dashboard's billing page shows for a training run, with ``--watch`` for
+live polling so an agent can monitor a run's running cost.
 """
 
 import time
-from typing import Any, Dict, Optional
 
 import typer
 from rich.live import Live
 from rich.markup import escape as rich_escape
 from rich.table import Table
 
-from prime_cli.api.billing import (
-    AreaUsage,
-    BillingClient,
-    RunUsage,
-    UsageSummary,
-)
+from prime_cli.api.billing import BillingClient, RunUsage
 from prime_cli.core import APIClient, APIError
 from prime_cli.utils import (
     build_table,
@@ -38,8 +28,6 @@ from prime_cli.utils.formatters import format_price_per_mtok
 console = get_console()
 
 
-VALID_PERIODS = ("7_days", "this_month", "last_month", "6_months")
-
 RUN_USAGE_JSON_HELP = json_output_help(
     ". = {run_id, run_name?, base_model?, status?, total_tokens, "
     "total_cost_usd, record_count, "
@@ -47,12 +35,6 @@ RUN_USAGE_JSON_HELP = json_output_help(
     "inference: {tokens, input_tokens, output_tokens, cost_usd}, "
     "pricing: {training_per_mtok?, inference_input_per_mtok?, "
     "inference_output_per_mtok?}}"
-)
-
-USAGE_SUMMARY_JSON_HELP = json_output_help(
-    ". = {period, start_date, end_date, wallet_id, team_id?, total_cost_usd, "
-    "areas: [{area, total_cost_usd, training_tokens, inference_tokens, "
-    "inference_requests}]}"
 )
 
 
@@ -75,12 +57,8 @@ def _format_usd(value: float) -> str:
     return f"${value:.2f}"
 
 
-def _run_usage_json(usage: RunUsage) -> Dict[str, Any]:
+def _run_usage_json(usage: RunUsage) -> dict:
     return usage.model_dump()
-
-
-def _summary_json(summary: UsageSummary) -> Dict[str, Any]:
-    return summary.model_dump()
 
 
 def _build_run_usage_table(usage: RunUsage) -> Table:
@@ -140,47 +118,6 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
     return table
 
 
-def _build_summary_table(summary: UsageSummary) -> Table:
-    # Escape API-supplied strings to keep them out of Rich's markup parser.
-    period = rich_escape(summary.period)
-    start = rich_escape(summary.start_date)
-    end = rich_escape(summary.end_date)
-    title = f"Usage Summary — {period} ({start} → {end})"
-    table = build_table(
-        title,
-        [
-            ("Area", "cyan"),
-            ("Tokens / Requests", "white"),
-            ("Cost", "green"),
-        ],
-        show_lines=False,
-    )
-
-    for area in summary.areas:
-        table.add_row(
-            area.area.title(),
-            _format_area_metric(area),
-            _format_usd(area.total_cost_usd),
-        )
-
-    table.add_row(
-        "[bold]Total[/bold]",
-        "",
-        f"[bold]{_format_usd(summary.total_cost_usd)}[/bold]",
-    )
-    return table
-
-
-def _format_area_metric(area: AreaUsage) -> str:
-    if area.area == "training":
-        train = _format_tokens(area.training_tokens)
-        infer = _format_tokens(area.inference_tokens)
-        return f"train {train} / inf {infer}"
-    if area.area == "inference":
-        return f"{area.inference_requests} req"
-    return "-"
-
-
 def run_usage_command(
     run_id: str = typer.Argument(..., help="RFT run ID (e.g. rft_..."),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
@@ -232,53 +169,6 @@ def run_usage_command(
         return
 
     _watch_live(billing.get_run_usage, run_id, interval, _build_run_usage_table)
-
-
-def summary_command(
-    period: str = typer.Option(
-        "this_month",
-        "--period",
-        "-p",
-        help=f"Time window. One of: {', '.join(VALID_PERIODS)}",
-    ),
-    team: Optional[str] = typer.Option(
-        None, "--team", "-t", help="Team ID (defaults to personal wallet)"
-    ),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
-) -> None:
-    """Account-wide billing summary (sandbox excluded).
-
-    Mirrors the dashboard analytics view — total tokens + cost per area
-    (training, inference, compute, disks, images) for the chosen period.
-
-    Example:
-
-        prime usage
-
-        prime usage --period 7_days --output json
-    """
-    validate_output_format(output, console)
-
-    if period not in VALID_PERIODS:
-        console.print(
-            f"[red]Error: invalid --period '{period}'. "
-            f"Expected one of: {', '.join(VALID_PERIODS)}[/red]"
-        )
-        raise typer.Exit(1)
-
-    billing = BillingClient(APIClient())
-
-    try:
-        result = billing.get_usage_summary(period=period, team_id=team)
-    except APIError as exc:
-        console.print(f"[red]Error: {exc}[/red]")
-        raise typer.Exit(1) from exc
-
-    if output == "json":
-        output_data_as_json(_summary_json(result), console)
-        return
-
-    console.print(_build_summary_table(result))
 
 
 def _watch_live(fetch, run_id, interval, render):

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -49,6 +49,17 @@ def _format_tokens(value: int) -> str:
     return str(value)
 
 
+def _derived_cost(tokens: int, price_per_mtok: float | None) -> float | None:
+    """Compute cost in USD from tokens × snapshotted rate.
+
+    Returns None when the rate is missing so the caller can render `-`
+    (genuinely unknown) instead of `$0.00` (zero rate, which is a real value).
+    """
+    if price_per_mtok is None:
+        return None
+    return float(tokens) * price_per_mtok / 1_000_000
+
+
 def _format_usd(value: float) -> str:
     if value == 0:
         return "$0.00"
@@ -88,25 +99,30 @@ def _build_run_usage_table(usage: RunUsage) -> Table:
     if caption_parts:
         table.caption = "[dim]" + "  •  ".join(caption_parts) + "[/dim]"
 
+    # Per-row inference cost is derived from tokens × the *same* snapshotted
+    # rate that produced RFTUsage.cost on the backend, so the two derived
+    # halves sum to the combined inference cost in the response (modulo a
+    # cent of rounding). The Total row keeps using the backend's exact sum
+    # so what we show as "Total" is what was actually billed.
+    in_cost = _derived_cost(usage.inference.input_tokens, usage.pricing.inference_input_per_mtok)
+    out_cost = _derived_cost(usage.inference.output_tokens, usage.pricing.inference_output_per_mtok)
+
     table.add_row(
         "Training",
         _format_tokens(usage.training.tokens),
         _format_usd(usage.training.cost_usd),
         format_price_per_mtok(usage.pricing.training_per_mtok) or "-",
     )
-    # Inference cost is a single combined number (input + output charges)
-    # — render it on the output row and leave the input row's Cost blank
-    # so the column doesn't double-count.
     table.add_row(
         "Inference (input)",
         _format_tokens(usage.inference.input_tokens),
-        "",
+        _format_usd(in_cost) if in_cost is not None else "-",
         format_price_per_mtok(usage.pricing.inference_input_per_mtok) or "-",
     )
     table.add_row(
         "Inference (output)",
         _format_tokens(usage.inference.output_tokens),
-        _format_usd(usage.inference.cost_usd),
+        _format_usd(out_cost) if out_cost is not None else "-",
         format_price_per_mtok(usage.pricing.inference_output_per_mtok) or "-",
     )
     table.add_row(

--- a/packages/prime/src/prime_cli/commands/usage.py
+++ b/packages/prime/src/prime_cli/commands/usage.py
@@ -39,10 +39,15 @@ RUN_USAGE_JSON_HELP = json_output_help(
 
 
 def _format_tokens(value: int) -> str:
-    """Render token counts compactly: 1234 → '1.23K', 1_500_000 → '1.50M'."""
+    """Render token counts compactly: 1234 → '1.23K', 1_500_000 → '1.50M'.
+
+    Promotes to M whenever rounding to 2dp would produce ≥ 1.00M, so values
+    just below the boundary (e.g. 999_995) render as ``1.00M`` instead of
+    the misleading ``1000.00K``.
+    """
     if value <= 0:
         return "0"
-    if value >= 1_000_000:
+    if round(value / 1_000_000, 2) >= 1.00:
         return f"{value / 1_000_000:.2f}M"
     if value >= 1_000:
         return f"{value / 1_000:.2f}K"

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -113,7 +113,9 @@ def wallet_command(
         raise typer.Exit(1) from exc
 
     if output == "json":
-        output_data_as_json(wallet.model_dump(), console)
+        # mode="json" emits ISO-8601 datetime strings rather than the
+        # space-separated repr that default=str produces.
+        output_data_as_json(wallet.model_dump(mode="json"), console)
         return
 
     if config.team_id:

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -1,0 +1,133 @@
+"""`prime wallet` — balance + most recent billing rows.
+
+Single one-shot command (no subcommands, no watch mode). Drives an agent's
+audit of the billing flow: "balance dropped by exactly $X after run R logged
+the charge in the Billing table".
+"""
+
+from typing import Optional
+
+import typer
+from rich.markup import escape as rich_escape
+
+from prime_cli.api.wallet import BillingEntry, Wallet, WalletClient
+from prime_cli.core import APIClient, APIError
+from prime_cli.utils import (
+    build_table,
+    get_console,
+    json_output_help,
+    output_data_as_json,
+    validate_output_format,
+)
+
+console = get_console()
+
+
+WALLET_JSON_HELP = json_output_help(
+    ". = {wallet_id, team_id?, balance_usd, currency, total_billings, "
+    "recent_billings: [{id, created_at, updated_at, last_billed_at?, "
+    "amount_usd, currency, resource_type, resource_id?}]}"
+)
+
+
+def _format_usd(value: float) -> str:
+    if value == 0:
+        return "$0.00"
+    if abs(value) < 0.01:
+        return f"${value:.4f}"
+    return f"${value:.2f}"
+
+
+def _format_when(entry: BillingEntry) -> str:
+    when = entry.last_billed_at or entry.updated_at
+    return when.strftime("%Y-%m-%d %H:%M")
+
+
+def _format_resource(entry: BillingEntry) -> str:
+    if entry.resource_id:
+        return f"{entry.resource_type} ({rich_escape(entry.resource_id)})"
+    return entry.resource_type
+
+
+def _build_balance_table(wallet: Wallet) -> object:
+    title = f"Wallet — {rich_escape(wallet.wallet_id)}" + (
+        f" (team {rich_escape(wallet.team_id)})" if wallet.team_id else ""
+    )
+    table = build_table(
+        title,
+        [("Field", "cyan"), ("Value", "white")],
+        show_lines=False,
+    )
+    table.add_row("Balance", f"[bold green]{_format_usd(wallet.balance_usd)}[/bold green]")
+    table.add_row("Currency", wallet.currency)
+    table.add_row("Total billing rows", str(wallet.total_billings))
+    return table
+
+
+def _build_billings_table(wallet: Wallet) -> object:
+    title = f"Recent billings ({len(wallet.recent_billings)} of {wallet.total_billings})"
+    table = build_table(
+        title,
+        [
+            ("When", "dim"),
+            ("Resource", "cyan"),
+            ("Amount", "green"),
+        ],
+        show_lines=False,
+    )
+    for entry in wallet.recent_billings:
+        table.add_row(
+            _format_when(entry),
+            _format_resource(entry),
+            _format_usd(entry.amount_usd),
+        )
+    return table
+
+
+def wallet_command(
+    limit: int = typer.Option(
+        20,
+        "--limit",
+        "-n",
+        min=1,
+        max=100,
+        help="Number of recent billing rows to fetch (max 100)",
+    ),
+    team: Optional[str] = typer.Option(
+        None, "--team", "-t", help="Team ID (defaults to personal wallet)"
+    ),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+) -> None:
+    """Show wallet balance and most recent billing rows.
+
+    Lets an agent audit billing end-to-end: pair this with
+    ``prime train usage <run_id>`` to confirm the wallet debit matches the
+    run's reported cost.
+
+    Example:
+
+        prime wallet
+
+        prime wallet --limit 50 --output json
+
+        prime wallet --team team_abc
+    """
+    validate_output_format(output, console)
+
+    client = WalletClient(APIClient())
+
+    try:
+        wallet = client.get(limit=limit, team_id=team)
+    except APIError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(1) from exc
+
+    if output == "json":
+        output_data_as_json(wallet.model_dump(), console)
+        return
+
+    console.print(_build_balance_table(wallet))
+    if wallet.recent_billings:
+        console.print(_build_billings_table(wallet))
+    else:
+        console.print("[dim]No billing rows yet.[/dim]")

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -19,6 +19,7 @@ from prime_cli.utils import (
     output_data_as_json,
     validate_output_format,
 )
+from prime_cli.utils.formatters import format_usd
 
 console = get_console()
 
@@ -28,14 +29,6 @@ WALLET_JSON_HELP = json_output_help(
     "recent_billings: [{id, created_at, updated_at, last_billed_at?, "
     "amount_usd, currency, resource_type, resource_id?}]}"
 )
-
-
-def _format_usd(value: float) -> str:
-    if value == 0:
-        return "$0.00"
-    if abs(value) < 0.01:
-        return f"${value:.4f}"
-    return f"${value:.2f}"
 
 
 def _format_when(entry: BillingEntry) -> str:
@@ -58,7 +51,7 @@ def _build_balance_table(wallet: Wallet) -> object:
         [("Field", "cyan"), ("Value", "white")],
         show_lines=False,
     )
-    table.add_row("Balance", f"[bold green]{_format_usd(wallet.balance_usd)}[/bold green]")
+    table.add_row("Balance", f"[bold green]{format_usd(wallet.balance_usd)}[/bold green]")
     table.add_row("Currency", wallet.currency)
     table.add_row("Total billing rows", str(wallet.total_billings))
     return table
@@ -79,7 +72,7 @@ def _build_billings_table(wallet: Wallet) -> object:
         table.add_row(
             _format_when(entry),
             _format_resource(entry),
-            _format_usd(entry.amount_usd),
+            format_usd(entry.amount_usd),
         )
     return table
 

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -119,7 +119,11 @@ def wallet_command(
         return
 
     if config.team_id:
-        team_label = f"team {rich_escape(config.team_name or config.team_id)}"
+        # When PRIME_TEAM_ID env var overrides the configured team, the file's
+        # team_name is for a different team — fall back to the id so the
+        # header doesn't lie about which wallet we're showing.
+        display_name = None if config.team_id_from_env else config.team_name
+        team_label = f"team {rich_escape(display_name or config.team_id)}"
     else:
         team_label = "personal"
     _print_header(wallet, team_label)

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -40,25 +40,25 @@ def _format_resource(entry: BillingEntry) -> str:
     return entry.resource_type
 
 
-def _build_balance_table(wallet: Wallet, team_label: str) -> object:
-    # Title stays short ("Wallet" + scope label) so long cuids never wrap
-    # across multiple lines. The wallet_id is internal-only and not
-    # user-meaningful, so it lives in the caption for support/debug.
-    title = f"Wallet — {team_label}"
-    table = build_table(
-        title,
-        [("Field", "cyan"), ("Value", "white")],
-        show_lines=False,
+def _print_header(wallet: Wallet, team_label: str) -> None:
+    """Render the balance summary as plain left-aligned lines.
+
+    Avoids stacking two centered tables of different widths, which makes
+    the title + first column visibly jump as the eye moves down. Plain
+    text keeps everything anchored to the left margin.
+    """
+    console.print(f"[bold]Wallet[/bold]  [dim]({team_label})[/dim]")
+    console.print(
+        f"  Balance:  [bold green]{format_usd(wallet.balance_usd)}[/bold green] "
+        f"[dim]{wallet.currency}[/dim]"
     )
-    table.add_row("Balance", f"[bold green]{format_usd(wallet.balance_usd)}[/bold green]")
-    table.add_row("Currency", wallet.currency)
-    table.add_row("Total billing rows", str(wallet.total_billings))
-    table.caption = f"[dim]wallet id: {rich_escape(wallet.wallet_id)}[/dim]"
-    return table
+    console.print(f"  Billings: [bold]{wallet.total_billings}[/bold] total")
+    console.print(f"  [dim]wallet id: {rich_escape(wallet.wallet_id)}[/dim]")
+    console.print()
 
 
 def _build_billings_table(wallet: Wallet) -> object:
-    title = f"Recent billings ({len(wallet.recent_billings)} of {wallet.total_billings})"
+    title = f"Recent billings — last {len(wallet.recent_billings)} of {wallet.total_billings}"
     table = build_table(
         title,
         [
@@ -119,8 +119,8 @@ def wallet_command(
     if config.team_id:
         team_label = f"team {rich_escape(config.team_name or config.team_id)}"
     else:
-        team_label = "Personal"
-    console.print(_build_balance_table(wallet, team_label))
+        team_label = "personal"
+    _print_header(wallet, team_label)
     if wallet.recent_billings:
         console.print(_build_billings_table(wallet))
     else:

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -5,13 +5,11 @@ audit of the billing flow: "balance dropped by exactly $X after run R logged
 the charge in the Billing table".
 """
 
-from typing import Optional
-
 import typer
 from rich.markup import escape as rich_escape
 
 from prime_cli.api.wallet import BillingEntry, Wallet, WalletClient
-from prime_cli.core import APIClient, APIError
+from prime_cli.core import APIClient, APIError, Config
 from prime_cli.utils import (
     build_table,
     get_console,
@@ -42,10 +40,11 @@ def _format_resource(entry: BillingEntry) -> str:
     return entry.resource_type
 
 
-def _build_balance_table(wallet: Wallet) -> object:
-    title = f"Wallet — {rich_escape(wallet.wallet_id)}" + (
-        f" (team {rich_escape(wallet.team_id)})" if wallet.team_id else ""
-    )
+def _build_balance_table(wallet: Wallet, team_label: str) -> object:
+    # Title stays short ("Wallet" + scope label) so long cuids never wrap
+    # across multiple lines. The wallet_id is internal-only and not
+    # user-meaningful, so it lives in the caption for support/debug.
+    title = f"Wallet — {team_label}"
     table = build_table(
         title,
         [("Field", "cyan"), ("Value", "white")],
@@ -54,6 +53,7 @@ def _build_balance_table(wallet: Wallet) -> object:
     table.add_row("Balance", f"[bold green]{format_usd(wallet.balance_usd)}[/bold green]")
     table.add_row("Currency", wallet.currency)
     table.add_row("Total billing rows", str(wallet.total_billings))
+    table.caption = f"[dim]wallet id: {rich_escape(wallet.wallet_id)}[/dim]"
     return table
 
 
@@ -86,31 +86,28 @@ def wallet_command(
         max=100,
         help="Number of recent billing rows to fetch (max 100)",
     ),
-    team: Optional[str] = typer.Option(
-        None, "--team", "-t", help="Team ID (defaults to personal wallet)"
-    ),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """Show wallet balance and most recent billing rows.
 
-    Lets an agent audit billing end-to-end: pair this with
-    ``prime train usage <run_id>`` to confirm the wallet debit matches the
-    run's reported cost.
+    Follows the team configured via ``prime switch`` / ``prime config``
+    (personal wallet when no team is selected). Lets an agent audit billing
+    end-to-end: pair this with ``prime train usage <run_id>`` to confirm
+    the wallet debit matches the run's reported cost.
 
     Example:
 
         prime wallet
 
         prime wallet --limit 50 --output json
-
-        prime wallet --team team_abc
     """
     validate_output_format(output, console)
 
+    config = Config()
     client = WalletClient(APIClient())
 
     try:
-        wallet = client.get(limit=limit, team_id=team)
+        wallet = client.get(limit=limit, team_id=config.team_id)
     except APIError as exc:
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(1) from exc
@@ -119,7 +116,11 @@ def wallet_command(
         output_data_as_json(wallet.model_dump(), console)
         return
 
-    console.print(_build_balance_table(wallet))
+    if config.team_id:
+        team_label = f"team {rich_escape(config.team_name or config.team_id)}"
+    else:
+        team_label = "Personal"
+    console.print(_build_balance_table(wallet, team_label))
     if wallet.recent_billings:
         console.print(_build_billings_table(wallet))
     else:

--- a/packages/prime/src/prime_cli/commands/wallet.py
+++ b/packages/prime/src/prime_cli/commands/wallet.py
@@ -106,10 +106,13 @@ def wallet_command(
     config = Config()
     client = WalletClient(APIClient())
 
+    # In JSON mode, errors must go to stderr so stdout stays strictly JSON
+    # for agents piping through `jq`.
+    err_console = get_console(stderr=True) if output == "json" else console
     try:
         wallet = client.get(limit=limit, team_id=config.team_id)
     except APIError as exc:
-        console.print(f"[red]Error: {exc}[/red]")
+        err_console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(1) from exc
 
     if output == "json":

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -27,6 +27,7 @@ from .commands.switch import app as switch_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
+from .commands.usage import app as usage_app
 from .commands.whoami import app as whoami_app
 from .core import Config
 from .utils import PlainTyper, get_console
@@ -54,6 +55,7 @@ app.add_typer(
     rich_help_panel="Lab",
 )
 app.add_typer(deployments_app, name="deployments", rich_help_panel="Lab")
+app.add_typer(usage_app, name="usage", rich_help_panel="Lab")
 
 # Compute commands
 app.add_typer(availability_app, name="availability", rich_help_panel="Compute")

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -27,6 +27,7 @@ from .commands.switch import app as switch_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
+from .commands.wallet import WALLET_JSON_HELP, wallet_command
 from .commands.whoami import app as whoami_app
 from .core import Config
 from .utils import PlainTyper, get_console
@@ -72,6 +73,7 @@ app.add_typer(switch_app, name="switch", rich_help_panel="Account")
 app.add_typer(config_app, name="config", rich_help_panel="Account")
 app.add_typer(teams_app, name="teams", rich_help_panel="Account")
 app.add_typer(secret_app, name="secret", rich_help_panel="Account")
+app.command("wallet", rich_help_panel="Account", epilog=WALLET_JSON_HELP)(wallet_command)
 app.add_typer(upgrade_app, name="upgrade", rich_help_panel="Account")
 app.add_typer(upgrade_app, name="update", rich_help_panel="Account", hidden=True)
 app.add_typer(feedback_app, name="feedback", rich_help_panel="Account")

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -27,7 +27,8 @@ from .commands.switch import app as switch_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
-from .commands.usage import app as usage_app
+from .commands.usage import USAGE_SUMMARY_JSON_HELP
+from .commands.usage import summary_command as usage_summary_command
 from .commands.whoami import app as whoami_app
 from .core import Config
 from .utils import PlainTyper, get_console
@@ -55,7 +56,9 @@ app.add_typer(
     rich_help_panel="Lab",
 )
 app.add_typer(deployments_app, name="deployments", rich_help_panel="Lab")
-app.add_typer(usage_app, name="usage", rich_help_panel="Lab")
+app.command("usage", rich_help_panel="Account", epilog=USAGE_SUMMARY_JSON_HELP)(
+    usage_summary_command
+)
 
 # Compute commands
 app.add_typer(availability_app, name="availability", rich_help_panel="Compute")

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -27,8 +27,6 @@ from .commands.switch import app as switch_app
 from .commands.teams import app as teams_app
 from .commands.tunnel import app as tunnel_app
 from .commands.upgrade import app as upgrade_app
-from .commands.usage import USAGE_SUMMARY_JSON_HELP
-from .commands.usage import summary_command as usage_summary_command
 from .commands.whoami import app as whoami_app
 from .core import Config
 from .utils import PlainTyper, get_console
@@ -56,9 +54,6 @@ app.add_typer(
     rich_help_panel="Lab",
 )
 app.add_typer(deployments_app, name="deployments", rich_help_panel="Lab")
-app.command("usage", rich_help_panel="Account", epilog=USAGE_SUMMARY_JSON_HELP)(
-    usage_summary_command
-)
 
 # Compute commands
 app.add_typer(availability_app, name="availability", rich_help_panel="Compute")

--- a/packages/prime/src/prime_cli/utils/display.py
+++ b/packages/prime/src/prime_cli/utils/display.py
@@ -20,8 +20,18 @@ def validate_output_format(output: str, console: Console) -> None:
 
 
 def output_data_as_json(data: Any, console: Console) -> None:
-    """Output data as formatted JSON."""
-    console.print(json.dumps(data, indent=2, default=str), markup=False, highlight=False)
+    """Output data as formatted JSON.
+
+    `soft_wrap=True` disables Rich's terminal-width wrapping so long string
+    values don't get a literal newline injected in the middle and break
+    parsers (e.g. `prime train usage` run names regularly exceed 80 chars).
+    """
+    console.print(
+        json.dumps(data, indent=2, default=str),
+        markup=False,
+        highlight=False,
+        soft_wrap=True,
+    )
 
 
 def build_table(title: str, columns: List[Tuple[str, str]], show_lines: bool = True) -> Table:

--- a/packages/prime/src/prime_cli/utils/formatters.py
+++ b/packages/prime/src/prime_cli/utils/formatters.py
@@ -45,6 +45,20 @@ def format_price(value: float) -> str:
     return f"${value:.2f}"
 
 
+def format_usd(value: float) -> str:
+    """Format a USD amount with sub-cent precision when the value is tiny.
+
+    Used by `prime train usage` and `prime wallet` for table cells. Zero
+    renders as `$0.00` (a real value, not "missing"); values below a cent
+    render with extra decimals so they don't collapse to `$0.00`.
+    """
+    if value == 0:
+        return "$0.00"
+    if abs(value) < 0.01:
+        return f"${value:.4f}"
+    return f"${value:.2f}"
+
+
 def format_price_per_mtok(value: Any) -> str:
     """Format USD per 1M tokens for display, trimming trailing zeros."""
     if value is None:

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -150,6 +150,21 @@ def test_train_usage_propagates_typed_api_errors(monkeypatch: pytest.MonkeyPatch
     assert "Failed to get run usage" not in result.output
 
 
+def test_format_tokens_promotes_to_M_at_rounding_boundary() -> None:
+    """A value that would round to '1000.00K' must render as '1.00M' instead."""
+    from prime_cli.commands.usage import _format_tokens
+
+    # 999_995 rounds to 1.0M at 2dp; without the fix it would print "1000.00K"
+    assert _format_tokens(999_995) == "1.00M"
+    # Comfortably within the K range
+    assert _format_tokens(900_000) == "900.00K"
+    assert _format_tokens(1234) == "1.23K"
+    # Comfortably within the M range
+    assert _format_tokens(1_000_000) == "1.00M"
+    assert _format_tokens(1_500_000) == "1.50M"
+    assert _format_tokens(0) == "0"
+
+
 def test_train_usage_wraps_response_shape_drift_as_api_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -156,6 +156,45 @@ def test_train_usage_appears_in_train_help() -> None:
     assert "usage" in result.output
 
 
+def test_train_usage_escapes_rich_markup_in_run_name_and_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API-supplied run_name/status must not be parsed as Rich markup."""
+    payload = _run_usage_payload()
+    payload["run_name"] = "evil[bold red]name[/bold red]"
+    payload["status"] = "RUN[blink]"
+
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": payload}, []),
+    )
+
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    # Bracketed text is rendered literally, not consumed as markup.
+    assert "evil[bold red]name[/bold red]" in plain
+    assert "RUN[blink]" in plain
+
+
+def test_train_usage_propagates_typed_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Subclassed APIErrors must propagate intact, not be re-wrapped."""
+    from prime_cli.core import UnauthorizedError
+
+    def raise_unauthorized(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise UnauthorizedError("token expired")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", raise_unauthorized)
+
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"])
+
+    assert result.exit_code == 1
+    # The original message should appear, not "Failed to get run usage: …".
+    assert "token expired" in result.output
+    assert "Failed to get run usage" not in result.output
+
+
 # -----------------------------------------------------------------------------
 # `prime usage` (account-wide summary)
 # -----------------------------------------------------------------------------

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -16,6 +16,12 @@ def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _run_usage_payload() -> Dict[str, Any]:
+    # Cost numbers are self-consistent with the rates × tokens math the CLI
+    # does for the per-row inference breakdown:
+    #   training:           5M × $2.5/Mtok = $12.50
+    #   inference (input):  1M × $0.5/Mtok = $0.50
+    #   inference (output): 3M × $1.5/Mtok = $4.50
+    #   inference combined: $5.00; total: $17.50
     return {
         "run_id": "rft_abc",
         "run_name": "my-run",
@@ -31,10 +37,10 @@ def _run_usage_payload() -> Dict[str, Any]:
             "tokens": 4_000_000,
             "input_tokens": 1_000_000,
             "output_tokens": 3_000_000,
-            "cost_usd": 7.0,
+            "cost_usd": 5.0,
         },
         "total_tokens": 9_000_000,
-        "total_cost_usd": 19.5,
+        "total_cost_usd": 17.5,
         "pricing": {
             "training_per_mtok": 2.5,
             "inference_input_per_mtok": 0.5,
@@ -74,8 +80,10 @@ def test_train_usage_table_renders_tokens_and_cost(monkeypatch: pytest.MonkeyPat
     assert "1.00M" in plain
     assert "3.00M" in plain
     assert "$12.50" in plain
-    assert "$7.00" in plain
-    assert "$19.50" in plain
+    # Per-row inference costs derived from rates × tokens:
+    assert "$0.50" in plain  # 1M × $0.5
+    assert "$4.50" in plain  # 3M × $1.5
+    assert "$17.50" in plain  # total
     assert "$2.5" in plain or "$2.50" in plain
     assert calls == [{"endpoint": "/billing/runs/rft_abc/usage", "params": None}]
 
@@ -92,7 +100,7 @@ def test_train_usage_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
     data = json.loads(result.output)
     assert data["run_id"] == "rft_abc"
     assert data["total_tokens"] == 9_000_000
-    assert data["total_cost_usd"] == 19.5
+    assert data["total_cost_usd"] == 17.5
     assert data["pricing"]["training_per_mtok"] == 2.5
 
 

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -148,3 +148,21 @@ def test_train_usage_propagates_typed_api_errors(monkeypatch: pytest.MonkeyPatch
     # The original message should appear, not "Failed to get run usage: …".
     assert "token expired" in result.output
     assert "Failed to get run usage" not in result.output
+
+
+def test_train_usage_wraps_response_shape_drift_as_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the backend response is missing required fields, the CLI should
+    surface a clean error rather than an unhandled Pydantic traceback.
+    """
+    bad_payload = {"run_id": "rft_abc"}  # missing training/inference/pricing
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": bad_payload}, []),
+    )
+
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"])
+
+    assert result.exit_code == 1
+    assert "Unexpected" in result.output

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -1,4 +1,4 @@
-"""Tests for `prime usage` — RFT run usage and aggregated billing summary."""
+"""Tests for `prime train usage` and `prime usage` (account-wide summary)."""
 
 import json
 from typing import Any, Dict, List, Optional
@@ -104,42 +104,42 @@ def _make_get_mock(routes: Dict[str, Dict[str, Any]], calls: List[Dict[str, Any]
     return mock_get
 
 
-def test_run_usage_table_renders_tokens_and_cost(monkeypatch: pytest.MonkeyPatch) -> None:
+# -----------------------------------------------------------------------------
+# `prime train usage <run_id>`
+# -----------------------------------------------------------------------------
+
+
+def test_train_usage_table_renders_tokens_and_cost(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: List[Dict[str, Any]] = []
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
         _make_get_mock({"/billing/runs/rft_abc/usage": _run_usage_payload()}, calls),
     )
 
-    result = CliRunner().invoke(app, ["usage", "run", "rft_abc"], env={"COLUMNS": "200"})
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc"], env={"COLUMNS": "200"})
 
     assert result.exit_code == 0, result.output
     plain = strip_ansi(result.output)
-    # Table header
     assert "Run Usage" in plain
     assert "my-run" in plain
     assert "RUNNING" in plain
-    # Token formatting (5M, 1M, 3M)
     assert "5.00M" in plain
     assert "1.00M" in plain
     assert "3.00M" in plain
-    # Costs
     assert "$12.50" in plain
     assert "$7.00" in plain
     assert "$19.50" in plain
-    # Pricing per Mtok
     assert "$2.5" in plain or "$2.50" in plain
-    # Single GET to the right endpoint
     assert calls == [{"endpoint": "/billing/runs/rft_abc/usage", "params": None}]
 
 
-def test_run_usage_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_train_usage_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
         _make_get_mock({"/billing/runs/rft_abc/usage": _run_usage_payload()}, []),
     )
 
-    result = CliRunner().invoke(app, ["usage", "run", "rft_abc", "--output", "json"])
+    result = CliRunner().invoke(app, ["train", "usage", "rft_abc", "--output", "json"])
 
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
@@ -149,7 +149,19 @@ def test_run_usage_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
     assert data["pricing"]["training_per_mtok"] == 2.5
 
 
-def test_summary_table_renders_all_areas_excludes_sandbox(
+def test_train_usage_appears_in_train_help() -> None:
+    result = CliRunner().invoke(app, ["train", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "usage" in result.output
+
+
+# -----------------------------------------------------------------------------
+# `prime usage` (account-wide summary)
+# -----------------------------------------------------------------------------
+
+
+def test_usage_summary_renders_all_areas_excludes_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: List[Dict[str, Any]] = []
@@ -158,7 +170,7 @@ def test_summary_table_renders_all_areas_excludes_sandbox(
         _make_get_mock({"/billing/usage": _summary_payload()}, calls),
     )
 
-    result = CliRunner().invoke(app, ["usage", "summary"], env={"COLUMNS": "200"})
+    result = CliRunner().invoke(app, ["usage"], env={"COLUMNS": "200"})
 
     assert result.exit_code == 0, result.output
     plain = strip_ansi(result.output)
@@ -171,13 +183,10 @@ def test_summary_table_renders_all_areas_excludes_sandbox(
     assert "$600.00" in plain
     assert "$612.50" in plain
     assert "20 req" in plain
-    # Default period sent as query param
     assert calls == [{"endpoint": "/billing/usage", "params": {"period": "this_month"}}]
 
 
-def test_summary_passes_team_and_period_query_params(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_usage_passes_team_and_period_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: List[Dict[str, Any]] = []
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
@@ -188,7 +197,6 @@ def test_summary_passes_team_and_period_query_params(
         app,
         [
             "usage",
-            "summary",
             "--period",
             "7_days",
             "--team",
@@ -209,23 +217,20 @@ def test_summary_passes_team_and_period_query_params(
     ]
 
 
-def test_summary_rejects_invalid_period(monkeypatch: pytest.MonkeyPatch) -> None:
-    # No HTTP call expected — should fail before that.
+def test_usage_rejects_invalid_period(monkeypatch: pytest.MonkeyPatch) -> None:
     def fail_get(*args: Any, **kwargs: Any) -> Dict[str, Any]:
         raise AssertionError("Should not call API on invalid period")
 
     monkeypatch.setattr("prime_cli.core.APIClient.get", fail_get)
 
-    result = CliRunner().invoke(app, ["usage", "summary", "--period", "forever"])
+    result = CliRunner().invoke(app, ["usage", "--period", "forever"])
 
     assert result.exit_code == 1, result.output
     assert "invalid --period" in result.output
 
 
-def test_usage_help_lists_subcommands(monkeypatch: pytest.MonkeyPatch) -> None:
-    result = CliRunner().invoke(app, ["usage", "--help"])
+def test_usage_appears_in_root_help() -> None:
+    result = CliRunner().invoke(app, ["--help"])
 
     assert result.exit_code == 0, result.output
-    assert "run" in result.output
-    assert "summary" in result.output
-    assert "View token usage and price" in result.output
+    assert "usage" in result.output

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -1,4 +1,4 @@
-"""Tests for `prime train usage` and `prime usage` (account-wide summary)."""
+"""Tests for `prime train usage` (per-run token + price view)."""
 
 import json
 from typing import Any, Dict, List, Optional
@@ -44,54 +44,6 @@ def _run_usage_payload() -> Dict[str, Any]:
     }
 
 
-def _summary_payload() -> Dict[str, Any]:
-    return {
-        "period": "this_month",
-        "start_date": "2026-04-01",
-        "end_date": "2026-04-30",
-        "wallet_id": "w-1",
-        "team_id": None,
-        "total_cost_usd": 612.5,
-        "areas": [
-            {
-                "area": "training",
-                "total_cost_usd": 600.0,
-                "training_tokens": 20_000_000,
-                "inference_tokens": 4_000_000,
-                "inference_requests": 0,
-            },
-            {
-                "area": "inference",
-                "total_cost_usd": 8.0,
-                "training_tokens": 0,
-                "inference_tokens": 0,
-                "inference_requests": 20,
-            },
-            {
-                "area": "compute",
-                "total_cost_usd": 2.5,
-                "training_tokens": 0,
-                "inference_tokens": 0,
-                "inference_requests": 0,
-            },
-            {
-                "area": "disks",
-                "total_cost_usd": 1.5,
-                "training_tokens": 0,
-                "inference_tokens": 0,
-                "inference_requests": 0,
-            },
-            {
-                "area": "images",
-                "total_cost_usd": 0.5,
-                "training_tokens": 0,
-                "inference_tokens": 0,
-                "inference_requests": 0,
-            },
-        ],
-    }
-
-
 def _make_get_mock(routes: Dict[str, Dict[str, Any]], calls: List[Dict[str, Any]]):
     def mock_get(
         self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
@@ -102,11 +54,6 @@ def _make_get_mock(routes: Dict[str, Dict[str, Any]], calls: List[Dict[str, Any]
         raise AssertionError(f"Unexpected endpoint: {endpoint}")
 
     return mock_get
-
-
-# -----------------------------------------------------------------------------
-# `prime train usage <run_id>`
-# -----------------------------------------------------------------------------
 
 
 def test_train_usage_table_renders_tokens_and_cost(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -193,83 +140,3 @@ def test_train_usage_propagates_typed_api_errors(monkeypatch: pytest.MonkeyPatch
     # The original message should appear, not "Failed to get run usage: …".
     assert "token expired" in result.output
     assert "Failed to get run usage" not in result.output
-
-
-# -----------------------------------------------------------------------------
-# `prime usage` (account-wide summary)
-# -----------------------------------------------------------------------------
-
-
-def test_usage_summary_renders_all_areas_excludes_sandbox(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls: List[Dict[str, Any]] = []
-    monkeypatch.setattr(
-        "prime_cli.core.APIClient.get",
-        _make_get_mock({"/billing/usage": _summary_payload()}, calls),
-    )
-
-    result = CliRunner().invoke(app, ["usage"], env={"COLUMNS": "200"})
-
-    assert result.exit_code == 0, result.output
-    plain = strip_ansi(result.output)
-    assert "Training" in plain
-    assert "Inference" in plain
-    assert "Compute" in plain
-    assert "Disks" in plain
-    assert "Images" in plain
-    assert "Sandbox" not in plain
-    assert "$600.00" in plain
-    assert "$612.50" in plain
-    assert "20 req" in plain
-    assert calls == [{"endpoint": "/billing/usage", "params": {"period": "this_month"}}]
-
-
-def test_usage_passes_team_and_period_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: List[Dict[str, Any]] = []
-    monkeypatch.setattr(
-        "prime_cli.core.APIClient.get",
-        _make_get_mock({"/billing/usage": _summary_payload()}, calls),
-    )
-
-    result = CliRunner().invoke(
-        app,
-        [
-            "usage",
-            "--period",
-            "7_days",
-            "--team",
-            "team-1",
-            "--output",
-            "json",
-        ],
-    )
-
-    assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
-    assert data["period"] == "this_month"  # echoed from payload
-    assert calls == [
-        {
-            "endpoint": "/billing/usage",
-            "params": {"period": "7_days", "teamId": "team-1"},
-        }
-    ]
-
-
-def test_usage_rejects_invalid_period(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fail_get(*args: Any, **kwargs: Any) -> Dict[str, Any]:
-        raise AssertionError("Should not call API on invalid period")
-
-    monkeypatch.setattr("prime_cli.core.APIClient.get", fail_get)
-
-    result = CliRunner().invoke(app, ["usage", "--period", "forever"])
-
-    assert result.exit_code == 1, result.output
-    assert "invalid --period" in result.output
-
-
-def test_usage_appears_in_root_help() -> None:
-    result = CliRunner().invoke(app, ["--help"])
-
-    assert result.exit_code == 0, result.output
-    assert "usage" in result.output

--- a/packages/prime/tests/test_usage_cli.py
+++ b/packages/prime/tests/test_usage_cli.py
@@ -1,0 +1,231 @@
+"""Tests for `prime usage` — RFT run usage and aggregated billing summary."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+from prime_cli.main import app
+from prime_cli.utils.formatters import strip_ansi
+from typer.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+
+def _run_usage_payload() -> Dict[str, Any]:
+    return {
+        "run_id": "rft_abc",
+        "run_name": "my-run",
+        "base_model": "qwen2.5-7b",
+        "status": "RUNNING",
+        "training": {
+            "tokens": 5_000_000,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 12.5,
+        },
+        "inference": {
+            "tokens": 4_000_000,
+            "input_tokens": 1_000_000,
+            "output_tokens": 3_000_000,
+            "cost_usd": 7.0,
+        },
+        "total_tokens": 9_000_000,
+        "total_cost_usd": 19.5,
+        "pricing": {
+            "training_per_mtok": 2.5,
+            "inference_input_per_mtok": 0.5,
+            "inference_output_per_mtok": 1.5,
+        },
+        "record_count": 12,
+    }
+
+
+def _summary_payload() -> Dict[str, Any]:
+    return {
+        "period": "this_month",
+        "start_date": "2026-04-01",
+        "end_date": "2026-04-30",
+        "wallet_id": "w-1",
+        "team_id": None,
+        "total_cost_usd": 612.5,
+        "areas": [
+            {
+                "area": "training",
+                "total_cost_usd": 600.0,
+                "training_tokens": 20_000_000,
+                "inference_tokens": 4_000_000,
+                "inference_requests": 0,
+            },
+            {
+                "area": "inference",
+                "total_cost_usd": 8.0,
+                "training_tokens": 0,
+                "inference_tokens": 0,
+                "inference_requests": 20,
+            },
+            {
+                "area": "compute",
+                "total_cost_usd": 2.5,
+                "training_tokens": 0,
+                "inference_tokens": 0,
+                "inference_requests": 0,
+            },
+            {
+                "area": "disks",
+                "total_cost_usd": 1.5,
+                "training_tokens": 0,
+                "inference_tokens": 0,
+                "inference_requests": 0,
+            },
+            {
+                "area": "images",
+                "total_cost_usd": 0.5,
+                "training_tokens": 0,
+                "inference_tokens": 0,
+                "inference_requests": 0,
+            },
+        ],
+    }
+
+
+def _make_get_mock(routes: Dict[str, Dict[str, Any]], calls: List[Dict[str, Any]]):
+    def mock_get(
+        self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        calls.append({"endpoint": endpoint, "params": params})
+        if endpoint in routes:
+            return routes[endpoint]
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    return mock_get
+
+
+def test_run_usage_table_renders_tokens_and_cost(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": _run_usage_payload()}, calls),
+    )
+
+    result = CliRunner().invoke(app, ["usage", "run", "rft_abc"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    # Table header
+    assert "Run Usage" in plain
+    assert "my-run" in plain
+    assert "RUNNING" in plain
+    # Token formatting (5M, 1M, 3M)
+    assert "5.00M" in plain
+    assert "1.00M" in plain
+    assert "3.00M" in plain
+    # Costs
+    assert "$12.50" in plain
+    assert "$7.00" in plain
+    assert "$19.50" in plain
+    # Pricing per Mtok
+    assert "$2.5" in plain or "$2.50" in plain
+    # Single GET to the right endpoint
+    assert calls == [{"endpoint": "/billing/runs/rft_abc/usage", "params": None}]
+
+
+def test_run_usage_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/runs/rft_abc/usage": _run_usage_payload()}, []),
+    )
+
+    result = CliRunner().invoke(app, ["usage", "run", "rft_abc", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["run_id"] == "rft_abc"
+    assert data["total_tokens"] == 9_000_000
+    assert data["total_cost_usd"] == 19.5
+    assert data["pricing"]["training_per_mtok"] == 2.5
+
+
+def test_summary_table_renders_all_areas_excludes_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/usage": _summary_payload()}, calls),
+    )
+
+    result = CliRunner().invoke(app, ["usage", "summary"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "Training" in plain
+    assert "Inference" in plain
+    assert "Compute" in plain
+    assert "Disks" in plain
+    assert "Images" in plain
+    assert "Sandbox" not in plain
+    assert "$600.00" in plain
+    assert "$612.50" in plain
+    assert "20 req" in plain
+    # Default period sent as query param
+    assert calls == [{"endpoint": "/billing/usage", "params": {"period": "this_month"}}]
+
+
+def test_summary_passes_team_and_period_query_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/usage": _summary_payload()}, calls),
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "usage",
+            "summary",
+            "--period",
+            "7_days",
+            "--team",
+            "team-1",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["period"] == "this_month"  # echoed from payload
+    assert calls == [
+        {
+            "endpoint": "/billing/usage",
+            "params": {"period": "7_days", "teamId": "team-1"},
+        }
+    ]
+
+
+def test_summary_rejects_invalid_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No HTTP call expected — should fail before that.
+    def fail_get(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise AssertionError("Should not call API on invalid period")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", fail_get)
+
+    result = CliRunner().invoke(app, ["usage", "summary", "--period", "forever"])
+
+    assert result.exit_code == 1, result.output
+    assert "invalid --period" in result.output
+
+
+def test_usage_help_lists_subcommands(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = CliRunner().invoke(app, ["usage", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "run" in result.output
+    assert "summary" in result.output
+    assert "View token usage and price" in result.output

--- a/packages/prime/tests/test_wallet_cli.py
+++ b/packages/prime/tests/test_wallet_cli.py
@@ -13,6 +13,11 @@ from typer.testing import CliRunner
 def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    # Default to no team so tests don't depend on the developer's local
+    # `~/.prime/config.json`. Tests that exercise the team path override
+    # `Config.team_id` explicitly.
+    monkeypatch.delenv("PRIME_TEAM_ID", raising=False)
+    monkeypatch.setattr("prime_cli.core.Config.team_id", None)
 
 
 def _wallet_payload() -> Dict[str, Any]:
@@ -126,21 +131,34 @@ def test_wallet_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
     assert data["recent_billings"][0]["resource_type"] == "training"
 
 
-def test_wallet_passes_limit_and_team(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_wallet_passes_limit_and_uses_configured_team(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """team_id comes from Config (set by `prime switch`), never a CLI flag."""
     calls: List[Dict[str, Any]] = []
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
         _make_get_mock({"/wallet": _wallet_payload()}, calls),
     )
+    monkeypatch.setattr("prime_cli.core.Config.team_id", "team-cfg")
 
-    result = CliRunner().invoke(
-        app, ["wallet", "--limit", "5", "--team", "team-1", "--output", "json"]
-    )
+    result = CliRunner().invoke(app, ["wallet", "--limit", "5", "--output", "json"])
 
     assert result.exit_code == 0, result.output
     assert calls == [
-        {"endpoint": "/wallet", "params": {"limit": 5, "offset": 0, "teamId": "team-1"}}
+        {
+            "endpoint": "/wallet",
+            "params": {"limit": 5, "offset": 0, "teamId": "team-cfg"},
+        }
     ]
+
+
+def test_wallet_does_not_accept_team_flag() -> None:
+    """`--team` is intentionally not supported — must follow the configured team."""
+    result = CliRunner().invoke(app, ["wallet", "--team", "team-1"])
+
+    assert result.exit_code != 0
+    assert "No such option: --team" in result.output or "no such option" in result.output.lower()
 
 
 def test_wallet_handles_empty_billings(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/prime/tests/test_wallet_cli.py
+++ b/packages/prime/tests/test_wallet_cli.py
@@ -1,0 +1,180 @@
+"""Tests for `prime wallet` — balance + recent billings snapshot."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import pytest
+from prime_cli.main import app
+from prime_cli.utils.formatters import strip_ansi
+from typer.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+
+def _wallet_payload() -> Dict[str, Any]:
+    return {
+        "wallet_id": "wal_abc",
+        "team_id": None,
+        "balance_usd": 123.45,
+        "currency": "USD",
+        "total_billings": 3,
+        "recent_billings": [
+            {
+                "id": "bill_1",
+                "created_at": "2026-04-30T10:00:00Z",
+                "updated_at": "2026-04-30T10:00:00Z",
+                "last_billed_at": "2026-04-30T10:00:00Z",
+                "amount_usd": 12.5,
+                "currency": "USD",
+                "resource_type": "training",
+                "resource_id": "rft_xyz",
+            },
+            {
+                "id": "bill_2",
+                "created_at": "2026-04-30T09:00:00Z",
+                "updated_at": "2026-04-30T09:30:00Z",
+                "last_billed_at": "2026-04-30T09:30:00Z",
+                "amount_usd": 1.25,
+                "currency": "USD",
+                "resource_type": "compute",
+                "resource_id": "pod_def",
+            },
+            {
+                "id": "bill_3",
+                "created_at": "2026-04-30T08:00:00Z",
+                "updated_at": "2026-04-30T08:00:00Z",
+                "last_billed_at": None,
+                "amount_usd": 0.05,
+                "currency": "USD",
+                "resource_type": "disks",
+                "resource_id": "disk_ghi",
+            },
+        ],
+    }
+
+
+def _empty_wallet_payload() -> Dict[str, Any]:
+    return {
+        "wallet_id": "wal_abc",
+        "team_id": None,
+        "balance_usd": 0.0,
+        "currency": "USD",
+        "total_billings": 0,
+        "recent_billings": [],
+    }
+
+
+def _make_get_mock(routes: Dict[str, Dict[str, Any]], calls: List[Dict[str, Any]]):
+    def mock_get(
+        self: Any, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        calls.append({"endpoint": endpoint, "params": params})
+        if endpoint in routes:
+            return routes[endpoint]
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    return mock_get
+
+
+def test_wallet_renders_balance_and_billings_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/wallet": _wallet_payload()}, calls),
+    )
+
+    result = CliRunner().invoke(app, ["wallet"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    # Balance
+    assert "$123.45" in plain
+    # Total count
+    assert "3" in plain
+    # Each billing row's resource type + id
+    assert "training" in plain
+    assert "rft_xyz" in plain
+    assert "compute" in plain
+    assert "pod_def" in plain
+    assert "disks" in plain
+    # Each billing row's amount
+    assert "$12.50" in plain
+    assert "$1.25" in plain
+    assert "$0.05" in plain or "$0.0500" in plain
+    # Default query params
+    assert calls == [{"endpoint": "/wallet", "params": {"limit": 20, "offset": 0}}]
+
+
+def test_wallet_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/wallet": _wallet_payload()}, []),
+    )
+
+    result = CliRunner().invoke(app, ["wallet", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["wallet_id"] == "wal_abc"
+    assert data["balance_usd"] == 123.45
+    assert data["total_billings"] == 3
+    assert len(data["recent_billings"]) == 3
+    assert data["recent_billings"][0]["resource_type"] == "training"
+
+
+def test_wallet_passes_limit_and_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/wallet": _wallet_payload()}, calls),
+    )
+
+    result = CliRunner().invoke(
+        app, ["wallet", "--limit", "5", "--team", "team-1", "--output", "json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {"endpoint": "/wallet", "params": {"limit": 5, "offset": 0, "teamId": "team-1"}}
+    ]
+
+
+def test_wallet_handles_empty_billings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/wallet": _empty_wallet_payload()}, []),
+    )
+
+    result = CliRunner().invoke(app, ["wallet"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "$0.00" in plain
+    assert "No billing rows yet" in plain
+
+
+def test_wallet_appears_in_root_help() -> None:
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "wallet" in result.output
+
+
+def test_wallet_propagates_typed_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Subclassed APIErrors must propagate intact (e.g. 401 → UnauthorizedError)."""
+    from prime_cli.core import UnauthorizedError
+
+    def raise_unauthorized(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise UnauthorizedError("token expired")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", raise_unauthorized)
+
+    result = CliRunner().invoke(app, ["wallet"])
+
+    assert result.exit_code == 1
+    assert "token expired" in result.output
+    assert "Failed to get wallet" not in result.output

--- a/packages/prime/tests/test_wallet_cli.py
+++ b/packages/prime/tests/test_wallet_cli.py
@@ -182,6 +182,42 @@ def test_wallet_appears_in_root_help() -> None:
     assert "wallet" in result.output
 
 
+def test_wallet_json_emits_iso_datetimes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`mode='json'` should produce ISO-8601 datetime strings (e.g. 2026-04-30T22:00:00),
+    not the space-separated fallback `default=str` produces.
+    """
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/wallet": _wallet_payload()}, []),
+    )
+
+    result = CliRunner().invoke(app, ["wallet", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    for entry in data["recent_billings"]:
+        assert "T" in entry["created_at"], f"expected ISO timestamp, got {entry['created_at']!r}"
+        assert "T" in entry["updated_at"]
+
+
+def test_wallet_wraps_response_shape_drift_as_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the backend response is missing required fields, the CLI should
+    surface a clean error rather than an unhandled Pydantic traceback.
+    """
+    bad_payload = {"wallet_id": "w-1"}  # missing balance/currency/etc.
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/wallet": bad_payload}, []),
+    )
+
+    result = CliRunner().invoke(app, ["wallet"])
+
+    assert result.exit_code == 1
+    assert "Unexpected" in result.output
+
+
 def test_wallet_propagates_typed_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Subclassed APIErrors must propagate intact (e.g. 401 → UnauthorizedError)."""
     from prime_cli.core import UnauthorizedError

--- a/packages/prime/tests/test_wallet_cli.py
+++ b/packages/prime/tests/test_wallet_cli.py
@@ -89,7 +89,7 @@ def test_wallet_renders_balance_and_billings_table(monkeypatch: pytest.MonkeyPat
     calls: List[Dict[str, Any]] = []
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
-        _make_get_mock({"/wallet": _wallet_payload()}, calls),
+        _make_get_mock({"/billing/wallet": _wallet_payload()}, calls),
     )
 
     result = CliRunner().invoke(app, ["wallet"], env={"COLUMNS": "200"})
@@ -111,13 +111,13 @@ def test_wallet_renders_balance_and_billings_table(monkeypatch: pytest.MonkeyPat
     assert "$1.25" in plain
     assert "$0.05" in plain or "$0.0500" in plain
     # Default query params
-    assert calls == [{"endpoint": "/wallet", "params": {"limit": 20, "offset": 0}}]
+    assert calls == [{"endpoint": "/billing/wallet", "params": {"limit": 20, "offset": 0}}]
 
 
 def test_wallet_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
-        _make_get_mock({"/wallet": _wallet_payload()}, []),
+        _make_get_mock({"/billing/wallet": _wallet_payload()}, []),
     )
 
     result = CliRunner().invoke(app, ["wallet", "--output", "json"])
@@ -138,7 +138,7 @@ def test_wallet_passes_limit_and_uses_configured_team(
     calls: List[Dict[str, Any]] = []
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
-        _make_get_mock({"/wallet": _wallet_payload()}, calls),
+        _make_get_mock({"/billing/wallet": _wallet_payload()}, calls),
     )
     monkeypatch.setattr("prime_cli.core.Config.team_id", "team-cfg")
 
@@ -147,7 +147,7 @@ def test_wallet_passes_limit_and_uses_configured_team(
     assert result.exit_code == 0, result.output
     assert calls == [
         {
-            "endpoint": "/wallet",
+            "endpoint": "/billing/wallet",
             "params": {"limit": 5, "offset": 0, "teamId": "team-cfg"},
         }
     ]
@@ -164,7 +164,7 @@ def test_wallet_does_not_accept_team_flag() -> None:
 def test_wallet_handles_empty_billings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "prime_cli.core.APIClient.get",
-        _make_get_mock({"/wallet": _empty_wallet_payload()}, []),
+        _make_get_mock({"/billing/wallet": _empty_wallet_payload()}, []),
     )
 
     result = CliRunner().invoke(app, ["wallet"], env={"COLUMNS": "200"})

--- a/packages/prime/tests/test_wallet_cli.py
+++ b/packages/prime/tests/test_wallet_cli.py
@@ -153,6 +153,49 @@ def test_wallet_passes_limit_and_uses_configured_team(
     ]
 
 
+def test_wallet_header_falls_back_to_team_id_when_env_overrides_team(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When PRIME_TEAM_ID env-overrides team_id, config.team_name is for a
+    different team and would mislead the audit header — the table must show
+    the env-sourced id, not the stale name from ~/.prime/config.json.
+    """
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/wallet": _wallet_payload()}, []),
+    )
+    monkeypatch.setattr("prime_cli.core.Config.team_id", "team-from-env")
+    monkeypatch.setattr("prime_cli.core.Config.team_name", "stale-name-from-file")
+    monkeypatch.setattr("prime_cli.core.Config.team_id_from_env", True)
+
+    result = CliRunner().invoke(app, ["wallet"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "team-from-env" in plain
+    assert "stale-name-from-file" not in plain
+
+
+def test_wallet_header_uses_team_name_when_not_env_sourced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the team comes from the config file (not env), team_name is
+    trustworthy and should be displayed for readability."""
+    monkeypatch.setattr(
+        "prime_cli.core.APIClient.get",
+        _make_get_mock({"/billing/wallet": _wallet_payload()}, []),
+    )
+    monkeypatch.setattr("prime_cli.core.Config.team_id", "team-from-file")
+    monkeypatch.setattr("prime_cli.core.Config.team_name", "Acme Inc")
+    monkeypatch.setattr("prime_cli.core.Config.team_id_from_env", False)
+
+    result = CliRunner().invoke(app, ["wallet"], env={"COLUMNS": "200"})
+
+    assert result.exit_code == 0, result.output
+    plain = strip_ansi(result.output)
+    assert "Acme Inc" in plain
+
+
 def test_wallet_does_not_accept_team_flag() -> None:
     """`--team` is intentionally not supported — must follow the configured team."""
     result = CliRunner().invoke(app, ["wallet", "--team", "team-1"])


### PR DESCRIPTION
Adds a new `prime usage` command group so an agent can watch the price of an RFT run without scraping the dashboard.

- `prime usage run <run_id>` — tokens + cost for a single run; `--watch` polls in place; `--output json` for agents
- `prime usage summary --period this_month|7_days|last_month|6_months` — aggregated tokens + cost per area (training, inference, compute, disks, images), sandbox excluded

Backed by new `/api/v1/billing/*` endpoints in platform: PrimeIntellect-ai/platform#1801.

Note: prime-cli has no `develop` branch — targeting `main` per repo convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new billing-related CLI commands and API clients, plus changes global JSON rendering (no line wrapping) and currency formatting; low security impact but could affect existing JSON consumers and error handling paths.
> 
> **Overview**
> Adds billing visibility to the CLI via new commands: `prime train usage` (with optional `--watch` polling and JSON output) to show per-run token usage, pricing, and costs, and a new top-level `prime wallet` command to show wallet balance plus recent billing rows.
> 
> Introduces typed Pydantic models and thin clients for new `/api/v1/billing/*` endpoints, with explicit behavior to *preserve typed `APIError` subclasses* while wrapping unexpected exceptions/response-shape drift as `APIError` for clean CLI messaging.
> 
> Improves output utilities to keep JSON output unwrapped (`soft_wrap=True`) and adds `format_usd` for more precise display of sub-cent amounts; includes comprehensive CLI tests covering rendering, JSON shape, escaping, and error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5ffee73fb165242404f6c74b68898b8012c9a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->