### PR TITLE
release: cli 0.5.81

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.80"
+__version__ = "0.5.81"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps the Prime CLI version from 0.5.80 to 0.5.81 for the next release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version string with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.80` to `0.5.81` in `prime_cli/__init__.py` for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf49807c12d68a4fa04bc44f6cc345b6bab491b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->