### PR TITLE
Add `prime train request` for Hosted Training model requests

### DIFF
--- a/packages/prime/src/prime_cli/commands/feedback.py
+++ b/packages/prime/src/prime_cli/commands/feedback.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import typer
 from click.exceptions import Abort
 
@@ -13,15 +15,17 @@ app = PlainTyper(
 )
 console = get_console()
 
+FeedbackCategory = Literal["bug", "feature", "general"]
 
-_CATEGORY_CHOICES: tuple[tuple[str, str], ...] = (
+
+_CATEGORY_CHOICES: tuple[tuple[FeedbackCategory, str], ...] = (
     ("bug", "Bug report"),
     ("feature", "Feature request"),
     ("general", "General feedback"),
 )
 
 
-def _prompt_category() -> str:
+def _prompt_category() -> FeedbackCategory:
     console.print("\n[bold]What are you sharing?[/bold]")
     for idx, (_, label) in enumerate(_CATEGORY_CHOICES, start=1):
         console.print(f"  [cyan]({idx})[/cyan] {label}")
@@ -51,6 +55,23 @@ def _prompt_run_id() -> str | None:
     return run_id or None
 
 
+def submit_feedback(
+    *,
+    message: str,
+    category: FeedbackCategory,
+    run_id: str | None = None,
+) -> None:
+    payload = {
+        "message": message,
+        "category": category,
+        "cli_version": __version__,
+        "run_id": run_id,
+    }
+
+    with console.status("Submitting...", spinner="dots"):
+        APIClient().post("/feedback", json=payload)
+
+
 @app.callback(invoke_without_command=True)
 def feedback(ctx: typer.Context) -> None:
     """Submit feedback (bug, feature request, or general) to the Prime team."""
@@ -68,16 +89,8 @@ def feedback(ctx: typer.Context) -> None:
         console.print("\n[yellow]Cancelled[/yellow]")
         raise typer.Exit(0)
 
-    payload = {
-        "message": message,
-        "category": category,
-        "cli_version": __version__,
-        "run_id": run_id,
-    }
-
     try:
-        with console.status("Submitting...", spinner="dots"):
-            APIClient().post("/feedback", json=payload)
+        submit_feedback(message=message, category=category, run_id=run_id)
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import toml
 import typer
+from click.exceptions import Abort
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic import ValidationError as PydanticValidationError
 from rich.markup import escape as rich_escape
@@ -36,6 +37,7 @@ from ..utils.formatters import (
     strip_ansi,
 )
 from ..utils.prompt import confirm_or_skip
+from .feedback import submit_feedback
 from .usage import RUN_USAGE_JSON_HELP, run_usage_command
 
 console = get_console()
@@ -1213,6 +1215,62 @@ def list_models(
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
+
+
+def _prompt_required_text(label: str, help_text: str, empty_error: str) -> str:
+    console.print(f"\n[bold]{label}[/bold] [dim](required)[/dim]")
+    console.print(f"[dim]{help_text}[/dim]")
+    while True:
+        value = typer.prompt("", prompt_suffix="> ").strip()
+        if value:
+            return value
+        console.print(f"[red]{empty_error}[/red]")
+
+
+def _prompt_optional_text(label: str, help_text: str) -> str | None:
+    console.print(f"\n[bold]{label}[/bold] [dim](optional)[/dim]")
+    console.print(f"[dim]{help_text}[/dim]")
+    value = typer.prompt("", default="", show_default=False, prompt_suffix="> ").strip()
+    return value or None
+
+
+def _format_model_request_feedback(models: str, context: str | None) -> str:
+    message = f"Hosted Training model request\n\nModels:\n{models}"
+    if context:
+        message += f"\n\nContext:\n{context}"
+    return message
+
+
+@app.command("request", rich_help_panel="Commands")
+def request_models() -> None:
+    """Request models for Hosted Training."""
+    console.print("[bold]Hosted Training Model Request[/bold]")
+    console.print("[dim]Tell us which models you want available for training.[/dim]")
+
+    try:
+        models = _prompt_required_text(
+            "Model(s)",
+            "Use provider/model names if you know them; comma-separated is fine.",
+            "At least one model is required.",
+        )
+        context = _prompt_optional_text(
+            "Use case or context",
+            "Share what you want to train or why this model matters.",
+        )
+    except Abort:
+        console.print("\n[yellow]Cancelled[/yellow]")
+        raise typer.Exit(0)
+
+    try:
+        submit_feedback(
+            message=_format_model_request_feedback(models, context),
+            category="feature",
+        )
+    except APIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print("[green]Request submitted. Thanks![/green]")
 
 
 def _unwrap_single_schema_variant(prop: Dict[str, Any]) -> Dict[str, Any]:

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 from prime_cli.main import app
 from typer.testing import CliRunner
@@ -18,6 +19,7 @@ def test_train_help_promotes_config_run_path() -> None:
     assert "Path to a TOML config file to launch as a" in result.output
     assert "Hosted Training run." in result.output
     assert "logs" in result.output
+    assert "request" in result.output
 
 
 def test_rl_alias_is_hidden_from_root_help() -> None:
@@ -61,3 +63,34 @@ def test_train_init_defaults_to_rl_toml() -> None:
         assert "Created rl.toml" in result.output
         assert "Run with: prime train rl.toml" in result.output
         assert Path("rl.toml").exists()
+
+
+def test_train_request_submits_model_request(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def mock_post(self: Any, endpoint: str, json: dict[str, Any] | None = None) -> dict:
+        captured["endpoint"] = endpoint
+        captured["json"] = json
+        return {"message": "Request submitted"}
+
+    monkeypatch.setattr("prime_cli.client.APIClient.post", mock_post)
+
+    result = runner.invoke(
+        app,
+        ["train", "request"],
+        input="openai/gpt-oss-120b, meta-llama/Llama-4\nSFT distillation\n",
+        env={**TEST_ENV, "PRIME_API_KEY": "test-key"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Request submitted" in result.output
+    assert captured["endpoint"] == "/feedback"
+    payload = captured["json"]
+    assert payload["category"] == "feature"
+    assert payload["run_id"] is None
+    assert payload["cli_version"]
+    assert payload["message"] == (
+        "Hosted Training model request\n\n"
+        "Models:\nopenai/gpt-oss-120b, meta-llama/Llama-4\n\n"
+        "Context:\nSFT distillation"
+    )


### PR DESCRIPTION
## Summary
- Add `prime train request` to collect requested Hosted Training models and optional context.
- Reuse the existing `/feedback` comms path by factoring feedback submission into a shared helper.
- Keep the feature aligned with the current `prime train` command surface and expose it in help output.

## Testing
- Added CLI coverage for the new request flow and help visibility.
- Verified the focused `prime feedback` and `prime train` tests pass.
- Ran `ruff check` on the touched command and test files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI subcommand and refactors feedback submission into a shared helper, with no changes to auth or core training/run management logic.
> 
> **Overview**
> Adds a new `prime train request` command that interactively collects desired Hosted Training model names plus optional context and submits the request through the existing `/feedback` API path.
> 
> Refactors `prime feedback` to reuse a new shared `submit_feedback()` helper (with a typed `FeedbackCategory`), and extends CLI tests to assert the new command appears in help and posts the expected payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7983923b6ca017067bfbbfeea308e910576f764e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->