### PR TITLE
Fix eval push verifiers upload parity

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -77,19 +77,19 @@ class EvalsClient:
 
     def _resolve_environment_id(self, env_name: str) -> str:
         """
-        Resolve environment ID by name (get-or-create behavior).
+        Lookup environment ID by name without creating an environment.
         Only used when no owner slug is provided.
 
         Raises:
             EvalsAPIError: If the environment does not exist (404)
         """
         try:
-            resolve_data: Dict[str, Any] = {"name": env_name}
+            lookup_data: Dict[str, Any] = {"name": env_name}
 
             if self.client.config.team_id:
-                resolve_data["team_id"] = self.client.config.team_id
+                lookup_data["team_id"] = self.client.config.team_id
 
-            response = self.client.post("/environmentshub/resolve", json=resolve_data)
+            response = self.client.post("/environmentshub/lookup", json=lookup_data)
             return response["data"]["id"]
 
         except APIError as e:
@@ -124,7 +124,7 @@ class EvalsClient:
                     owner_slug, name = slug.split("/", 1)
                     resolved_env["id"] = self._lookup_environment_by_slug(owner_slug, name)
                 elif "name" in resolved_env:
-                    # Just a name, resolve to database ID (get-or-create)
+                    # Just a name, lookup to database ID without creating an environment
                     resolved_env["id"] = self._resolve_environment_id(resolved_env.pop("name"))
                 elif "id" in resolved_env:
                     # "id" key exists - validate it exists in the hub via lookup
@@ -155,32 +155,27 @@ class EvalsClient:
         metrics: Optional[Dict[str, Any]] = None,
         is_public: Optional[bool] = None,
     ) -> Dict[str, Any]:
-        """Create a new evaluation
+        """Create a new evaluation.
 
-        Either run_id or environments must be provided.
-        Environments should be a list of dicts with 'id' and optional 'version_id'.
+        Environment associations are optional. When provided, environments should be a list of
+        dicts with 'id' and optional 'version_id'.
 
         Example: [{"id": "simpleqa", "version_id": "v1"}]
 
         Raises:
-            InvalidEvaluationError: If neither run_id nor environments is provided
+            InvalidEvaluationError: If environment identifiers are provided but none resolve
+                and no run_id is provided
         """
-        if not run_id and not environments:
-            raise InvalidEvaluationError(
-                "Either 'run_id' or 'environments' must be provided. "
-                "For environment evals, provide environments=[{'id': 'env-id', 'version_id': 'v1'}]"
-            )
-
         resolved_environments = None
         if environments:
             resolved_environments = self._resolve_environments(environments)
 
-            # Validate that we have at least one resolved environment if run_id is not provided
             # This check happens AFTER resolution to catch cases where all environments were invalid
             if not resolved_environments and not run_id:
                 raise InvalidEvaluationError(
                     "All provided environments lack valid identifiers (slug, name, or id). "
-                    "Either provide valid environment identifiers or provide a 'run_id'. "
+                    "Either provide valid environment identifiers, provide a 'run_id', "
+                    "or omit 'environments'. "
                 )
 
         payload = {
@@ -421,19 +416,19 @@ class AsyncEvalsClient:
 
     async def _resolve_environment_id(self, env_name: str) -> str:
         """
