### PR TITLE
Release prime CLI 0.5.79

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.78"
+__version__ = "0.5.79"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI to 0.5.79.

- Adds `prime train usage <run_id>` and `prime wallet` (#587)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the exported `__version__` constant, affecting version reporting/telemetry but not runtime behavior.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.78` to `0.5.79` by updating `prime_cli.__version__`, which is used by commands like `feedback` and `upgrade` when reporting the installed CLI version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73e10945c5da1a7aac05e52d9a9e639cc204478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->