### PR TITLE
[codex] Add parameter-aware Hosted Training model sorting

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import time
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
@@ -99,6 +100,30 @@ LEVEL_STYLES = {
 
 # Sentinel to indicate "this is JSON but should be skipped"
 _SKIP_LINE = "__SKIP__"
+
+_MODEL_PARAM_COUNT_PATTERN = re.compile(
+    r"-(?P<total>\d+(?:\.\d)?)[bB](?:-[aA](?P<active>\d+(?:\.\d)?)[bB])?(?=$|-)"
+)
+
+
+def _model_name_sort_key(name: str) -> tuple[tuple[Any, ...], ...]:
+    """Sort model names lexically, with recognized billion-parameter counts numeric."""
+    segments: list[tuple[Any, ...]] = []
+    start = 0
+
+    for match in _MODEL_PARAM_COUNT_PATTERN.finditer(name):
+        if match.start() > start:
+            segments.append((0, name[start : match.start()]))
+
+        total_params = Decimal(match.group("total"))
+        active_params = Decimal(match.group("active") or match.group("total"))
+        segments.append((1, total_params, active_params))
+        start = match.end()
+
+    if start < len(name):
+        segments.append((0, name[start:]))
+
+    return tuple(segments)
 
 
 def format_json_log_line(line: str) -> str | None:
@@ -1160,7 +1185,7 @@ def list_models(
         table.add_column("Train", style="green", justify="right")
 
         promo_labels: List[str] = []
-        for model in models:
+        for model in sorted(models, key=lambda model: _model_name_sort_key(model.name)):
             if model.at_capacity:
                 status = "[red]At Capacity[/red]"
             else:

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -4,6 +4,7 @@ import json
 from typing import Any, Dict, List
 
 import pytest
+from prime_cli.commands.rl import _model_name_sort_key
 from prime_cli.main import app
 from prime_cli.utils.formatters import strip_ansi
 from typer.testing import CliRunner
@@ -290,3 +291,57 @@ def test_models_json_includes_effective_fields(monkeypatch: pytest.MonkeyPatch) 
     assert data["models"][0]["effective_inference_input_price_per_mtok"] == 0.0
     assert data["models"][0]["effective_inference_output_price_per_mtok"] == 0.0
     assert data["models"][0]["promo_label"] == "Free RFT week"
+
+
+def test_model_name_sort_key_orders_parameter_counts_numerically() -> None:
+    models = [
+        "Qwen/Qwen3-30B-A3B-Instruct-2507",
+        "Qwen/Qwen3-4B-Instruct-2507",
+        "Qwen/Qwen3-4B-Thinking-2507",
+        "Qwen/Qwen3.5-0.8B",
+        "Qwen/Qwen3.5-122B-A10B",
+        "Qwen/Qwen3.5-2B",
+        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.5-397B-A17B",
+        "Qwen/Qwen3.5-4B",
+        "Qwen/Qwen3.5-9B",
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "meta-llama/Llama-3.2-3B-Instruct",
+        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
+    ]
+
+    assert sorted(models, key=_model_name_sort_key) == [
+        "Qwen/Qwen3-4B-Instruct-2507",
+        "Qwen/Qwen3-4B-Thinking-2507",
+        "Qwen/Qwen3-30B-A3B-Instruct-2507",
+        "Qwen/Qwen3.5-0.8B",
+        "Qwen/Qwen3.5-2B",
+        "Qwen/Qwen3.5-4B",
+        "Qwen/Qwen3.5-9B",
+        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.5-122B-A10B",
+        "Qwen/Qwen3.5-397B-A17B",
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "meta-llama/Llama-3.2-3B-Instruct",
+        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+        "openai/gpt-oss-20b",
+        "openai/gpt-oss-120b",
+    ]
+
+
+def test_model_name_sort_key_handles_active_params_case_insensitively() -> None:
+    models = [
+        "org/model-30B-A10b",
+        "org/model-30b-a3B",
+        "org/model-30B",
+    ]
+
+    assert sorted(models, key=_model_name_sort_key) == [
+        "org/model-30b-a3B",
+        "org/model-30B-A10b",
+        "org/model-30B",
+    ]


### PR DESCRIPTION
## Summary

Adds parameter-aware sorting for Hosted Training model names in `prime train models` table output. The sort remains lexical for normal name text, but treats recognized `-xxB` and `-xxB-AxxB` parameter segments as numeric values so names like `20b` sort before `120b` and `4B` sorts before `30B-A3B`.

## Impact

This keeps the model list easier to scan without changing JSON output ordering or API behavior.

## Validation

- `uv run --package prime pytest packages/prime/tests/test_rl_models.py`
- `uv run --package prime ruff check packages/prime/src/prime_cli/commands/rl.py packages/prime/tests/test_rl_models.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the display ordering of the Hosted Training `models` table output via a deterministic sort key, with added unit tests; no API calls, JSON schema, or pricing logic changes.
> 
> **Overview**
> Improves `prime train models` table readability by sorting model names with recognized parameter-count segments (e.g. `-20B`, `-120B-A12B`) numerically instead of purely lexically.
> 
> Adds `_model_name_sort_key` (regex + `Decimal`) to parse total/active billion-parameter counts case-insensitively, applies it to the table listing, and introduces tests covering numeric ordering and `AxxB` active-parameter handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa7b0c9cd34e4e30bdb7742e721400c98da232d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->