-        Resolve environment ID by name (get-or-create behavior).
+        Lookup environment ID by name without creating an environment.
         Only used when no owner slug is provided.
 
         Raises:
             EvalsAPIError: If the environment does not exist (404)
         """
         try:
-            resolve_data: Dict[str, Any] = {"name": env_name}
+            lookup_data: Dict[str, Any] = {"name": env_name}
 
             if self.client.config.team_id:
-                resolve_data["team_id"] = self.client.config.team_id
+                lookup_data["team_id"] = self.client.config.team_id
 
-            response = await self.client.post("/environmentshub/resolve", json=resolve_data)
+            response = await self.client.post("/environmentshub/lookup", json=lookup_data)
             return response["data"]["id"]
 
         except APIError as e:
@@ -467,7 +462,7 @@ class AsyncEvalsClient:
                     owner_slug, name = slug.split("/", 1)
                     resolved_env["id"] = await self._lookup_environment_by_slug(owner_slug, name)
                 elif "name" in resolved_env:
-                    # Just a name, resolve to database ID (get-or-create)
+                    # Just a name, lookup to database ID without creating an environment
                     resolved_env["id"] = await self._resolve_environment_id(
                         resolved_env.pop("name")
                     )
@@ -505,32 +500,27 @@ class AsyncEvalsClient:
         metrics: Optional[Dict[str, Any]] = None,
         is_public: Optional[bool] = None,
     ) -> Dict[str, Any]:
-        """Create a new evaluation
+        """Create a new evaluation.
 
-        Either run_id or environments must be provided.
-        Environments should be a list of dicts with 'id' and optional 'version_id'.
+        Environment associations are optional. When provided, environments should be a list of
+        dicts with 'id' and optional 'version_id'.
 
         Example: [{"id": "simpleqa", "version_id": "v1"}]
 
         Raises:
-            InvalidEvaluationError: If neither run_id nor environments is provided
+            InvalidEvaluationError: If environment identifiers are provided but none resolve
+                and no run_id is provided
         """
-        if not run_id and not environments:
-            raise InvalidEvaluationError(
-                "Either 'run_id' or 'environments' must be provided. "
-                "For environment evals, provide environments=[{'id': 'env-id', 'version_id': 'v1'}]"
-            )
-
         resolved_environments = None
         if environments:
             resolved_environments = await self._resolve_environments(environments)
 
