### PR TITLE
Back off train log polling and rename Hosted Training log copy

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -1,4 +1,4 @@
-"""Hosted RL (Reinforcement Learning) API client."""
+"""Hosted Training API client."""
 
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
@@ -9,7 +9,7 @@ from prime_cli.core import APIClient, APIError, ValidationError
 
 
 class RLModel(BaseModel):
-    """Model available for RL training."""
+    """Model available for Hosted Training."""
 
     name: str = Field(..., description="Model name")
     at_capacity: bool = Field(False, alias="atCapacity")
@@ -60,7 +60,7 @@ class RLModel(BaseModel):
 
 
 class RLRun(BaseModel):
-    """RL Training Run."""
+    """Hosted Training run."""
 
     id: str = Field(..., description="Run ID")
     name: Optional[str] = Field(None, description="Run name")
@@ -110,7 +110,7 @@ class RLRun(BaseModel):
 
 
 class RLCheckpoint(BaseModel):
-    """Checkpoint from an RL training run."""
+    """Checkpoint from a Hosted Training run."""
 
     id: str = Field(..., description="Checkpoint ID")
     rft_run_id: str = Field(..., alias="rftRunId")
@@ -125,7 +125,7 @@ class RLCheckpoint(BaseModel):
 
 
 class EnvServerInfo(BaseModel):
-    """Env-server pod info for an RL run."""
+    """Env-server pod info for a Hosted Training run."""
 
     env_name: Optional[str] = Field(None, description="Environment name")
     env_index: Optional[int] = Field(None, description="Environment server index")
@@ -136,13 +136,13 @@ class EnvServerInfo(BaseModel):
 
 
 class RLClient:
-    """Client for hosted RL API."""
+    """Client for the Hosted Training API."""
 
     def __init__(self, client: APIClient) -> None:
         self.client = client
 
     def list_models(self, team_id: Optional[str] = None) -> List[RLModel]:
-        """List available models for RL training."""
+        """List available models for Hosted Training."""
         try:
             params = {}
             if team_id:
@@ -152,11 +152,11 @@ class RLClient:
             return [RLModel.model_validate(model) for model in models_data]
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to list RL models: {e.response.text}")
-            raise APIError(f"Failed to list RL models: {str(e)}")
+                raise APIError(f"Failed to list Hosted Training models: {e.response.text}")
+            raise APIError(f"Failed to list Hosted Training models: {str(e)}")
 
     def list_runs(self, team_id: Optional[str] = None) -> List[RLRun]:
-        """List RL training runs for the authenticated user."""
+        """List Hosted Training runs for the authenticated user."""
         try:
             params = {}
             if team_id:
@@ -166,8 +166,8 @@ class RLClient:
             return [RLRun.model_validate(run) for run in runs_data]
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to list RL runs: {e.response.text}")
-            raise APIError(f"Failed to list RL runs: {str(e)}")
+                raise APIError(f"Failed to list Hosted Training runs: {e.response.text}")
+            raise APIError(f"Failed to list Hosted Training runs: {str(e)}")
 
     def create_run(
         self,
@@ -206,7 +206,7 @@ class RLClient:
         reasoning_effort: Optional[Literal["low", "medium", "high"]] = None,
         run_config: Optional[Dict[str, Any]] = None,
     ) -> RLRun:
-        """Create a new RL training run."""
+        """Create a new Hosted Training run."""
         try:
             secrets_list: List[Dict[str, str]] = []
             if secrets:
@@ -315,30 +315,30 @@ class RLClient:
             raise  # Let ValidationError pass through for proper CLI handling
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to create RL run: {e.response.text}")
-            raise APIError(f"Failed to create RL run: {str(e)}")
+                raise APIError(f"Failed to create Hosted Training run: {e.response.text}")
+            raise APIError(f"Failed to create Hosted Training run: {str(e)}")
 
     def stop_run(self, run_id: str) -> RLRun:
-        """Stop a running RL training run."""
+        """Stop a running Hosted Training run."""
         try:
             response = self.client.request("PUT", f"/rft/runs/{run_id}/stop")
             return RLRun.model_validate(response.get("run"))
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to stop RL run: {e.response.text}")
-            raise APIError(f"Failed to stop RL run: {str(e)}")
+                raise APIError(f"Failed to stop Hosted Training run: {e.response.text}")
+            raise APIError(f"Failed to stop Hosted Training run: {str(e)}")
 
     def delete_run(self, run_id: str) -> None:
-        """Delete an RL run."""
+        """Delete a Hosted Training run."""
         try:
             self.client.delete(f"/rft/runs/{run_id}")
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to delete RL run: {e.response.text}")
-            raise APIError(f"Failed to delete RL run: {str(e)}")
+                raise APIError(f"Failed to delete Hosted Training run: {e.response.text}")
+            raise APIError(f"Failed to delete Hosted Training run: {str(e)}")
 
     def restart_run(self, run_id: str) -> RLRun:
-        """Restart a running RL training run from its latest checkpoint.
+        """Restart a running Hosted Training run from its latest checkpoint.
 
         Only RUNNING runs can be restarted (checkpoints still on PVC).
         For STOPPED/FAILED/COMPLETED runs, checkpoints have been cleaned up.
@@ -348,13 +348,13 @@ class RLClient:
             return RLRun.model_validate(response.get("run"))
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to restart RL run: {e.response.text}")
-            raise APIError(f"Failed to restart RL run: {str(e)}")
+                raise APIError(f"Failed to restart Hosted Training run: {e.response.text}")
+            raise APIError(f"Failed to restart Hosted Training run: {str(e)}")
 
     def list_checkpoints(
         self, run_id: str, status_filter: Optional[str] = None
     ) -> List[RLCheckpoint]:
-        """List checkpoints for an RL run."""
+        """List checkpoints for a Hosted Training run."""
         try:
             params: Dict[str, str] = {}
             if status_filter:
@@ -371,17 +371,17 @@ class RLClient:
             raise APIError(f"Failed to list checkpoints: {str(e)}")
 
     def get_run(self, run_id: str) -> RLRun:
-        """Get details of a specific RL run."""
+        """Get details of a specific Hosted Training run."""
         try:
             response = self.client.get(f"/rft/runs/{run_id}")
             return RLRun.model_validate(response.get("run"))
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to get RL run: {e.response.text}")
-            raise APIError(f"Failed to get RL run: {str(e)}")
+                raise APIError(f"Failed to get Hosted Training run: {e.response.text}")
+            raise APIError(f"Failed to get Hosted Training run: {str(e)}")
 
     def get_logs(self, run_id: str, tail_lines: int = 1000) -> str:
-        """Get orchestrator logs for an RL run."""
+        """Get orchestrator logs for a Hosted Training run."""
         try:
             response = self.client.get(
                 f"/rft/runs/{run_id}/logs", params={"tail_lines": tail_lines}
@@ -389,11 +389,11 @@ class RLClient:
             return response.get("logs", "")
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to get RL run logs: {e.response.text}")
-            raise APIError(f"Failed to get RL run logs: {str(e)}")
+                raise APIError(f"Failed to get Hosted Training run logs: {e.response.text}")
+            raise APIError(f"Failed to get Hosted Training run logs: {str(e)}")
 
     def list_env_servers(self, run_id: str) -> List[EnvServerInfo]:
-        """List env-server pods for an RL run."""
+        """List env-server pods for a Hosted Training run."""
         try:
             response = self.client.get(f"/rft/runs/{run_id}/env-servers")
             return [EnvServerInfo.model_validate(p) for p in response.get("env_servers", [])]
@@ -409,7 +409,7 @@ class RLClient:
         env_index: int = 0,
         tail_lines: int = 1000,
     ) -> str:
