### PR TITLE
Fix Lab Setup agent picker and button layout

### DIFF
--- a/packages/prime/src/prime_lab_app/setup_screens.py
+++ b/packages/prime/src/prime_lab_app/setup_screens.py
@@ -24,9 +24,9 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
-from textual.widgets import Button, Footer, Static
+from textual.widgets import Button, Footer, Select, Static
 
-from .agent_capabilities import agent_capability, known_agent_names
+from .agent_capabilities import agent_select_options
 from .environment_screen import EnvironmentScreen
 from .models import LabItem
 from .palette import STATUS_ERROR, STATUS_SUCCESS, STATUS_WARNING
@@ -41,7 +41,6 @@ class SetupScreen(Screen[None]):
     BINDINGS = [
         Binding("escape", "back", "Back", key_display="Esc"),
         Binding("b", "back", "Back", key_display="B"),
-        Binding("enter", "run_setup", "Run setup", key_display="Enter"),
     ]
 
     CSS = (
@@ -55,9 +54,34 @@ class SetupScreen(Screen[None]):
         height: 1fr;
     }
 
-    .setup-option-button {
-        width: 1fr;
-        margin-right: 1;
+    .setup-controls {
+        width: 42;
+        height: auto;
+        margin-top: 1;
+    }
+
+    .setup-field-label {
+        height: 1;
+        color: $text-muted;
+    }
+
+    .setup-agent-select {
+        width: 40;
+        height: auto;
+        background: $panel;
+    }
+
+    .setup-agent-select > SelectOverlay {
+        height: auto;
+        max-height: 20;
+        border: tall $primary;
+        background: $panel;
+    }
+
+    .setup-run-button {
+        width: auto;
+        min-width: 16;
+        margin-top: 1;
     }
 
     .setup-log {
@@ -75,28 +99,36 @@ class SetupScreen(Screen[None]):
         super().__init__()
         self._item = item
         self._on_complete = on_complete
-        self._agents = known_agent_names()
-        self._agent_index = 0
-        self._prime_rl = False
-        self._running = False
+        self._agent_options = agent_select_options("codex")
+        self._default_agent = str(self._agent_options[0][1])
+        self._command_running = False
         self._output = ""
 
     def compose(self) -> ComposeResult:
         yield Static(_setup_header(self._item), id="env-header", classes="page-header")
         with Vertical(classes="empty-panel setup-shell"):
             yield Static(_setup_body(self._item), markup=False)
-            with Horizontal(classes="setup-actions"):
-                yield Button(
-                    self._agent_label(),
+            with Vertical(classes="setup-controls"):
+                yield Static(
+                    "Choose your coding agent",
+                    id="setup-agent-label",
+                    classes="setup-field-label",
+                    markup=False,
+                )
+                yield Select(
+                    self._agent_options,
+                    value=self._default_agent,
+                    allow_blank=False,
                     id="setup-agent",
-                    classes="setup-option-button",
+                    classes="setup-agent-select",
+                    compact=False,
                 )
                 yield Button(
-                    self._prime_rl_label(),
-                    id="setup-prime-rl",
-                    classes="setup-option-button",
+                    "Run setup",
+                    id="setup-run",
+                    classes="setup-run-button",
+                    variant="primary",
                 )
-                yield Button("Run setup", id="setup-run", variant="primary")
             yield Static("Ready", id="setup-status", markup=False)
             with VerticalScroll(classes="setup-log"):
                 yield Static("Setup output will appear here.", id="setup-output", markup=False)
@@ -106,20 +138,20 @@ class SetupScreen(Screen[None]):
         self.app.pop_screen()
 
     def action_run_setup(self) -> None:
-        if self._running:
+        if self._command_running:
             return
         workspace = Path(str(self._item.raw.get("workspace") or self._item.subtitle)).resolve()
-        self._running = True
+        self._command_running = True
         self._output = ""
         self._set_setup_buttons_disabled(True)
         self.query_one("#setup-status", Static).update("Running setup ...")
         self.query_one("#setup-output", Static).update("")
-        self._run_setup_worker(workspace, self._selected_agent(), self._prime_rl)
+        self._run_setup_worker(workspace, self._selected_agent())
 
     @work(thread=True, exclusive=True)
-    def _run_setup_worker(self, workspace: Path, agent: str, prime_rl: bool) -> None:
+    def _run_setup_worker(self, workspace: Path, agent: str) -> None:
         result = run_lab_setup_service(
-            LabSetupOptions(prime_rl=prime_rl, agents=(agent,)),
+            LabSetupOptions(agents=(agent,)),
             workspace=workspace,
             emit=lambda text: self.app.call_from_thread(self._append_setup_output, text),
         )
@@ -130,7 +162,7 @@ class SetupScreen(Screen[None]):
         self.query_one("#setup-output", Static).update(Text(self._output))
 
     def _finish_setup(self, result: LabSetupResult) -> None:
-        self._running = False
+        self._command_running = False
         self._set_setup_buttons_disabled(False)
         if result.exit_code == 0:
             self.query_one("#setup-status", Static).update("Setup completed")
@@ -140,35 +172,16 @@ class SetupScreen(Screen[None]):
             self.query_one("#setup-status", Static).update("Setup failed")
 
     def _selected_agent(self) -> str:
-        return self._agents[self._agent_index % len(self._agents)]
-
-    def _agent_label(self) -> str:
-        return f"Agent: {agent_capability(self._selected_agent()).label}"
-
-    def _prime_rl_label(self) -> str:
-        return f"Prime RL: {'on' if self._prime_rl else 'off'}"
+        value = self.query_one("#setup-agent", Select).value
+        return self._default_agent if value is Select.BLANK else str(value)
 
     def _set_setup_buttons_disabled(self, disabled: bool) -> None:
-        for button_id in ("setup-agent", "setup-prime-rl", "setup-run"):
-            self.query_one(f"#{button_id}", Button).disabled = disabled
+        self.query_one("#setup-agent", Select).disabled = disabled
+        self.query_one("#setup-run", Button).disabled = disabled
 
     @on(Button.Pressed, "#setup-run")
     def _setup_pressed(self, _event: Button.Pressed) -> None:
         self.action_run_setup()
-
-    @on(Button.Pressed, "#setup-agent")
-    def _agent_pressed(self, _event: Button.Pressed) -> None:
-        if self._running:
-            return
-        self._agent_index = (self._agent_index + 1) % len(self._agents)
-        self.query_one("#setup-agent", Button).label = self._agent_label()
-
-    @on(Button.Pressed, "#setup-prime-rl")
-    def _prime_rl_pressed(self, _event: Button.Pressed) -> None:
-        if self._running:
-            return
-        self._prime_rl = not self._prime_rl
-        self.query_one("#setup-prime-rl", Button).label = self._prime_rl_label()
 
 
 class AgentSyncScreen(Screen[None]):
@@ -211,7 +224,7 @@ class AgentSyncScreen(Screen[None]):
         super().__init__()
         self._item = item
         self._on_complete = on_complete
-        self._running = False
+        self._command_running = False
         self._output = ""
 
     def compose(self) -> ComposeResult:
@@ -229,10 +242,10 @@ class AgentSyncScreen(Screen[None]):
         self.app.pop_screen()
 
     def action_run_sync(self) -> None:
-        if self._running:
+        if self._command_running:
             return
         workspace = Path(str(self._item.raw.get("workspace") or self._item.subtitle)).resolve()
-        self._running = True
+        self._command_running = True
         self._output = ""
         self.query_one("#sync-run", Button).disabled = True
         self.query_one("#sync-status", Static).update("Running sync ...")
@@ -254,7 +267,7 @@ class AgentSyncScreen(Screen[None]):
         self.query_one("#sync-output", Static).update(Text(self._output))
 
     def _finish_sync(self, result: LabSyncResult) -> None:
-        self._running = False
+        self._command_running = False
         self.query_one("#sync-run", Button).disabled = False
         if result.exit_code == 0:
             self.query_one("#sync-status", Static).update("Sync completed")
@@ -309,7 +322,7 @@ class DoctorScreen(Screen[None]):
         super().__init__()
         self._item = item
         self._on_complete = on_complete
-        self._running = False
+        self._command_running = False
 
     def compose(self) -> ComposeResult:
         yield Static(_doctor_header(self._item), id="env-header", classes="page-header")
@@ -345,10 +358,10 @@ class DoctorScreen(Screen[None]):
         self._run_doctor(fix=True)
 
     def _run_doctor(self, *, fix: bool) -> None:
-        if self._running:
+        if self._command_running:
             return
         workspace = Path(str(self._item.raw.get("workspace") or self._item.subtitle)).resolve()
-        self._running = True
+        self._command_running = True
         self._set_doctor_buttons_disabled(True)
         self.query_one("#doctor-status", Static).update(
             "Applying safe fixes ..." if fix else "Checking workspace ..."
@@ -361,7 +374,7 @@ class DoctorScreen(Screen[None]):
         self.app.call_from_thread(self._finish_doctor, result, fix)
 
     def _finish_doctor(self, result: LabDoctorResult, fix: bool) -> None:
-        self._running = False
+        self._command_running = False
         self._set_doctor_buttons_disabled(False)
         self.query_one("#doctor-status", Static).update(
             "Workspace passed" if result.exit_code == 0 else "Workspace needs attention"
@@ -410,7 +423,7 @@ def _setup_body(item: LabItem) -> Group:
     table.add_column()
     table.add_row("Workspace", str(item.raw.get("workspace") or item.subtitle))
     table.add_row("Command", str(item.raw.get("command") or "prime lab setup"))
-    note = Text("Press Enter to run setup in this workspace.", style=STATUS_WARNING)
+    note = Text("Choose an agent, then run setup in this workspace.", style=STATUS_WARNING)
     return Group(Text("Setup", style="bold"), table, Text(""), note)
 
 

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import prime_lab_app.agent_widget_model as agent_widget_model
 import pytest
@@ -27,6 +27,7 @@ from prime_cli.lab_mcp import _serve_lab_mcp_stdio, lab_mcp_tool_definitions
 from prime_cli.lab_setup import (
     LabDoctorOptions,
     LabSetupOptions,
+    LabSetupResult,
     LabSyncOptions,
     parse_lab_doctor_args,
     parse_lab_setup_args,
@@ -157,7 +158,7 @@ from prime_lab_app.platform_preview import preview_lab_config
 from prime_lab_app.readme import readme_links as _readme_links
 from prime_lab_app.readme import readme_markdown as _readme_markdown
 from prime_lab_app.rows import item_badges_text
-from prime_lab_app.setup_screens import AgentSyncScreen, DoctorScreen, SetupScreen
+from prime_lab_app.setup_screens import AgentSyncScreen, DoctorScreen, SetupScreen, _setup_body
 from prime_lab_app.shell import (
     compact_path,
     configured_workspace_agent,
@@ -6410,6 +6411,103 @@ async def test_prime_lab_app_opens_setup_screen_for_uninitialized_workspace(
         await pilot.pause()
 
         assert isinstance(app.screen, SetupScreen)
+
+
+@pytest.mark.asyncio
+async def test_setup_screen_uses_agent_select_without_prime_rl_option(
+    tmp_path: Path,
+) -> None:
+    snapshot = make_source().load(LabLoadOptions(limit=10, workspace=tmp_path))
+    app = PrimeLabView(lambda: snapshot)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app._dismiss_launch_screen()
+        await pilot.pause()
+        section = snapshot.section("workspace")
+        assert section is not None
+        setup_item = next(item for item in section.items if item.raw.get("type") == "setup_action")
+        app._show_item(setup_item)
+        app.action_load_detail()
+        await pilot.pause()
+
+        screen = app.screen
+        assert isinstance(screen, SetupScreen)
+        setup_body = _render_renderable(_setup_body(setup_item))
+        assert "Choose an agent, then run setup in this workspace." in setup_body
+        assert "Press Enter to run setup" not in setup_body
+        picker_label = _render_renderable(screen.query_one("#setup-agent-label", Static).content)
+        assert "Choose your coding agent" in picker_label
+        assert not screen.query("#setup-prime-rl")
+
+        agent_select = screen.query_one("#setup-agent", Select)
+        assert agent_select.value == "codex"
+        assert agent_select._options[0] == ("Codex", "codex")
+        assert all("Agent:" not in str(label) for label, _value in agent_select._options)
+
+        agent_select.value = "claude"
+        await pilot.pause()
+        assert screen._selected_agent() == "claude"
+
+        agent_select.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert agent_select.expanded is True
+        assert screen._command_running is False
+
+
+@pytest.mark.asyncio
+async def test_setup_screen_run_uses_selected_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = make_source().load(LabLoadOptions(limit=10, workspace=tmp_path))
+    app = PrimeLabView(lambda: snapshot)
+    captured: list[tuple[LabSetupOptions, Path]] = []
+
+    def fake_run_lab_setup_service(
+        options: LabSetupOptions,
+        *,
+        workspace: Path,
+        emit: Callable[[str], None],
+    ) -> LabSetupResult:
+        _ = emit
+        captured.append((options, workspace))
+        return LabSetupResult(exit_code=0, workspace=workspace)
+
+    monkeypatch.setattr(
+        "prime_lab_app.setup_screens.run_lab_setup_service",
+        fake_run_lab_setup_service,
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app._dismiss_launch_screen()
+        await pilot.pause()
+        section = snapshot.section("workspace")
+        assert section is not None
+        setup_item = next(item for item in section.items if item.raw.get("type") == "setup_action")
+        app._show_item(setup_item)
+        app.action_load_detail()
+        await pilot.pause()
+
+        screen = app.screen
+        assert isinstance(screen, SetupScreen)
+        agent_select = screen.query_one("#setup-agent", Select)
+        agent_select.value = "claude"
+        await pilot.pause()
+
+        screen.action_run_setup()
+        for _ in range(20):
+            if captured:
+                break
+            await pilot.pause()
+
+        assert captured
+        options, workspace = captured[0]
+        assert options.agents == ("claude",)
+        assert options.prime_rl is False
+        assert workspace == tmp_path.resolve()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Replace the busted Setup screen agent toggle with a real `Select` control using plain agent names.
- Remove the `prime-rl` option from the Setup UI.
- Move `Run setup` into a left-aligned row beneath the agent picker.
- Fix the screen-local running state so setup actions are no longer blocked by Textual internals.
- Add regressions for the Setup picker UI and selected-agent setup execution.

## Testing
- `pytest packages/prime/tests/test_lab_view.py -q` passed (`203 passed`)
- `ruff check` and `ruff format --check` passed on touched files
- `ty check packages/prime/src/prime_lab_app/setup_screens.py` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/control-flow update limited to Textual Lab setup/sync/doctor screens plus new UI-focused tests; main risk is regressions in agent selection/defaulting and command-running state handling.
> 
> **Overview**
> Updates the Lab `SetupScreen` UI to use a proper `Select` agent picker (label/value options via `agent_select_options`) and simplifies the layout by removing the `prime-rl` toggle and placing a single **Run setup** button beneath the picker.
> 
> Setup execution now always runs `run_lab_setup_service` with the selected agent only, and the screen-local running flags were renamed/standardized to `_command_running` across setup/sync/doctor to avoid actions being blocked.
> 
> Adds regression tests asserting the new picker text/controls, default + changed agent selection, and that running setup passes the chosen agent into `LabSetupOptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0454f7fb986cacef7237f74231187c109ac3bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->