-            # Validate that we have at least one resolved environment if run_id is not provided
             # This check happens AFTER resolution to catch cases where all environments were invalid
             if not resolved_environments and not run_id:
                 raise InvalidEvaluationError(
                     "All provided environments lack valid identifiers (slug, name, or id). "
-                    "Either provide valid environment identifiers or provide a 'run_id'. "
+                    "Either provide valid environment identifiers, provide a 'run_id', "
+                    "or omit 'environments'. "
                 )
 
         payload = {

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -64,10 +64,7 @@ class EvalsClient:
             EvalsAPIError: If the environment does not exist (404)
         """
         try:
-            # Try team_slug first (lookup endpoint supports team_slug)
-            # If owner is not a team, backend will handle it appropriately
-            lookup_data: Dict[str, Any] = {"name": name, "team_slug": owner_slug}
-            response = self.client.post("/environmentshub/lookup", json=lookup_data)
+            response = self.client.get(f"/environmentshub/{owner_slug}/{name}/@latest")
             return response["data"]["id"]
         except APIError as e:
             raise EvalsAPIError(
@@ -403,10 +400,7 @@ class AsyncEvalsClient:
             EvalsAPIError: If the environment does not exist (404)
         """
         try:
-            # Try team_slug first (lookup endpoint supports team_slug)
-            # If owner is not a team, backend will handle it appropriately
-            lookup_data: Dict[str, Any] = {"name": name, "team_slug": owner_slug}
-            response = await self.client.post("/environmentshub/lookup", json=lookup_data)
+            response = await self.client.get(f"/environmentshub/{owner_slug}/{name}/@latest")
             return response["data"]["id"]
         except APIError as e:
             raise EvalsAPIError(

--- a/packages/prime-evals/tests/test_evals.py
+++ b/packages/prime-evals/tests/test_evals.py
@@ -41,6 +41,67 @@ def test_create_evaluation_request_with_metadata():
     assert request.metadata == metadata
 
 
+class _FakeConfig:
+    team_id = "team-123"
+
+
+class _FakeAPIClient:
+    def __init__(self):
+        self.config = _FakeConfig()
+        self.calls = []
+
+    def post(self, path, json):
+        self.calls.append(("post", path, json))
+        if path == "/environmentshub/lookup":
+            return {"data": {"id": "env-123"}}
+        raise AssertionError(f"unexpected POST {path}")
+
+    def request(self, method, path, json):
+        self.calls.append(("request", method, path, json))
+        return {"evaluation_id": "eval-123"}
+
+
+def test_create_evaluation_allows_dataset_only_without_environment_resolution():
+    """Dataset-only evaluations should not resolve or create environments."""
+    api_client = _FakeAPIClient()
+    client = EvalsClient(api_client)
+
+    response = client.create_evaluation(
+        name="test-evaluation",
+        model_name="gpt-4o-mini",
+        dataset="gsm8k",
+    )
+
+    assert response == {"evaluation_id": "eval-123"}
+    assert [call for call in api_client.calls if call[0] == "post"] == []
+    request_payload = next(call[3] for call in api_client.calls if call[0] == "request")
+    assert request_payload["dataset"] == "gsm8k"
+    assert "environments" not in request_payload
+
+
+def test_create_evaluation_name_lookup_does_not_resolve_or_create_environment():
+    """Name environment refs must use lookup-only semantics, not get-or-create resolve."""
+    api_client = _FakeAPIClient()
+    client = EvalsClient(api_client)
+
+    response = client.create_evaluation(
+        name="test-evaluation",
+        environments=[{"name": "gsm8k"}],
+        model_name="gpt-4o-mini",
+        dataset="gsm8k",
+    )
+
+    assert response == {"evaluation_id": "eval-123"}
+    assert (
+        "post",
+        "/environmentshub/lookup",
+        {"name": "gsm8k", "team_id": "team-123"},
+    ) in api_client.calls
+    assert not any(call[1] == "/environmentshub/resolve" for call in api_client.calls)
+    request_payload = next(call[3] for call in api_client.calls if call[0] == "request")
+    assert request_payload["environments"] == [{"id": "env-123"}]
+
+
 def test_evaluation_status_enum():
     """Test EvaluationStatus enum values"""
     assert EvaluationStatus.PENDING == "PENDING"

--- a/packages/prime-evals/tests/test_evals.py
+++ b/packages/prime-evals/tests/test_evals.py
@@ -56,6 +56,12 @@ class _FakeAPIClient:
             return {"data": {"id": "env-123"}}
         raise AssertionError(f"unexpected POST {path}")
 
+    def get(self, path):
+        self.calls.append(("get", path))
+        if path == "/environmentshub/owner/gsm8k/@latest":
+            return {"data": {"id": "env-slug-123"}}
+        raise AssertionError(f"unexpected GET {path}")
+
     def request(self, method, path, json):
         self.calls.append(("request", method, path, json))
         return {"evaluation_id": "eval-123"}
@@ -100,6 +106,25 @@ def test_create_evaluation_name_lookup_does_not_resolve_or_create_environment():
     assert not any(call[1] == "/environmentshub/resolve" for call in api_client.calls)
     request_payload = next(call[3] for call in api_client.calls if call[0] == "request")
     assert request_payload["environments"] == [{"id": "env-123"}]
+
+
+def test_create_evaluation_slug_lookup_uses_owner_detail_endpoint():
+    """Owner/name refs must support both user and team owners without creating envs."""
+    api_client = _FakeAPIClient()
+    client = EvalsClient(api_client)
+
+    response = client.create_evaluation(
+        name="test-evaluation",
+        environments=[{"slug": "owner/gsm8k"}],
+        model_name="gpt-4o-mini",
+        dataset="owner/gsm8k",
+    )
+
+    assert response == {"evaluation_id": "eval-123"}
+    assert ("get", "/environmentshub/owner/gsm8k/@latest") in api_client.calls
+    assert not any(call[1] == "/environmentshub/resolve" for call in api_client.calls)
+    request_payload = next(call[3] for call in api_client.calls if call[0] == "request")
+    assert request_payload["environments"] == [{"id": "env-slug-123"}]
 
 
 def test_evaluation_status_enum():

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import re
 import time
 from functools import wraps
 from pathlib import Path
@@ -23,7 +22,11 @@ from ..utils import (
 )
 from ..utils.display import get_eval_viewer_url
 from ..utils.env_metadata import find_environment_metadata
-from ..utils.eval_push import load_results_jsonl
+from ..utils.eval_push import (
+    extract_verifiers_metrics,
+    load_results_jsonl,
+    normalize_verifiers_result_samples,
+)
 from ..utils.hosted_eval import (
     EvalStatus,
     HostedEvalConfig,
@@ -903,26 +906,13 @@ def _load_eval_directory(directory: Path) -> dict:
 
     results = load_results_jsonl(directory / "results.jsonl")
 
-    for sample in results:
-        if "id" in sample and "example_id" not in sample:
-            sample["example_id"] = sample["id"]
-
-    avg_pattern = re.compile(r"^avg_(.+)$")
-    metrics = {}
-    metadata_copy = {}
-    for key, value in metadata.items():
-        if match := avg_pattern.match(key):
-            metrics[match.group(1)] = value
-        else:
-            metadata_copy[key] = value
-
     return {
         "eval_name": f"{env_field}-{metadata['model']}",
         "model_name": metadata["model"],
         "env": env_field,
-        "metrics": metrics,
-        "metadata": metadata_copy,
-        "results": results,
+        "metrics": extract_verifiers_metrics(metadata),
+        "metadata": {"framework": "verifiers", **metadata},
+        "results": normalize_verifiers_result_samples(results),
     }
 
 
@@ -1031,6 +1021,7 @@ def _push_single_eval(
                 evaluation_id=eval_id,
                 name=eval_name,
                 model_name=eval_data.get("model_name"),
+                dataset=eval_data.get("env"),
                 framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
                 task_type=eval_data.get("metadata", {}).get("task_type"),
                 metadata=eval_data.get("metadata"),
@@ -1049,6 +1040,7 @@ def _push_single_eval(
             environments=environments,
             run_id=run_id,
             model_name=eval_data.get("model_name"),
+            dataset=eval_data.get("env"),
             framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
             task_type=eval_data.get("metadata", {}).get("task_type"),
             metadata=eval_data.get("metadata"),

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -977,6 +977,18 @@ def _resolve_eval_viewer_url(evaluation_id: str, response: Optional[dict[str, An
     return get_eval_viewer_url(evaluation_id)
 
 
+def _eval_push_environments(env_ref: Optional[str]) -> Optional[list[dict[str, str]]]:
+    """Return lookup-only environment refs for eval push.
+
+    Bare environment names are dataset labels only: resolving them through the evals SDK uses
+    environmenthub get-or-create semantics in older clients, which can create partial environment
+    records during `prime eval push`.
+    """
+    if not env_ref or "/" not in env_ref:
+        return None
+    return [{"slug": env_ref}]
+
+
 def _push_single_eval(
     config_path: str,
     env_slug: Optional[str],
@@ -990,20 +1002,12 @@ def _push_single_eval(
     eval_name = name or eval_data["eval_name"]
     console.print(f"[blue]✓ Loaded eval data:[/blue] {path}")
 
-    detected_env = eval_data.get("env_id") or eval_data.get("env")
-    if not env_slug and detected_env and not run_id and not eval_id:
-        env_slug = detected_env
-
+    detected_env = eval_data.get("env")
+    dataset = env_slug or detected_env
+    environment_ref = env_slug or detected_env
     environments = None
-    if env_slug and not run_id and not eval_id:
-        # Determine if env_slug is a slug (owner/name) or a name
-        # Use appropriate key so _resolve_environments can properly resolve it
-        if "/" in env_slug:
-            # It's a slug (owner/name format)
-            environments = [{"slug": env_slug}]
-        else:
-            # It's a name (will be resolved by _resolve_environments)
-            environments = [{"name": env_slug}]
+    if not run_id and not eval_id:
+        environments = _eval_push_environments(environment_ref)
 
     console.print()
 
@@ -1021,7 +1025,7 @@ def _push_single_eval(
                 evaluation_id=eval_id,
                 name=eval_name,
                 model_name=eval_data.get("model_name"),
-                dataset=eval_data.get("env"),
+                dataset=dataset,
                 framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
                 task_type=eval_data.get("metadata", {}).get("task_type"),
                 metadata=eval_data.get("metadata"),
@@ -1040,7 +1044,7 @@ def _push_single_eval(
             environments=environments,
             run_id=run_id,
             model_name=eval_data.get("model_name"),
-            dataset=eval_data.get("env"),
+            dataset=dataset,
             framework=eval_data.get("metadata", {}).get("framework", "verifiers"),
             task_type=eval_data.get("metadata", {}).get("task_type"),
             metadata=eval_data.get("metadata"),

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -51,6 +51,22 @@ def load_results_jsonl(path: Path) -> list[dict]:
     return results
 
 
+def extract_verifiers_metrics(metadata: dict) -> dict:
+    return {k: v for k, v in metadata.items() if k.startswith("avg_")}
+
+
+def normalize_verifiers_result_sample(sample: dict) -> dict:
+    return {
+        "example_id": sample.get("id", 0),
+        "reward": sample.get("reward", 0.0),
+        **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
+    }
+
+
+def normalize_verifiers_result_samples(samples: list[dict]) -> list[dict]:
+    return [normalize_verifiers_result_sample(sample) for sample in samples]
+
+
 def push_eval_results_to_hub(
     env_name: str,
     model: str,
@@ -175,18 +191,11 @@ def push_eval_results_to_hub(
             environments = [{"slug": resolved_env_slug}]
     else:
         raise ValueError("No valid environment identifier found")
-    metrics = {k: v for k, v in metadata.items() if k.startswith("avg_")}
+    metrics = extract_verifiers_metrics(metadata)
 
     eval_metadata = {"framework": "verifiers", "job_id": job_id, **metadata}
 
-    converted_results = [
-        {
-            "example_id": sample.get("id", 0),
-            "reward": sample.get("reward", 0.0),
-            **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
-        }
-        for sample in results_samples
-    ]
+    converted_results = normalize_verifiers_result_samples(results_samples)
 
     eval_name = f"{env_name}--{model}--{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 

--- a/packages/prime/src/prime_cli/utils/eval_push.py
+++ b/packages/prime/src/prime_cli/utils/eval_push.py
@@ -55,12 +55,97 @@ def extract_verifiers_metrics(metadata: dict) -> dict:
     return {k: v for k, v in metadata.items() if k.startswith("avg_")}
 
 
+_SAMPLE_FIELD_ALIASES = {
+    "exampleId": "example_id",
+    "rolloutNumber": "rollout_number",
+    "numSteps": "num_steps",
+    "totalTime": "total_time",
+    "latencyMs": "latency_ms",
+}
+
+_STANDARD_SAMPLE_FIELDS = {
+    "evaluation_id",
+    "sample_id",
+    "example_id",
+    "reward",
+    "task",
+    "prompt",
+    "completion",
+    "answer",
+    "score",
+    "correct",
+    "num_steps",
+    "total_time",
+    "latency_ms",
+    "rollout_number",
+}
+
+_RESERVED_RESULT_KEYS = {
+    "id",
+    "info",
+    "metadata",
+    *_STANDARD_SAMPLE_FIELDS,
+    *_SAMPLE_FIELD_ALIASES,
+}
+
+
+def _numeric_or_none(value: object) -> float | int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return None
+
+
+def _timing_total_time(timing: object) -> float | None:
+    if not isinstance(timing, dict):
+        return None
+
+    timing_dict = {str(key): value for key, value in timing.items()}
+
+    total_ms = _numeric_or_none(timing_dict.get("total_ms"))
+    if total_ms is None:
+        total_ms = _numeric_or_none(timing_dict.get("totalMs"))
+    if total_ms is not None:
+        return float(total_ms) / 1000.0
+
+    total = _numeric_or_none(timing_dict.get("total"))
+    return float(total) if total is not None else None
+
+
 def normalize_verifiers_result_sample(sample: dict) -> dict:
-    return {
-        "example_id": sample.get("id", 0),
+    normalized = {
+        "example_id": sample.get("example_id", sample.get("exampleId", sample.get("id", 0))),
         "reward": sample.get("reward", 0.0),
-        **{k: v for k, v in sample.items() if k not in {"id", "reward"}},
     }
+
+    for key in _STANDARD_SAMPLE_FIELDS - {"example_id", "reward"}:
+        if key in sample:
+            normalized[key] = sample[key]
+
+    for source_key, target_key in _SAMPLE_FIELD_ALIASES.items():
+        if source_key in sample and target_key not in normalized:
+            normalized[target_key] = sample[source_key]
+
+    timing_total_time = _timing_total_time(sample.get("timing"))
+    if timing_total_time is not None:
+        normalized.setdefault("total_time", timing_total_time)
+        normalized.setdefault("latency_ms", int(round(timing_total_time * 1000)))
+
+    info = {}
+    for key in ("metadata", "info"):
+        value = sample.get(key)
+        if isinstance(value, dict):
+            info.update(value)
+
+    for key, value in sample.items():
+        if key not in _RESERVED_RESULT_KEYS:
+            info.setdefault(key, value)
+
+    if info:
+        normalized["info"] = info
+
+    return normalized
 
 
 def normalize_verifiers_result_samples(samples: list[dict]) -> list[dict]:

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -211,6 +211,35 @@ class TestPushSingleEval:
         assert eval_id == "eval-123"
         assert captured["is_public"] is False
         assert captured["dataset"] == "gsm8k"
+        assert captured["environments"] is None
+
+    def test_create_evaluation_links_only_owner_slug_environment(self, tmp_path, monkeypatch):
+        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        captured = {}
+
+        class DummyEvalsClient:
+            def __init__(self, _api_client):
+                pass
+
+            def create_evaluation(self, **kwargs):
+                captured.update(kwargs)
+                return {"evaluation_id": "eval-123"}
+
+            def finalize_evaluation(self, evaluation_id, metrics=None):
+                captured["finalized_evaluation_id"] = evaluation_id
+                captured["finalized_metrics"] = metrics
+
+        monkeypatch.setattr("prime_cli.commands.evals.APIClient", lambda: object())
+        monkeypatch.setattr("prime_cli.commands.evals.EvalsClient", DummyEvalsClient)
+
+        eval_id = _push_single_eval(str(tmp_path), "owner/gsm8k", None, None)
+
+        assert eval_id == "eval-123"
+        assert captured["dataset"] == "owner/gsm8k"
+        assert captured["environments"] == [{"slug": "owner/gsm8k"}]
 
     def test_create_evaluation_passes_public_flag(self, tmp_path, monkeypatch):
         metadata = {"env": "gsm8k", "model": "gpt-4"}

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -210,6 +210,7 @@ class TestPushSingleEval:
 
         assert eval_id == "eval-123"
         assert captured["is_public"] is False
+        assert captured["dataset"] == "gsm8k"
 
     def test_create_evaluation_passes_public_flag(self, tmp_path, monkeypatch):
         metadata = {"env": "gsm8k", "model": "gpt-4"}
@@ -385,7 +386,8 @@ class TestLoadEvalDirectory:
         assert data["eval_name"] == "gsm8k-gpt-4"
         assert data["model_name"] == "gpt-4"
         assert data["env"] == "gsm8k"
-        assert data["metrics"] == {"reward": 0.85, "accuracy": 0.9}
+        assert data["metrics"] == {"avg_reward": 0.85, "avg_accuracy": 0.9}
+        assert data["metadata"]["avg_reward"] == 0.85
         assert data["metadata"]["num_examples"] == 100
         assert len(data["results"]) == 2
         assert data["results"][0]["example_id"] == 0
@@ -477,7 +479,7 @@ class TestLoadEvalDirectory:
         data = _load_eval_directory(tmp_path)
 
         assert data["results"][0]["example_id"] == 42
-        assert data["results"][0]["id"] == 42  # Original field preserved
+        assert "id" not in data["results"][0]
 
     def test_extracts_avg_metrics(self, tmp_path):
         """Extracts avg_* fields into metrics dict"""
@@ -495,11 +497,11 @@ class TestLoadEvalDirectory:
         data = _load_eval_directory(tmp_path)
 
         assert data["metrics"] == {
-            "reward": 0.75,
-            "correctness": 0.8,
-            "format_reward": 0.95,
+            "avg_reward": 0.75,
+            "avg_correctness": 0.8,
+            "avg_format_reward": 0.95,
         }
-        assert "avg_reward" not in data["metadata"]
+        assert data["metadata"]["avg_reward"] == 0.75
         assert data["metadata"]["other_field"] == "value"
 
     def test_invalid_metadata_json_raises(self, tmp_path):

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -481,6 +481,41 @@ class TestLoadEvalDirectory:
         assert data["results"][0]["example_id"] == 42
         assert "id" not in data["results"][0]
 
+    def test_preserves_rollout_viewer_state_in_info(self, tmp_path):
+        """Preserves vf-eval state fields in info for the rollout viewer."""
+        metadata = {"env": "test", "model": "test-model"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+
+        result = {
+            "id": 42,
+            "reward": 1.0,
+            "timing": {"total_ms": 1500, "generation_ms": 1200},
+            "token_usage": {"input_tokens": 10, "output_tokens": 20},
+            "trajectory": [{"reward": 1.0}],
+            "metrics": {"answer_reward": 1.0},
+            "is_completed": True,
+            "stop_condition": "done",
+            "turn": 2,
+            "metadata": {"source": "vf-eval"},
+        }
+        (tmp_path / "results.jsonl").write_text(json.dumps(result))
+
+        data = _load_eval_directory(tmp_path)
+        sample = data["results"][0]
+
+        assert sample["example_id"] == 42
+        assert sample["total_time"] == 1.5
+        assert sample["latency_ms"] == 1500
+        assert "timing" not in sample
+        assert sample["info"]["timing"] == {"total_ms": 1500, "generation_ms": 1200}
+        assert sample["info"]["token_usage"] == {"input_tokens": 10, "output_tokens": 20}
+        assert sample["info"]["trajectory"] == [{"reward": 1.0}]
+        assert sample["info"]["metrics"] == {"answer_reward": 1.0}
+        assert sample["info"]["is_completed"] is True
+        assert sample["info"]["stop_condition"] == "done"
+        assert sample["info"]["turn"] == 2
+        assert sample["info"]["source"] == "vf-eval"
+
     def test_extracts_avg_metrics(self, tmp_path):
         """Extracts avg_* fields into metrics dict"""
         metadata = {


### PR DESCRIPTION
## Summary
- Reuse the same verifiers result normalization for automatic uploads and `prime eval push`.
- Preserve rollout viewer data by carrying non-standard vf-eval fields such as `timing`, `token_usage`, `trajectory`, status flags, and state columns through `info`.
- Keep `avg_*` metrics and metadata intact for manually pushed `vf-eval` outputs.
- Set the evaluation dataset from the pushed environment, matching automatic `prime eval run` uploads.

## Validation
- `uv run pytest packages/prime/tests -q`
- `uv run ruff check packages/prime/src/prime_cli/commands/evals.py packages/prime/src/prime_cli/utils/eval_push.py packages/prime/tests/test_eval_push.py`
- `uv run ty check packages/prime/src packages/prime/tests/test_eval_push.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes environment resolution semantics in the Evals SDK and `prime eval push`, which could affect how evaluations link to environments and may surface new 404/validation errors for previously auto-created names.
> 
> **Overview**
> Aligns manual `prime eval push` uploads with automatic verifiers uploads by reusing shared normalization: `avg_*` metrics are extracted consistently, result samples are normalized (field aliases, timing-derived `total_time`/`latency_ms`), and non-standard vf-eval fields are preserved under `info`.
> 
> Prevents unintended environment creation during evaluation creation/push: the Evals SDK switches name-based environment resolution from `/environmentshub/resolve` to lookup-only `/environmentshub/lookup`, slug lookups use `GET /environmentshub/{owner}/{name}/@latest`, and `create_evaluation` now allows dataset-only evaluations (only erroring when `environments` are provided but none resolve). The CLI now treats bare env names as dataset labels and only links environments when an owner slug is provided, while also setting `dataset` from the pushed env reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61cbfdca3952afda0d461a141cee60b67e8f5f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->