-        """Get logs for a specific env-server pod of an RL run."""
+        """Get logs for a specific env-server pod of a Hosted Training run."""
         try:
             response = self.client.get(
                 f"/rft/runs/{run_id}/env-server-logs",
@@ -432,7 +432,7 @@ class RLClient:
         max_step: Optional[int] = None,
         limit: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
-        """Get metrics for an RL run."""
+        """Get metrics for a Hosted Training run."""
         try:
             params: Dict[str, Any] = {}
             if min_step is not None:
@@ -448,8 +448,8 @@ class RLClient:
             return response.get("metrics", [])
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to get RL run metrics: {e.response.text}")
-            raise APIError(f"Failed to get RL run metrics: {str(e)}")
+                raise APIError(f"Failed to get Hosted Training run metrics: {e.response.text}")
+            raise APIError(f"Failed to get Hosted Training run metrics: {str(e)}")
 
     def get_rollouts(
         self,
@@ -458,7 +458,7 @@ class RLClient:
         page: int = 1,
         limit: int = 100,
     ) -> Dict[str, Any]:
-        """Get rollout samples for an RL run."""
+        """Get rollout samples for a Hosted Training run."""
         try:
             params: Dict[str, Any] = {
                 "page": page,
@@ -477,11 +477,11 @@ class RLClient:
             }
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to get RL run rollouts: {e.response.text}")
-            raise APIError(f"Failed to get RL run rollouts: {str(e)}")
+                raise APIError(f"Failed to get Hosted Training run rollouts: {e.response.text}")
+            raise APIError(f"Failed to get Hosted Training run rollouts: {str(e)}")
 
     def get_progress(self, run_id: str) -> Dict[str, Any]:
-        """Get progress information for an RL run."""
+        """Get progress information for a Hosted Training run."""
         try:
             response = self.client.get(f"/rft/runs/{run_id}/progress")
             return {
@@ -492,8 +492,8 @@ class RLClient:
             }
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to get RL run progress: {e.response.text}")
-            raise APIError(f"Failed to get RL run progress: {str(e)}")
+                raise APIError(f"Failed to get Hosted Training run progress: {e.response.text}")
+            raise APIError(f"Failed to get Hosted Training run progress: {str(e)}")
 
     def get_distributions(
         self,
@@ -501,7 +501,7 @@ class RLClient:
         distribution_type: Optional[str] = None,
         step: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Get reward/advantage distribution histogram for an RL run."""
+        """Get reward/advantage distribution histogram for a Hosted Training run."""
         try:
             params: Dict[str, Any] = {}
             if distribution_type is not None:
@@ -516,8 +516,10 @@ class RLClient:
             }
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
-                raise APIError(f"Failed to get RL run distributions: {e.response.text}")
-            raise APIError(f"Failed to get RL run distributions: {str(e)}")
+                raise APIError(
+                    f"Failed to get Hosted Training run distributions: {e.response.text}"
+                )
+            raise APIError(f"Failed to get Hosted Training run distributions: {str(e)}")
 
     def get_environment_status(self, owner: str, name: str) -> Dict[str, Any]:
         """Get status for an environment including latest version and action info."""

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -62,7 +62,7 @@ RL_LIST_JSON_HELP = json_output_help(
 )
 
 RL_METRICS_JSON_HELP = json_help(
-    ".metrics[] = metric record from the RL API",
+    ".metrics[] = metric record from the Hosted Training API",
 )
 
 RL_ROLLOUTS_JSON_HELP = json_help(
@@ -85,6 +85,10 @@ RL_CHECKPOINTS_JSON_HELP = json_output_help(
 
 # Progress bar pattern (tqdm-style progress bars)
 PROGRESS_BAR = re.compile(r".*\|[█▏▎▍▌▋▊▉ ]{10,}\|.*")
+
+HOSTED_TRAINING_LOG_STARTUP_POLL_SECONDS = 10
+HOSTED_TRAINING_LOG_STARTUP_POLLS = 18
+HOSTED_TRAINING_LOG_FOLLOW_POLL_SECONDS = 5
 
 # Log level colors for rich console
 LEVEL_STYLES = {
@@ -231,7 +235,7 @@ max_tokens = 2048
 # min_tokens = 0
 # seed = 42
 
-# Optional: hosted RL reasoning controls (mutually exclusive)
+# Optional: Hosted Training reasoning controls (mutually exclusive)
 # enable_thinking = false    # supported models: Qwen3.5, Nemotron
 # reasoning_effort = "high"  # supported models: GPT-OSS ("low" | "medium" | "high")
 
@@ -1172,7 +1176,9 @@ def list_models(
 
         if not models:
             console.print("[yellow]No models available for Hosted Training.[/yellow]")
-            console.print("[dim]This could mean no healthy RL clusters are running.[/dim]")
+            console.print(
+                "[dim]This could mean no healthy Hosted Training clusters are running.[/dim]"
+            )
             return
 
         table = Table(
@@ -1615,6 +1621,43 @@ def _print_new_lines(last_lines: list[str], current_lines: list[str]) -> None:
         console.print(line)
 
 
+def _is_log_startup_error(error: APIError) -> bool:
+    message = str(error).lower()
+    startup_markers = (
+        "queued",
+        "pending",
+        "starting",
+        "initializing",
+        "not started",
+        "not available yet",
+        "logs are not available",
+        "logs not available",
+    )
+    return any(marker in message for marker in startup_markers)
+
+
+def _fetch_logs_with_startup_poll(fetch_fn: Any, tail: int, label: str) -> str:
+    for poll in range(HOSTED_TRAINING_LOG_STARTUP_POLLS + 1):
+        try:
+            return fetch_fn(tail)
+        except APIError as e:
+            if not _is_log_startup_error(e):
+                raise
+            if poll == 0:
+                console.print(
+                    f"[yellow]Hosted Training run is starting; waiting for {label} logs...[/yellow]"
+                )
+            if poll == HOSTED_TRAINING_LOG_STARTUP_POLLS:
+                console.print(
+                    "[yellow]Hosted Training run has not started yet. "
+                    "Logs will be available once it is running.[/yellow]"
+                )
+                raise typer.Exit(0)
+            time.sleep(HOSTED_TRAINING_LOG_STARTUP_POLL_SECONDS)
+
+    raise AssertionError("unreachable")
+
+
 def _stream_logs(
     fetch_fn: Any,
     tail: int,
@@ -1639,10 +1682,11 @@ def _stream_logs(
                 raw_logs = fetch_fn(tail)
                 consecutive_errors = 0
             except APIError as e:
-                err_str = str(e).lower()
-                if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
-                    console.print("[yellow]Run is queued, waiting for it to start...[/yellow]")
-                    time.sleep(10)
+                if _is_log_startup_error(e):
+                    console.print(
+                        "[yellow]Hosted Training run is starting; waiting for logs...[/yellow]"
+                    )
+                    time.sleep(HOSTED_TRAINING_LOG_STARTUP_POLL_SECONDS)
                     continue
                 consecutive_errors += 1
                 if "429" in str(e):
@@ -1657,9 +1701,9 @@ def _stream_logs(
             current_lines = render(raw_logs)
             _print_new_lines(last_lines, current_lines)
             last_lines = current_lines
-            time.sleep(5)
+            time.sleep(HOSTED_TRAINING_LOG_FOLLOW_POLL_SECONDS)
     else:
-        raw_logs = fetch_fn(tail)
+        raw_logs = _fetch_logs_with_startup_poll(fetch_fn, tail, label)
         rendered = render(raw_logs)
         if rendered:
             for line in rendered:
@@ -1669,9 +1713,8 @@ def _stream_logs(
 
 
 def _handle_logs_api_error(e: APIError) -> None:
-    err_str = str(e).lower()
-    if "404" in str(e) and ("queued" in err_str or "pending" in err_str):
-        msg = "Run has not started yet. Logs will be available once running."
+    if _is_log_startup_error(e):
+        msg = "Hosted Training run has not started yet. Logs will be available once running."
         console.print(f"[yellow]{msg}[/yellow]")
         raise typer.Exit(0)
     console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1633,7 +1633,7 @@ def _is_log_startup_error(error: APIError) -> bool:
         "logs are not available",
         "logs not available",
     )
-    return any(marker in message for marker in startup_markers)
+    return "404" in message and any(marker in message for marker in startup_markers)
 
 
 def _fetch_logs_with_startup_poll(fetch_fn: Any, tail: int, label: str) -> str:

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -1,4 +1,4 @@
-"""Tests for `prime rl logs` (orchestrator + env-server) and `prime rl components`."""
+"""Tests for `prime train logs` (orchestrator + env-server) and components."""
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 import pytest
 from prime_cli.api.rl import RLClient
 from prime_cli.client import APIError
+from prime_cli.commands import rl as rl_commands
 from prime_cli.main import app
 from typer.testing import CliRunner
 
@@ -64,7 +65,7 @@ def _make_mock_get(
     return mock_get
 
 
-# ---------- prime rl logs (orchestrator default) ----------
+# ---------- prime train logs (orchestrator default) ----------
 
 
 def test_logs_default_hits_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -116,7 +117,7 @@ def test_logs_explicit_orchestrator_with_env_errors(monkeypatch: pytest.MonkeyPa
     assert result.exit_code != 0
 
 
-# ---------- prime rl logs -c env-server ----------
+# ---------- prime train logs -c env-server ----------
 
 
 def test_logs_env_server_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -234,17 +235,46 @@ def test_logs_invalid_component(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_logs_run_not_started(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Queued runs return 404 with 'queued'; CLI should exit 0 with a friendly message."""
+    """Queued runs poll for the startup window before exiting with a friendly message."""
+    assert (
+        rl_commands.HOSTED_TRAINING_LOG_STARTUP_POLLS
+        * rl_commands.HOSTED_TRAINING_LOG_STARTUP_POLL_SECONDS
+        >= 180
+    )
+    calls = {"n": 0}
 
     def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
-        raise APIError("Failed to get RL run logs: 404 run is queued")
+        calls["n"] += 1
+        raise APIError("Failed to get Hosted Training run logs: 404 run is queued")
 
     monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
 
-    result = CliRunner().invoke(app, ["rl", "logs", RUN_ID, "--raw"])
+    result = CliRunner().invoke(app, ["train", "logs", RUN_ID, "--raw"])
 
     assert result.exit_code == 0, result.output
-    assert "has not started yet" in result.output
+    assert calls["n"] == rl_commands.HOSTED_TRAINING_LOG_STARTUP_POLLS + 1
+    assert "Hosted Training run is starting" in result.output
+    assert "Hosted Training run has not started yet" in result.output
+    assert "RL" not in result.output
+
+
+def test_logs_queued_run_succeeds_when_logs_appear(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise APIError("Failed to get Hosted Training run logs: 404 run is queued")
+        return {"logs": "orch-ready"}
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["train", "logs", RUN_ID, "--raw"])
+
+    assert result.exit_code == 0, result.output
+    assert calls["n"] == 3
+    assert "orch-ready" in result.output
+    assert "Failed" not in result.output
 
 
 def test_logs_env_server_follow_dedupes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -289,7 +319,7 @@ def test_logs_env_server_follow_dedupes(monkeypatch: pytest.MonkeyPatch) -> None
     assert call_count["n"] >= 2
 
 
-# ---------- prime rl components ----------
+# ---------- prime train components ----------
 
 
 def test_components_lists_orchestrator_and_env_servers(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -258,6 +258,25 @@ def test_logs_run_not_started(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "RL" not in result.output
 
 
+def test_logs_startup_marker_without_404_exits_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"n": 0}
+
+    def mock_get(self: Any, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        calls["n"] += 1
+        raise APIError("Failed to get Hosted Training run logs: HTTP 403: run is pending")
+
+    monkeypatch.setattr("prime_cli.core.APIClient.get", mock_get)
+
+    result = CliRunner().invoke(app, ["train", "logs", RUN_ID, "--raw"])
+
+    assert result.exit_code == 1
+    assert calls["n"] == 1
+    assert "Error:" in result.output
+    assert "Hosted Training run has not started yet" not in result.output
+
+
 def test_logs_queued_run_succeeds_when_logs_appear(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"n": 0}
 


### PR DESCRIPTION
## Summary
- Adds a bounded startup polling window for `prime train logs` so queued runs keep retrying for a few minutes before exiting.
- Keeps follow mode polling normally while the run is starting, instead of failing immediately on the first queued response.
- Renames user-facing log/API copy from `RL` to `Hosted Training` in the log path and related CLI strings.
- Expands the logs test coverage for both the startup wait path and the case where logs appear after a short queue delay.

## Testing
- `uv run pytest packages/prime/tests/test_rl_logs.py packages/prime/tests/test_train_cli.py -q`
- `uv run ruff check packages/prime/src/prime_cli/commands/rl.py packages/prime/src/prime_cli/api/rl.py packages/prime/tests/test_rl_logs.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI log polling/backoff behavior and user-facing messaging, with no auth, persistence, or server-side logic changes.
> 
> **Overview**
> Improves `prime train logs` behavior for queued/starting runs by adding a bounded startup polling window (with clearer messages) before exiting, and by treating startup-related 404s as retryable in follow mode.
> 
> Updates user-facing copy and API error strings from *RL* to **Hosted Training** across the CLI/API client log-related paths, and expands tests to cover the new startup polling behavior and the case where logs appear after a short queue delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf632952230277b59b20255cd67018c889b4137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->