### PR TITLE
add ls alias for all list subcommands

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1474,7 +1474,6 @@ def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> No
 
 
 @app.command("list", rich_help_panel="Commands", epilog=RL_LIST_JSON_HELP)
-@app.command("ls", rich_help_panel="Commands", hidden=True)
 def list_runs(
     team: Optional[str] = typer.Option(None, "--team", "-t", help="Filter by team ID"),
     num: int = typer.Option(20, "--num", "-n", help="Items per page"),

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -146,7 +146,6 @@ def _guard_vm_unsupported(sandbox: Sandbox, feature_name: str) -> None:
 
 
 @app.command("list", epilog=LIST_SANDBOXES_JSON_HELP)
-@app.command("ls", hidden=True)
 def list_sandboxes_cmd(
     team_id: Optional[str] = typer.Option(
         None, help="Filter by team ID (uses config team_id if not specified)"

--- a/packages/prime/src/prime_cli/utils/plain.py
+++ b/packages/prime/src/prime_cli/utils/plain.py
@@ -203,8 +203,20 @@ class _PlainTyperCommand(_PlainMixin, TyperCommand):
     pass
 
 
+COMMAND_ALIASES = {
+    "ls": "list",
+}
+
+
 class PlainAwareTyperGroup(_PlainMixin, TyperGroup):
-    pass
+    def get_command(self, ctx, cmd_name):
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is not None:
+            return cmd
+        target = COMMAND_ALIASES.get(cmd_name)
+        if target is None:
+            return None
+        return super().get_command(ctx, target)
 
 
 class DefaultCommandGroup(PlainAwareTyperGroup):
@@ -223,7 +235,7 @@ class DefaultCommandGroup(PlainAwareTyperGroup):
         if decision_args[0] in ("--help", "-h"):
             return super().parse_args(ctx, args)
 
-        if decision_args[0] in self.commands:
+        if self.get_command(ctx, decision_args[0]) is not None:
             return super().parse_args(ctx, args)
 
         args = [self.default_cmd_name] + list(args)


### PR DESCRIPTION
- adds `ls` as an alias for every `list` subcommand (`prime pods ls`, `prime disks ls`, `prime images ls`, etc), matching what already worked for `sandbox` and `rl`.
- centralizes the alias in `PlainAwareTyperGroup` so all subcommands built on `PlainTyper` get alias options instead of duplicating `@app.command("ls", hidden=True)` per file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small CLI dispatch change that adds a command alias and removes duplicated hidden commands; main risk is unexpected alias collisions or help/command-resolution edge cases.
> 
> **Overview**
> Adds a global `ls` → `list` command alias in `PlainAwareTyperGroup.get_command`, so any CLI group built on `PlainTyper` automatically supports `... ls` wherever `... list` exists.
> 
> Removes the per-command hidden `@app.command("ls")` registrations from `rl` and `sandbox`, and updates default-command argument parsing to treat aliases as valid commands (avoiding accidental fallback to the default command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18547a951e34548b50e61277571a915f8293c9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->