### PR TITLE
Refresh Lab config templates from upstream configs

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -34,7 +34,8 @@ from .lab_agents import (
 
 PRIME_RL_REPO = "primeintellect-ai/prime-rl"
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
-VERIFIERS_REF = "7bdc769caae0ba339ea8b67e362aa75331dcc79d"
+VERIFIERS_REF = "7d8a522df67308327cb9b8931ce6a5873a99834a"
+VERIFIERS_CONFIG_REF = "main"
 PRIME_RL_REF = "38b524925d09ce917b51e54bd99446b822f0a87f"
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
@@ -55,7 +56,15 @@ LAB_GITIGNORE_PATTERNS = (
 )
 PRIME_SKILLS_MANIFEST = ".prime-managed.json"
 WORKSPACE_SKILLS_DIR = Path(".prime") / "skills"
-ConfigSpec = tuple[str, str, str]
+DeprecatedConfigField = tuple[tuple[str, ...], str]
+DEPRECATED_CONFIG_FIELDS: tuple[DeprecatedConfigField, ...] = (
+    (("trajectory_strategy",), "`trajectory_strategy` is deprecated and ignored."),
+    (("trajectoryStrategy",), "`trajectoryStrategy` is deprecated and ignored."),
+    (("env_file",), "`env_file` is deprecated; use `env_files`."),
+    (("oversampling_factor",), "`oversampling_factor` is outdated; remove it from Lab configs."),
+    (("max_async_level",), "`max_async_level` is outdated; remove it from Lab configs."),
+    (("max_off_policy_steps",), "`max_off_policy_steps` is outdated; remove it from Lab configs."),
+)
 
 Emit = Callable[[str], None]
 Runner = Callable[[Sequence[str], Path, Emit], int]
@@ -131,9 +140,6 @@ class LabDoctorResult:
     checks: tuple[LabDoctorCheck, ...]
 
 
-ENDPOINTS_SRC = (
-    f"https://raw.githubusercontent.com/{VERIFIERS_REPO}/{VERIFIERS_REF}/configs/endpoints.toml"
-)
 AGENTS_MD_SRC = (
     f"https://raw.githubusercontent.com/{VERIFIERS_REPO}/{VERIFIERS_REF}/assets/lab/AGENTS.md"
 )
@@ -141,38 +147,6 @@ CLAUDE_MD_SRC = (
     f"https://raw.githubusercontent.com/{VERIFIERS_REPO}/{VERIFIERS_REF}/assets/lab/CLAUDE.md"
 )
 ENVS_AGENTS_MD_SRC = f"https://raw.githubusercontent.com/{VERIFIERS_REPO}/{VERIFIERS_REF}/assets/lab/environments/AGENTS.md"
-PRIME_RL_CONFIGS: tuple[ConfigSpec, ...] = (
-    (
-        VERIFIERS_REPO,
-        "configs/local/prime-rl/wiki-search.toml",
-        "configs/prime-rl/wiki-search.toml",
-    ),
-)
-RL_CONFIGS: tuple[ConfigSpec, ...] = tuple(
-    (VERIFIERS_REPO, path, path)
-    for path in (
-        "configs/rl/alphabet-sort.toml",
-        "configs/rl/gsm8k.toml",
-        "configs/rl/math-python.toml",
-        "configs/rl/reverse-text.toml",
-        "configs/rl/wiki-search.toml",
-        "configs/rl/wordle.toml",
-    )
-)
-GEPA_CONFIGS: tuple[ConfigSpec, ...] = tuple(
-    (VERIFIERS_REPO, path, path)
-    for path in (
-        "configs/gepa/base.toml",
-        "configs/gepa/wordle.toml",
-    )
-)
-EVAL_CONFIGS: tuple[ConfigSpec, ...] = tuple(
-    (VERIFIERS_REPO, path, path)
-    for path in (
-        "configs/eval/minimal.toml",
-        "configs/eval/multi-env.toml",
-    )
-)
 SKILL_SOURCES: tuple[SkillSource, ...] = (SkillSource(repo=VERIFIERS_REPO, ref=VERIFIERS_REF),)
 
 
@@ -241,7 +215,7 @@ def parse_lab_setup_args(args: list[str]) -> LabSetupOptions:
     parser.add_argument(
         "--prime-rl",
         action="store_true",
-        help="Install prime-rl and download prime-rl configs.",
+        help="Install prime-rl.",
     )
     parser.add_argument(
         "--skip-agents-md",
@@ -403,7 +377,7 @@ def _run_lab_setup_steps(
         _install_prime_rl(workspace, emit, runner)
         _install_environments_to_prime_rl(workspace, emit, runner)
 
-    _copy_setup_configs(workspace, emit, prime_rl=options.prime_rl)
+    _copy_setup_configs(workspace, emit)
     emit("Lab setup completed\n")
 
 
@@ -515,6 +489,8 @@ def _download_repo_directory(
     source_path: str,
     dest: Path,
     emit: Emit,
+    *,
+    force: bool = True,
 ) -> None:
     payload = _download_json(_github_contents_url(repo, ref, source_path))
     if not isinstance(payload, list):
@@ -528,13 +504,13 @@ def _download_repo_directory(
         if not isinstance(name, str) or not isinstance(entry_path, str):
             continue
         if entry_type == "dir":
-            _download_repo_directory(repo, ref, entry_path, dest / name, emit)
+            _download_repo_directory(repo, ref, entry_path, dest / name, emit, force=force)
         elif entry_type == "file":
             _download_file(
                 _repo_raw_url(repo, ref, entry_path),
                 dest / name,
                 emit,
-                force=True,
+                force=force,
             )
 
 
@@ -593,35 +569,47 @@ def _read_prime_skills_manifest(skills_dir: Path) -> dict[str, Any]:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def _copy_setup_configs(workspace: Path, emit: Emit, *, prime_rl: bool) -> None:
-    _download_file(ENDPOINTS_SRC, workspace / "configs" / "endpoints.toml", emit)
-    configs: list[ConfigSpec] = []
-    if prime_rl:
-        configs.extend(PRIME_RL_CONFIGS)
-    configs.extend(GEPA_CONFIGS)
-    configs.extend(EVAL_CONFIGS)
-    if not prime_rl:
-        configs.extend(RL_CONFIGS)
-    _download_configs(workspace, _dedupe_config_destinations(configs), emit)
+def _copy_setup_configs(workspace: Path, emit: Emit) -> None:
+    _download_repo_directory(
+        VERIFIERS_REPO,
+        VERIFIERS_CONFIG_REF,
+        "configs",
+        workspace / "configs",
+        emit,
+        force=False,
+    )
 
 
 def _sync_config_templates(workspace: Path, emit: Emit) -> None:
-    template_root = workspace / ".prime" / "lab" / "templates"
-    _download_file(
-        ENDPOINTS_SRC,
-        template_root / "configs" / "endpoints.toml",
-        emit,
-        force=True,
-    )
-    configs: list[ConfigSpec] = [*GEPA_CONFIGS, *EVAL_CONFIGS, *RL_CONFIGS]
-    for repo, source_path, dest_path in _dedupe_config_destinations(configs):
-        ref = PRIME_RL_REF if repo == PRIME_RL_REPO else VERIFIERS_REF
-        _download_file(
-            _repo_raw_url(repo, ref, source_path),
-            template_root / dest_path,
+    global_template_root = _global_lab_templates_dir()
+    global_template_root.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix=".templates-staging-",
+        dir=str(global_template_root.parent),
+    ) as staging_dir:
+        staging_template_root = Path(staging_dir) / "templates"
+        _download_repo_directory(
+            VERIFIERS_REPO,
+            VERIFIERS_CONFIG_REF,
+            "configs",
+            staging_template_root / "configs",
             emit,
-            force=True,
         )
+        _remove_path(global_template_root)
+        shutil.move(str(staging_template_root), str(global_template_root))
+    emit(f"Refreshed {global_template_root}\n")
+
+    template_root = workspace / ".prime" / "lab" / "templates"
+    if template_root.resolve(strict=False) == global_template_root.resolve(strict=False):
+        return
+    _remove_path(template_root)
+    template_root.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(global_template_root, template_root)
+    emit(f"Refreshed {template_root}\n")
+
+
+def _global_lab_templates_dir() -> Path:
+    return Path.home() / ".prime" / "lab" / "templates"
 
 
 def _prepare_workspace_skill_dir(
@@ -783,9 +771,11 @@ def _lab_doctor_checks(options: LabDoctorOptions, workspace: Path) -> list[LabDo
         ),
         _gitignore_check(workspace),
         _config_validity_check(workspace),
+        _config_deprecated_fields_check(workspace),
         _config_environment_reference_check(workspace),
         _environment_source_hygiene_check(workspace),
         _managed_skill_manifest_check(),
+        _global_lab_templates_check(),
         _workspace_managed_skills_check(workspace),
         _path_check(
             "Lab templates",
@@ -847,6 +837,22 @@ def _managed_skill_manifest_check() -> LabDoctorCheck:
         name="Global Lab skill cache",
         status="WARN",
         message=f"Missing {_global_prime_skills_dir() / PRIME_SKILLS_MANIFEST}",
+        remediation="Run prime lab sync.",
+    )
+
+
+def _global_lab_templates_check() -> LabDoctorCheck:
+    path = _global_lab_templates_dir() / "configs" / "rl" / "gsm8k.toml"
+    if path.is_file():
+        return LabDoctorCheck(
+            name="Global Lab template cache",
+            status="PASS",
+            message=f"Installed at {_global_lab_templates_dir()}.",
+        )
+    return LabDoctorCheck(
+        name="Global Lab template cache",
+        status="WARN",
+        message=f"Missing {_global_lab_templates_dir()}",
         remediation="Run prime lab sync.",
     )
 
@@ -1042,6 +1048,59 @@ def _config_validity_check(workspace: Path) -> LabDoctorCheck:
         status="PASS",
         message=f"{len(config_paths)} config file(s) parse cleanly.",
     )
+
+
+def _config_deprecated_fields_check(workspace: Path) -> LabDoctorCheck:
+    configs_dir = workspace / "configs"
+    if not configs_dir.is_dir():
+        return LabDoctorCheck(
+            name="Config deprecated fields",
+            status="FAIL",
+            message="Missing configs directory.",
+            remediation="Run prime lab doctor --fix to create configs/.",
+        )
+    config_paths = sorted(configs_dir.rglob("*.toml"))
+    if not config_paths:
+        return LabDoctorCheck(
+            name="Config deprecated fields",
+            status="WARN",
+            message="No TOML configs found.",
+            remediation="Run prime lab setup or save a config copy from Lab.",
+        )
+    findings: list[str] = []
+    for path in config_paths:
+        try:
+            parsed = toml.loads(path.read_text(encoding="utf-8"))
+        except (OSError, toml.TomlDecodeError):
+            continue
+        for field_path, message in _deprecated_config_fields(parsed):
+            location = ".".join(field_path)
+            findings.append(f"{path.relative_to(workspace)}:{location} ({message})")
+    if findings:
+        return LabDoctorCheck(
+            name="Config deprecated fields",
+            status="WARN",
+            message="Deprecated " + ", ".join(findings[:5]),
+            remediation="Remove deprecated config fields or replace them with the suggested names.",
+        )
+    return LabDoctorCheck(
+        name="Config deprecated fields",
+        status="PASS",
+        message="No deprecated config fields found.",
+    )
+
+
+def _deprecated_config_fields(config: dict[str, Any]) -> list[DeprecatedConfigField]:
+    findings: list[DeprecatedConfigField] = []
+    for field_path, message in DEPRECATED_CONFIG_FIELDS:
+        value: Any = config
+        for part in field_path:
+            if not isinstance(value, dict) or part not in value:
+                break
+            value = value[part]
+        else:
+            findings.append((field_path, message))
+    return findings
 
 
 def _config_environment_reference_check(workspace: Path) -> LabDoctorCheck:
@@ -1334,12 +1393,6 @@ def _resolve_sync_agents(
     raise RuntimeError("No configured coding agent found. Run prime lab setup or pass --agent.")
 
 
-def _download_configs(workspace: Path, configs: list[ConfigSpec], emit: Emit) -> None:
-    for repo, source_path, dest_path in configs:
-        ref = PRIME_RL_REF if repo == PRIME_RL_REPO else VERIFIERS_REF
-        _download_file(_repo_raw_url(repo, ref, source_path), workspace / dest_path, emit)
-
-
 def _download_file(url: str, dest: Path, emit: Emit, *, force: bool = False) -> None:
     if dest.exists() and not force:
         emit(f"{dest.name} already exists\n")
@@ -1379,17 +1432,6 @@ def _read_url(url: str, *, emit: Emit | None = None) -> bytes:
                 emit(f"Download failed for {url}; retrying ({attempt + 1}/{DOWNLOAD_ATTEMPTS})\n")
             time.sleep(DOWNLOAD_RETRY_DELAY_SECONDS * attempt)
     raise RuntimeError(f"Failed to download {url}") from last_exc
-
-
-def _dedupe_config_destinations(configs: list[ConfigSpec]) -> list[ConfigSpec]:
-    deduped: list[ConfigSpec] = []
-    seen: set[str] = set()
-    for config in configs:
-        if config[2] in seen:
-            continue
-        seen.add(config[2])
-        deduped.append(config)
-    return deduped
 
 
 def _prime_package_version() -> str:

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -33,6 +33,36 @@ def fake_lab_asset_downloads(monkeypatch: Any) -> list[str]:
         "train-with-environments",
         "brainstorm",
     )
+    config_tree: dict[str, list[tuple[str, str]]] = {
+        "configs": [
+            ("endpoints.toml", "file"),
+            ("eval", "dir"),
+            ("gepa", "dir"),
+            ("local", "dir"),
+            ("rl", "dir"),
+            ("zero3.yaml", "file"),
+        ],
+        "configs/eval": [
+            ("debug.toml", "file"),
+            ("minimal.toml", "file"),
+            ("multi-env.toml", "file"),
+            ("wordle.toml", "file"),
+        ],
+        "configs/gepa": [
+            ("base.toml", "file"),
+            ("wordle.toml", "file"),
+        ],
+        "configs/local": [("prime-rl", "dir")],
+        "configs/local/prime-rl": [("wiki-search.toml", "file")],
+        "configs/rl": [
+            ("alphabet-sort.toml", "file"),
+            ("gsm8k.toml", "file"),
+            ("math-python.toml", "file"),
+            ("reverse-text.toml", "file"),
+            ("wiki-search.toml", "file"),
+            ("wordle.toml", "file"),
+        ],
+    }
 
     def fake_download_file(
         url: str,
@@ -76,6 +106,16 @@ def fake_lab_asset_downloads(monkeypatch: Any) -> list[str]:
                     "type": "dir",
                     "path": f"{source_path}/references",
                 },
+            ]
+        if "/contents/configs" in url:
+            source_path = url.split("/contents/", 1)[1].split("?", 1)[0]
+            return [
+                {
+                    "name": name,
+                    "type": entry_type,
+                    "path": f"{source_path}/{name}",
+                }
+                for name, entry_type in config_tree[source_path]
             ]
         return []
 
@@ -180,6 +220,8 @@ def test_lab_setup_service_downloads_upstream_assets_without_agent_installs(
     assert (tmp_path / ".pi" / "skills" / "create-environments").exists()
     assert not (home / ".pi" / "agent" / "skills").exists()
     assert (tmp_path / "configs" / "rl" / "gsm8k.toml").is_file()
+    assert (tmp_path / "configs" / "eval" / "debug.toml").is_file()
+    assert (tmp_path / "configs" / "zero3.yaml").is_file()
     assert any("npm install -g pi-acp" in line for line in emitted)
 
 
@@ -199,6 +241,7 @@ def test_lab_setup_uses_existing_verifiers_sources(
 
     assert result.exit_code == 0
     assert _is_pinned_ref(lab_setup.VERIFIERS_REF)
+    assert lab_setup.VERIFIERS_CONFIG_REF == "main"
     assert _is_pinned_ref(lab_setup.PRIME_RL_REF)
     assert any(
         url.endswith(
@@ -208,7 +251,7 @@ def test_lab_setup_uses_existing_verifiers_sources(
     )
     assert any(
         url.endswith(
-            f"/primeintellect-ai/verifiers/{lab_setup.VERIFIERS_REF}/configs/rl/gsm8k.toml"
+            f"/primeintellect-ai/verifiers/{lab_setup.VERIFIERS_CONFIG_REF}/configs/rl/gsm8k.toml"
         )
         for url in fake_lab_asset_downloads
     )
@@ -381,6 +424,36 @@ def test_lab_sync_all_scaffolds_amp_and_factory_skills(
     assert (tmp_path / ".prime" / "lab" / "templates" / "configs" / "rl" / "gsm8k.toml").is_file()
 
 
+def test_lab_sync_fully_refreshes_global_and_workspace_config_templates(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    global_templates = home / ".prime" / "lab" / "templates"
+    workspace_templates = tmp_path / ".prime" / "lab" / "templates"
+    for root in (global_templates, workspace_templates):
+        (root / "configs" / "rl").mkdir(parents=True)
+        (root / "configs" / "rl" / "gsm8k.toml").write_text("stale\n", encoding="utf-8")
+        (root / "configs" / "old.toml").write_text("old\n", encoding="utf-8")
+
+    result = run_lab_sync_service(
+        LabSyncOptions(skip_docs=True, no_agent=True),
+        workspace=tmp_path,
+        emit=lambda _text: None,
+    )
+
+    assert result.exit_code == 0
+    for root in (global_templates, workspace_templates):
+        refreshed = root / "configs" / "rl" / "gsm8k.toml"
+        assert refreshed.read_text(encoding="utf-8") == 'model = "openai/gpt-4.1-mini"\n'
+        assert not (root / "configs" / "old.toml").exists()
+        assert (root / "configs" / "eval" / "debug.toml").is_file()
+        assert (root / "configs" / "eval" / "wordle.toml").is_file()
+        assert (root / "configs" / "zero3.yaml").is_file()
+
+
 def test_lab_doctor_reports_missing_selected_agent_guidance(
     tmp_path: Path,
     monkeypatch: Any,
@@ -441,6 +514,34 @@ def test_lab_doctor_validates_environment_table_refs(tmp_path: Path) -> None:
 
     assert checks["Config environment refs"].status == "WARN"
     assert "missing-env" in checks["Config environment refs"].message
+
+
+def test_lab_doctor_warns_on_deprecated_config_fields(tmp_path: Path) -> None:
+    (tmp_path / ".prime").mkdir()
+    (tmp_path / ".prime" / "lab.json").write_text(
+        json.dumps({"choices": {"agents": ["codex"], "primary_agent": "codex"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "configs" / "rl").mkdir(parents=True)
+    (tmp_path / "configs" / "rl" / "old.toml").write_text(
+        'model = "Qwen/Qwen3.5-0.8B"\n'
+        'trajectory_strategy = "interleaved"\n'
+        'env_file = ["secrets.env"]\n'
+        "oversampling_factor = 2.0\n"
+        "max_async_level = 2\n"
+        "max_off_policy_steps = 4\n",
+        encoding="utf-8",
+    )
+
+    result = run_lab_doctor_service(LabDoctorOptions(), workspace=tmp_path)
+    checks = {check.name: check for check in result.checks}
+
+    assert checks["Config deprecated fields"].status == "WARN"
+    assert "configs/rl/old.toml:trajectory_strategy" in checks["Config deprecated fields"].message
+    assert "configs/rl/old.toml:env_file" in checks["Config deprecated fields"].message
+    assert "configs/rl/old.toml:oversampling_factor" in checks["Config deprecated fields"].message
+    assert "configs/rl/old.toml:max_async_level" in checks["Config deprecated fields"].message
+    assert "configs/rl/old.toml:max_off_policy_steps" in checks["Config deprecated fields"].message
 
 
 def test_lab_setup_installs_prime_rl_envs_with_split_editable_args(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Mirror the full upstream `verifiers/configs` tree for `prime lab setup` and `prime lab sync` instead of a hand-curated subset
- Refresh the managed global template cache before copying it into each workspace
- Warn in `prime lab doctor` on deprecated config fields, including `trajectory_strategy`, `env_file`, `oversampling_factor`, `max_async_level`, and `max_off_policy_steps`
- Keep config examples sourced from `verifiers@main` so new upstream files flow through automatically

## Testing
- `uv run pytest packages/prime/tests/test_lab_setup.py -q`
- `uv run ruff check packages/prime/src/prime_cli/lab_setup.py packages/prime/tests/test_lab_setup.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `prime lab setup`/`prime lab sync` source and refresh config templates (now mirroring the full upstream `verifiers/configs` tree and using a global cache), which could alter which files appear in user workspaces. Adds new `lab doctor` warnings for deprecated config keys, affecting diagnostics but not runtime execution.
> 
> **Overview**
> `prime lab setup` now mirrors the full upstream `verifiers/configs` tree into `configs/` (non-destructive if files already exist) instead of downloading a curated subset, and updates the verifiers pinned ref while sourcing config examples from `verifiers@main`.
> 
> `prime lab sync` now *fully refreshes* a global template cache at `~/.prime/lab/templates` before copying it into each workspace, ensuring stale template files are removed.
> 
> `prime lab doctor` adds checks to warn on deprecated config fields (e.g. `trajectory_strategy`, `env_file`, `oversampling_factor`, `max_async_level`, `max_off_policy_steps`) and to report missing global template cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263f782996cebdad76eba82709da8cde5fa97751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->