### PR TITLE
Refine Hosted Training docs and default rl.toml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prime Intellect CLI & SDKs
 [![Python versions](https://img.shields.io/pypi/pyversions/prime?cacheSeconds=60)](https://pypi.org/project/prime/)
 [![Downloads](https://img.shields.io/pypi/dm/prime)](https://pypi.org/project/prime/)
 
-Command line interface and SDKs for managing Prime Intellect GPU resources, sandboxes, and environments.
+Command line interface and SDKs for Prime Lab, Hosted Training, GPU resources, sandboxes, and environments.
 </div>
 
 ## Quick Start
@@ -35,6 +35,16 @@ uv tool install prime
 # Authenticate
 prime login
 
+# Set up a Lab workspace for environments, evals, GEPA, and Hosted Training
+prime lab setup
+
+# See available Hosted Training models, capacity, and pricing
+prime train models
+
+# Generate and launch a Hosted Training config
+prime train init
+prime train rl.toml
+
 # Browse verified environments
 prime env list
 
@@ -44,6 +54,8 @@ prime availability list
 
 ## Features
 
+- **Lab Workspaces** - Set up local verifiers workspaces for environments, evals, GEPA, and training
+- **Hosted Training** - Train models against verifiers environments and inspect runs, logs, metrics, and checkpoints
 - **Environments** - Access hundreds of verified environments on our community hub
 - **Evaluations** - Push and manage evaluation results
 - **GPU Resource Management** - Query and filter available GPU resources
@@ -130,6 +142,30 @@ prime env install <environment-name>
 # Create and push your own environment
 prime env init my-environment
 prime env push my-environment
+```
+
+### Lab and Hosted Training
+
+Prime Lab connects verifiers environments to evaluations, GEPA prompt optimization, and Hosted Training. Start with `prime lab setup` to create a local workspace with starter configs, then use `prime train models` to choose a Hosted Training model with current capacity and pricing.
+
+```bash
+# Set up a Lab workspace
+prime lab setup
+
+# List trainable models, capacity, and token pricing
+prime train models
+
+# Generate a Hosted Training config
+prime train init
+
+# Launch the run from the generated config
+prime train rl.toml
+
+# Inspect and manage Hosted Training runs
+prime train list
+prime train logs <run-id> -f
+prime train metrics <run-id>
+prime train checkpoints <run-id>
 ```
 
 ### GPU Resources

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -20,17 +20,19 @@ Prime Intellect CLI & SDKs
 [![Python versions](https://img.shields.io/pypi/pyversions/prime?cacheSeconds=60)](https://pypi.org/project/prime/)
 [![Downloads](https://img.shields.io/pypi/dm/prime)](https://pypi.org/project/prime/)
 
-Command line interface and SDKs for managing Prime Intellect GPU resources, sandboxes, and environments.
+Command line interface and SDKs for Prime Lab, Hosted Training, GPU resources, sandboxes, and environments.
 
 </div>
 
 ## Overview
 
-Prime is the official CLI and Python SDK for [Prime Intellect](https://primeintellect.ai), providing seamless access to GPU compute infrastructure, remote code execution environments (sandboxes), and AI inference capabilities.
+Prime is the official CLI and Python SDK for [Prime Intellect](https://primeintellect.ai), providing seamless access to Prime Lab workflows, Hosted Training, GPU compute infrastructure, remote code execution environments (sandboxes), and AI inference capabilities.
 
 **What can you do with Prime?**
 
 - Deploy GPU pods with H100, A100, and other high-performance GPUs
+- Set up Lab workspaces for verifiers environments, evals, GEPA, and training
+- Discover and launch Hosted Training runs against verifiers environments
 - Create and manage isolated sandbox environments for running code
 - Access hundreds of pre-configured development environments
 - SSH directly into your compute instances
@@ -82,6 +84,16 @@ Get your API key from the [Prime Intellect Dashboard](https://app.primeintellect
 # Browse environments on the hub
 prime env list
 
+# Set up a Lab workspace
+prime lab setup
+
+# See available Hosted Training models, capacity, and pricing
+prime train models
+
+# Generate and launch a Hosted Training config
+prime train init
+prime train rl.toml
+
 # List available GPUs
 prime availability list
 
@@ -96,6 +108,30 @@ prime sandbox create python:3.11
 ```
 
 ## Features
+
+### Lab and Hosted Training
+
+Prime Lab connects verifiers environments to evaluations, GEPA prompt optimization, and Hosted Training. Start with `prime lab setup` to create a local workspace with starter configs, then use `prime train models` to choose a Hosted Training model with current capacity and pricing.
+
+```bash
+# Set up a Lab workspace
+prime lab setup
+
+# List trainable models, capacity, and token pricing
+prime train models
+
+# Generate a Hosted Training config
+prime train init
+
+# Launch the run from the generated config
+prime train rl.toml
+
+# Inspect and manage Hosted Training runs
+prime train list
+prime train logs <run-id> -f
+prime train metrics <run-id>
+prime train checkpoints <run-id>
+```
 
 ### Environments Hub
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -208,7 +208,7 @@ def generate_rl_config_template(environment: str | None = None) -> str:
     env_value = environment or "primeintellect/reverse-text"
 
     return f'''\
-model = "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+model = "Qwen/Qwen3.5-0.8B"
 max_steps = 100
 
 # env_files = ["secrets.env"] # optional file(s) for secrets
@@ -216,10 +216,7 @@ max_steps = 100
 # Training
 batch_size = 128
 rollouts_per_example = 8
-# learning_rate = 1e-6
-# lora_alpha = 16
-# oversampling_factor = 1.0
-# max_async_level = 4
+# learning_rate = 3e-5 # optional; default is 1e-4
 
 # Optional: warm-start from an existing checkpoint
 # checkpoint_id = "..."
@@ -227,20 +224,10 @@ rollouts_per_example = 8
 [sampling]
 max_tokens = 2048
 # temperature = 0.7
-# repetition_penalty = 1.0
-# min_tokens = 0
-# seed = 42
 
 # Optional: hosted RL reasoning controls (mutually exclusive)
 # enable_thinking = false    # supported models: Qwen3.5, Nemotron
 # reasoning_effort = "high"  # supported models: GPT-OSS ("low" | "medium" | "high")
-
-# Optional: temperature scheduling (use instead of temperature)
-# [sampling.temp_scheduler]
-# type = "linear"               # "linear" or "cosine"
-# start_temperature = 1.5
-# end_temperature = 0.3
-# total_steps = 1000            # defaults to max_steps if not set
 
 [[env]]
 id = "{env_value}"
@@ -248,12 +235,6 @@ id = "{env_value}"
 # [[env]] # add multiple [[env]] sections for multi-env training
 # id = "primeintellect/another-env"
 # args = {{ split = "train", max_examples = 1000 }}
-
-# Optional: W&B logging
-# [wandb]
-# project = "my-project"
-# entity = "my-team"
-# name = "my-run-name"
 
 # Optional: online evaluation
 # [eval]
@@ -285,7 +266,6 @@ id = "{env_value}"
 # online_difficulty_filtering = false
 # env_ratios = [0.5, 0.5]
 # skip_verification = false
-# seed = 42
 
 # Optional: checkpoint configuration
 # [checkpoints]
@@ -296,10 +276,6 @@ id = "{env_value}"
 # [adapters]
 # interval = 0                # Upload adapter every N steps (0 = only at run end)
 # keep_last = 3               # Keep N adapters in cloud (-1 = keep all)
-
-# Optional: infrastructure configuration
-# [infrastructure]
-# compute_size = "M"          # S, M (default), or L
 '''
 
 
@@ -1203,7 +1179,10 @@ def list_models(
             if model.promo_label and model.promo_label not in promo_labels:
                 promo_labels.append(model.promo_label)
 
-        caption_lines = ["[dim]Prices per 1M tokens[/dim]"]
+        caption = (
+            "[dim]Prices are per 1M tokens. All models support context windows of 64K tokens.[/dim]"
+        )
+        caption_lines = [caption]
         if promo_labels:
             joined = ", ".join(rich_escape(label) for label in promo_labels)
             caption_lines.append(f"[bold yellow]{joined}[/bold yellow]")

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -50,6 +50,27 @@ def test_generate_rl_config_template_uses_broad_buffer_threshold_examples() -> N
     assert "# hard_threshold = 0.0" in template
 
 
+def test_generate_rl_config_template_keeps_default_surface_minimal() -> None:
+    template = generate_rl_config_template()
+
+    assert 'model = "Qwen/Qwen3.5-0.8B"' in template
+    assert "# learning_rate = 3e-5 # optional; default is 1e-4" in template
+
+    hidden_fields = [
+        "oversampling_factor",
+        "max_async_level",
+        "lora_alpha",
+        "repetition_penalty",
+        "min_tokens",
+        "temp_scheduler",
+        "seed",
+        "[wandb]",
+        "[infrastructure]",
+    ]
+    for field in hidden_fields:
+        assert field not in template
+
+
 def test_flatten_config_schema_expands_optional_nested_models() -> None:
     schema = RLConfig.model_json_schema()
     rows = _flatten_config_schema(schema, schema.get("$defs", {}))

--- a/packages/prime/tests/test_rl_models.py
+++ b/packages/prime/tests/test_rl_models.py
@@ -128,6 +128,9 @@ def test_models_table_renders_promo_arrow_and_caption(
     assert "$0.5" in plain
     assert "$1" in plain
     assert "$3" in plain
+    normalized = " ".join(plain.split())
+    expected_footer = "Prices are per 1M tokens. All models support context windows of 64K tokens."
+    assert expected_footer in normalized
     # Promo label rendered once below the table.
     assert plain.count("Free RFT week") == 1
 


### PR DESCRIPTION
## Summary
- Highlight `prime lab setup` and `prime train models` near the top of the main README and package README.
- Simplify the default Hosted Training `rl.toml` template by removing advanced knobs from the starter surface.
- Update the default model to `Qwen/Qwen3.5-0.8B`, revise the learning-rate suggestion to `3e-5`, and note the `1e-4` default.
- Change the Hosted Training models footer to state per-1M-token pricing and the 64K context window support.

## Testing
- `ruff check` passed for the touched CLI and test files.
- `ruff format` was applied and rechecked successfully.
- Focused pytest coverage passed for `test_rl_config.py`, `test_rl_models.py`, and `test_train_cli.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily documentation updates plus a small change to the generated Hosted Training `rl.toml` template and the `train/rl models` table footer, affecting only CLI output defaults.
> 
> **Overview**
> **Updates docs to foreground Prime Lab and Hosted Training.** The top-level README and `packages/prime/README.md` now mention `prime lab setup` and `prime train models/init` in Quick Start/Features and add a dedicated “Lab and Hosted Training” section.
> 
> **Refines Hosted Training defaults and messaging.** The generated `rl.toml` template is simplified by removing advanced knobs from the starter surface, updates the default model to `Qwen/Qwen3.5-0.8B`, and tweaks the suggested `learning_rate` comment; the models table footer now explicitly states pricing is per 1M tokens and notes 64K context support, with tests added/updated to enforce these outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95cb66c93e798b33f47e3b6ae9d047f426446ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->