### PR TITLE
release: cli 0.6.0

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.5.82"
+__version__ = "0.6.0"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps the Prime CLI package version to 0.6.0 for the next minor release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package `__version__` string with no functional or behavioral code changes.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.5.82` to `0.6.0` by updating `prime_cli.__version__` in `__init__.py` for the next minor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146d02f88988759f13d18626c3c134665f6f505e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->