### PR TITLE
release: cli 0.5.82

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.81"
+__version__ = "0.5.82"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps the Prime CLI version from `0.5.81` to `0.5.82` for the next release.

Validation:
- `uv run --project packages/prime python -c "import prime_cli; assert prime_cli.__version__ == '0.5.82'; print(prime_cli.__version__)"`
- `uv build packages/prime --out-dir /private/tmp/prime-cli-release-build`
- commit hooks: `ruff`, `ruff format`, `ty`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the packaged CLI version constant and does not change runtime behavior.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.81` to `0.5.82` by updating `prime_cli.__version__` in `prime_cli/__init__.py` for the next release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2c6d123a7c0b9d0c75f4ef3a8bffc1587329a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->