### PR TITLE
prime images list pagination

### DIFF
--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -564,6 +564,10 @@ def list_images(
     all_images: bool = typer.Option(
         False, "--all", "-a", help="[Deprecated] Show all accessible images (personal + team)"
     ),
+    limit: int = typer.Option(
+        100, "--limit", "-l", min=0, max=250, help="Maximum images to return (max 250)"
+    ),
+    offset: int = typer.Option(0, "--offset", min=0, help="Number of images to skip"),
 ):
     """
     List all images you've pushed to Prime Intellect registry.
@@ -573,6 +577,8 @@ def list_images(
     \b
     Examples:
         prime images list
+        prime images list --limit 50
+        prime images list --limit 50 --offset 50
         prime images list --output json
     """
     validate_output_format(output, console)
@@ -587,12 +593,13 @@ def list_images(
         client = APIClient()
 
         # Build query params
-        params: dict[str, str] = {}
+        params: dict[str, str] = {"limit": str(limit), "offset": str(offset)}
         if config.team_id:
             params["teamId"] = config.team_id
 
-        response = client.request("GET", "/images", params=params if params else None)
+        response = client.request("GET", "/images", params=params)
         images: list[ImageRow] = response.get("data", [])
+        total_count: int = int(response.get("totalCount", len(images)))
 
         if not images:
             console.print("[yellow]No images or builds found.[/yellow]")
@@ -678,7 +685,20 @@ def list_images(
         console.print()
         console.print(table)
         console.print()
-        console.print(f"[dim]Total: {len(grouped)} image(s)[/dim]")
+        shown = len(images)
+        if total_count > shown or offset > 0:
+            start = offset + 1
+            end = offset + shown
+            footer = (
+                f"[dim]Showing {start}-{end} of {total_count} image(s) "
+                f"({len(grouped)} group(s))[/dim]"
+            )
+            console.print(footer)
+            if total_count > offset + shown:
+                next_offset = offset + limit
+                console.print(f"[dim]Use --offset {next_offset} to see more.[/dim]")
+        else:
+            console.print(f"[dim]Total: {len(grouped)} image(s)[/dim]")
         console.print()
 
     except UnauthorizedError:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -597,8 +597,6 @@ def list_images(
     try:
         client = APIClient()
 
-        # Backend speaks offset/limit; --page/--num is the user-facing convention
-        # (matches `prime sandbox list`). Translate here.
         offset = (page - 1) * num
 
         # Build query params

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -599,15 +599,21 @@ def list_images(
 
         response = client.request("GET", "/images", params=params)
         images: list[ImageRow] = response.get("data", [])
-        total_count: int = int(response.get("totalCount", len(images)))
-
-        if not images:
-            console.print("[yellow]No images or builds found.[/yellow]")
-            console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
-            return
+        total_count: int = int(response.get("totalCount", offset + len(images)))
 
         if output == "json":
             console.print(json.dumps(response, indent=2))
+            return
+
+        if not images:
+            if total_count == 0:
+                console.print("[yellow]No images or builds found.[/yellow]")
+                console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
+            else:
+                console.print(
+                    f"[yellow]No images at offset {offset}. Total: {total_count} image(s).[/yellow]"
+                )
+                console.print("Try [bold]--offset 0[/bold] to start from the beginning.")
             return
 
         # Table output

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -564,10 +564,8 @@ def list_images(
     all_images: bool = typer.Option(
         False, "--all", "-a", help="[Deprecated] Show all accessible images (personal + team)"
     ),
-    limit: int = typer.Option(
-        100, "--limit", "-l", min=1, max=250, help="Maximum images to return (max 250)"
-    ),
-    offset: int = typer.Option(0, "--offset", min=0, help="Number of images to skip"),
+    page: int = typer.Option(1, "--page", "-p", help="Page number"),
+    num: int = typer.Option(50, "--num", "-n", help="Items per page (max 250)"),
 ):
     """
     List all images you've pushed to Prime Intellect registry.
@@ -577,11 +575,18 @@ def list_images(
     \b
     Examples:
         prime images list
-        prime images list --limit 50
-        prime images list --limit 50 --offset 50
+        prime images list --num 100
+        prime images list --page 2
         prime images list --output json
     """
     validate_output_format(output, console)
+
+    if num < 1 or page < 1:
+        console.print("[red]Error:[/red] --num and --page must be at least 1")
+        raise typer.Exit(1)
+    if num > 250:
+        console.print("[red]Error:[/red] --num cannot exceed 250")
+        raise typer.Exit(1)
 
     if all_images and output != "json":
         console.print(
@@ -592,8 +597,12 @@ def list_images(
     try:
         client = APIClient()
 
+        # Backend speaks offset/limit; --page/--num is the user-facing convention
+        # (matches `prime sandbox list`). Translate here.
+        offset = (page - 1) * num
+
         # Build query params
-        params: dict[str, str] = {"limit": str(limit), "offset": str(offset)}
+        params: dict[str, str] = {"limit": str(num), "offset": str(offset)}
         if config.team_id:
             params["teamId"] = config.team_id
 
@@ -611,9 +620,9 @@ def list_images(
                 console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
             else:
                 console.print(
-                    f"[yellow]No images at offset {offset}. Total: {total_count} image(s).[/yellow]"
+                    f"[yellow]No images on page {page}. Total: {total_count} image(s).[/yellow]"
                 )
-                console.print("Try [bold]--offset 0[/bold] to start from the beginning.")
+                console.print("Try [bold]--page 1[/bold] to start from the beginning.")
             return
 
         # Table output
@@ -691,20 +700,18 @@ def list_images(
         console.print()
         console.print(table)
         console.print()
-        shown = len(images)
-        if total_count > shown or offset > 0:
+        shown_groups = len(grouped)
+        has_next = offset + shown_groups < total_count
+        if has_next or page > 1:
             start = offset + 1
-            end = offset + shown
-            footer = (
-                f"[dim]Showing {start}-{end} of {total_count} image(s) "
-                f"({len(grouped)} group(s))[/dim]"
+            end = offset + shown_groups
+            console.print(
+                f"[dim]Page {page} • showing {start}-{end} of {total_count} image(s)[/dim]"
             )
-            console.print(footer)
-            if total_count > offset + shown:
-                next_offset = offset + limit
-                console.print(f"[dim]Use --offset {next_offset} to see more.[/dim]")
+            if has_next:
+                console.print(f"[dim]Use --page {page + 1} to see more.[/dim]")
         else:
-            console.print(f"[dim]Total: {len(grouped)} image(s)[/dim]")
+            console.print(f"[dim]Total: {shown_groups} image(s)[/dim]")
         console.print()
 
     except UnauthorizedError:

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -608,6 +608,7 @@ def list_images(
 
         response = client.request("GET", "/images", params=params)
         images: list[ImageRow] = response.get("data", [])
+        has_total_count: bool = "totalCount" in response
         total_count: int = int(response.get("totalCount", offset + len(images)))
 
         if output == "json":
@@ -615,14 +616,20 @@ def list_images(
             return
 
         if not images:
-            if total_count == 0:
+            if has_total_count and total_count == 0:
                 console.print("[yellow]No images or builds found.[/yellow]")
                 console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
-            else:
+            elif has_total_count:
                 console.print(
                     f"[yellow]No images on page {page}. Total: {total_count} image(s).[/yellow]"
                 )
                 console.print("Try [bold]--page 1[/bold] to start from the beginning.")
+            elif page > 1:
+                console.print(f"[yellow]No images on page {page}.[/yellow]")
+                console.print("Try [bold]--page 1[/bold] to start from the beginning.")
+            else:
+                console.print("[yellow]No images or builds found.[/yellow]")
+                console.print("Push an image with: [bold]prime images push <name>:<tag>[/bold]")
             return
 
         # Table output
@@ -701,15 +708,23 @@ def list_images(
         console.print(table)
         console.print()
         shown_groups = len(grouped)
-        has_next = offset + shown_groups < total_count
+        if has_total_count:
+            has_next = offset + shown_groups < total_count
+        else:
+            has_next = shown_groups >= num
         if has_next or page > 1:
             start = offset + 1
             end = offset + shown_groups
-            console.print(
-                f"[dim]Page {page} • showing {start}-{end} of {total_count} image(s)[/dim]"
-            )
+            if has_total_count:
+                console.print(
+                    f"[dim]Page {page} • showing {start}-{end} of {total_count} image(s)[/dim]"
+                )
+            else:
+                console.print(f"[dim]Page {page} • showing {start}-{end}[/dim]")
             if has_next:
                 console.print(f"[dim]Use --page {page + 1} to see more.[/dim]")
+        elif has_total_count:
+            console.print(f"[dim]Total: {total_count} image(s)[/dim]")
         else:
             console.print(f"[dim]Total: {shown_groups} image(s)[/dim]")
         console.print()

--- a/packages/prime/src/prime_cli/commands/images.py
+++ b/packages/prime/src/prime_cli/commands/images.py
@@ -565,7 +565,7 @@ def list_images(
         False, "--all", "-a", help="[Deprecated] Show all accessible images (personal + team)"
     ),
     limit: int = typer.Option(
-        100, "--limit", "-l", min=0, max=250, help="Maximum images to return (max 250)"
+        100, "--limit", "-l", min=1, max=250, help="Maximum images to return (max 250)"
     ),
     offset: int = typer.Option(0, "--offset", min=0, help="Number of images to skip"),
 ):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the `prime images list` API query to always send `limit/offset` and adds pagination logic, which could affect results/order and relies on backend pagination/`totalCount` behavior.
> 
> **Overview**
> Adds **pagination support** to `prime images list` via new `--page` and `--num` options, translating them into `limit`/`offset` query params on `GET /images` (with validation and a max of 250 per page).
> 
> Updates table-mode output to handle empty pages more explicitly and to show page ranges/next-page hints, using `totalCount` when present in the API response (while leaving JSON output as the raw response).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755aabd51d754794906636d25df8641c773761f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->