### PR TITLE
Remove recursive Contents API walking from Lab setup

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -57,6 +57,7 @@ LAB_GITIGNORE_PATTERNS = (
 PRIME_SKILLS_MANIFEST = ".prime-managed.json"
 WORKSPACE_SKILLS_DIR = Path(".prime") / "skills"
 DeprecatedConfigField = tuple[tuple[str, ...], str]
+RepoTreeEntry = tuple[str, str]
 DEPRECATED_CONFIG_FIELDS: tuple[DeprecatedConfigField, ...] = (
     (("trajectory_strategy",), "`trajectory_strategy` is deprecated and ignored."),
     (("trajectoryStrategy",), "`trajectoryStrategy` is deprecated and ignored."),
@@ -65,6 +66,7 @@ DEPRECATED_CONFIG_FIELDS: tuple[DeprecatedConfigField, ...] = (
     (("max_async_level",), "`max_async_level` is outdated; remove it from Lab configs."),
     (("max_off_policy_steps",), "`max_off_policy_steps` is outdated; remove it from Lab configs."),
 )
+_REPO_TREE_CACHE: dict[tuple[str, str, int], tuple[RepoTreeEntry, ...]] = {}
 
 Emit = Callable[[str], None]
 Runner = Callable[[Sequence[str], Path, Emit], int]
@@ -502,26 +504,26 @@ def _download_repo_directory(
     *,
     force: bool = True,
 ) -> None:
-    payload = _download_json(_github_contents_url(repo, ref, source_path))
-    if not isinstance(payload, list):
+    normalized_source_path = _normalize_repo_path(source_path)
+    tree_entries = _repo_tree_entries(repo, ref)
+    prefix = f"{normalized_source_path}/" if normalized_source_path else ""
+    source_exists = any(
+        path == normalized_source_path and entry_type == "tree" for path, entry_type in tree_entries
+    )
+    file_entries = [
+        (path, path.removeprefix(prefix))
+        for path, entry_type in tree_entries
+        if entry_type == "blob" and path.startswith(prefix)
+    ]
+    if not source_exists and not file_entries:
         raise RuntimeError(f"Expected a directory listing for {repo}/{source_path}.")
-    for entry in payload:
-        if not isinstance(entry, dict):
-            continue
-        name = entry.get("name")
-        entry_type = entry.get("type")
-        entry_path = entry.get("path")
-        if not isinstance(name, str) or not isinstance(entry_path, str):
-            continue
-        if entry_type == "dir":
-            _download_repo_directory(repo, ref, entry_path, dest / name, emit, force=force)
-        elif entry_type == "file":
-            _download_file(
-                _repo_raw_url(repo, ref, entry_path),
-                dest / name,
-                emit,
-                force=force,
-            )
+    for entry_path, relative_path in sorted(file_entries):
+        _download_file(
+            _repo_raw_url(repo, ref, entry_path),
+            dest / relative_path,
+            emit,
+            force=force,
+        )
 
 
 def _hash_directory(root: Path) -> str:
@@ -535,17 +537,22 @@ def _hash_directory(root: Path) -> str:
 
 
 def _discover_skill_names(source: SkillSource) -> tuple[str, ...]:
-    payload = _download_json(_github_contents_url(source.repo, source.ref, source.path))
-    if not isinstance(payload, list):
+    normalized_source_path = _normalize_repo_path(source.path)
+    tree_entries = _repo_tree_entries(source.repo, source.ref)
+    source_exists = any(
+        path == normalized_source_path and entry_type == "tree" for path, entry_type in tree_entries
+    )
+    if not source_exists:
         raise RuntimeError(f"Expected a directory listing for {source.repo}/{source.path}.")
-    names: list[str] = []
-    for entry in payload:
-        if (
-            isinstance(entry, dict)
-            and entry.get("type") == "dir"
-            and isinstance(entry.get("name"), str)
-        ):
-            names.append(entry["name"])
+    prefix = f"{normalized_source_path}/" if normalized_source_path else ""
+    names = {
+        relative_path
+        for path, entry_type in tree_entries
+        if entry_type == "tree"
+        and path.startswith(prefix)
+        and (relative_path := path.removeprefix(prefix))
+        and "/" not in relative_path
+    }
     return tuple(sorted(names))
 
 
@@ -1442,8 +1449,35 @@ def _repo_raw_url(repo: str, ref: str, source_path: str) -> str:
     return f"https://raw.githubusercontent.com/{repo}/{ref}/{source_path}"
 
 
-def _github_contents_url(repo: str, ref: str, source_path: str) -> str:
-    return f"https://api.github.com/repos/{repo}/contents/{source_path}?ref={ref}"
+def _github_tree_url(repo: str, ref: str) -> str:
+    return f"https://api.github.com/repos/{repo}/git/trees/{ref}?recursive=1"
+
+
+def _normalize_repo_path(path: str) -> str:
+    return path.strip("/")
+
+
+def _repo_tree_entries(repo: str, ref: str) -> tuple[RepoTreeEntry, ...]:
+    cache_key = (repo, ref, id(_download_json))
+    cached = _REPO_TREE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    payload = _download_json(_github_tree_url(repo, ref))
+    if not isinstance(payload, dict) or not isinstance(payload.get("tree"), list):
+        raise RuntimeError(f"Expected a repository tree for {repo}/{ref}.")
+    if payload.get("truncated") is True:
+        raise RuntimeError(f"Repository tree for {repo}/{ref} is too large to download.")
+    entries: list[RepoTreeEntry] = []
+    for entry in payload["tree"]:
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path")
+        entry_type = entry.get("type")
+        if isinstance(path, str) and isinstance(entry_type, str):
+            entries.append((_normalize_repo_path(path), entry_type))
+    tree_entries = tuple(entries)
+    _REPO_TREE_CACHE[cache_key] = tree_entries
+    return tree_entries
 
 
 def _read_url(url: str, *, emit: Emit | None = None) -> bytes:

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -84,41 +84,29 @@ def fake_lab_asset_downloads(monkeypatch: Any) -> list[str]:
             dest.write_text(f"downloaded from {url}\n", encoding="utf-8")
         emit(f"Downloaded {dest}\n")
 
-    def fake_download_json(url: str) -> list[dict[str, str]]:
-        if "/contents/skills?" in url:
-            return [{"name": name, "type": "dir"} for name in skill_names]
-        if "/contents/skills/" in url:
-            source_path = url.split("/contents/", 1)[1].split("?", 1)[0]
-            if source_path.endswith("/references"):
-                return [
-                    {
-                        "name": "notes.md",
-                        "type": "file",
-                        "path": f"{source_path}/notes.md",
-                    }
-                ]
-            return [
-                {
-                    "name": "SKILL.md",
-                    "type": "file",
-                    "path": f"{source_path}/SKILL.md",
-                },
-                {
-                    "name": "references",
-                    "type": "dir",
-                    "path": f"{source_path}/references",
-                },
-            ]
-        if "/contents/configs" in url:
-            source_path = url.split("/contents/", 1)[1].split("?", 1)[0]
-            return [
-                {
-                    "name": name,
-                    "type": entry_type,
-                    "path": f"{source_path}/{name}",
-                }
-                for name, entry_type in config_tree[source_path]
-            ]
+    def fake_download_json(url: str) -> Any:
+        if "/git/trees/" in url:
+            tree = [{"path": "skills", "type": "tree"}]
+            for skill_name in skill_names:
+                source_path = f"skills/{skill_name}"
+                tree.extend(
+                    [
+                        {"path": source_path, "type": "tree"},
+                        {"path": f"{source_path}/SKILL.md", "type": "blob"},
+                        {"path": f"{source_path}/references", "type": "tree"},
+                        {"path": f"{source_path}/references/notes.md", "type": "blob"},
+                    ]
+                )
+            for source_path, entries in config_tree.items():
+                tree.append({"path": source_path, "type": "tree"})
+                for name, entry_type in entries:
+                    tree.append(
+                        {
+                            "path": f"{source_path}/{name}",
+                            "type": "tree" if entry_type == "dir" else "blob",
+                        }
+                    )
+            return {"tree": tree}
         return []
 
     monkeypatch.setattr("prime_cli.lab_setup._download_file", fake_download_file)

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -2067,7 +2067,7 @@ def test_prime_lab_doctor_service_warns_on_config_environment_refs(tmp_path: Pat
     )
 
 
-def _fake_lab_skill_download_json(url: str) -> list[dict[str, str]]:
+def _fake_lab_skill_download_json(url: str) -> Any:
     config_tree: dict[str, list[tuple[str, str]]] = {
         "configs": [
             ("endpoints.toml", "file"),
@@ -2098,27 +2098,22 @@ def _fake_lab_skill_download_json(url: str) -> list[dict[str, str]]:
             ("wordle.toml", "file"),
         ],
     }
-    if "/contents/skills?" in url:
-        return [{"name": "create-environments", "type": "dir"}]
-    if "/contents/skills/" in url:
-        source_path = url.split("/contents/", 1)[1].split("?", 1)[0]
-        return [
-            {
-                "name": "SKILL.md",
-                "type": "file",
-                "path": f"{source_path}/SKILL.md",
-            }
+    if "/git/trees/" in url:
+        tree = [
+            {"path": "skills", "type": "tree"},
+            {"path": "skills/create-environments", "type": "tree"},
+            {"path": "skills/create-environments/SKILL.md", "type": "blob"},
         ]
-    if "/contents/configs" in url:
-        source_path = url.split("/contents/", 1)[1].split("?", 1)[0]
-        return [
-            {
-                "name": name,
-                "type": entry_type,
-                "path": f"{source_path}/{name}",
-            }
-            for name, entry_type in config_tree[source_path]
-        ]
+        for source_path, entries in config_tree.items():
+            tree.append({"path": source_path, "type": "tree"})
+            for name, entry_type in entries:
+                tree.append(
+                    {
+                        "path": f"{source_path}/{name}",
+                        "type": "tree" if entry_type == "dir" else "blob",
+                    }
+                )
+        return {"tree": tree}
     return []
 
 


### PR DESCRIPTION
## Summary
- Replace recursive GitHub Contents API traversal with a single cached recursive Git tree lookup for Lab setup assets.
- Keep config and skill downloads local to the tree snapshot so nested paths like `configs/local/prime-rl` no longer depend on per-directory API calls.
- Update setup and Lab view tests to mock the Git tree shape instead of nested Contents responses.

## Testing
- `uv run pytest packages/prime/tests/test_lab_setup.py -q`
- `uv run pytest packages/prime/tests/test_lab_view.py -q`
- `uv run ruff check packages/prime/src/prime_cli/lab_setup.py packages/prime/tests/test_lab_setup.py packages/prime/tests/test_lab_view.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how Lab skills/config templates are discovered and downloaded from GitHub; failures would break `prime lab setup/sync` asset refresh, especially for nested directories or large repos (tree truncation handling).
> 
> **Overview**
> Lab setup/sync now fetches repository assets (skills and `configs` templates) by downloading a single **recursive Git tree** snapshot per repo/ref and deriving file lists from it, instead of recursively walking the GitHub Contents API.
> 
> This adds `_repo_tree_entries()` with in-memory caching and path normalization, updates `_download_repo_directory()` to download all matching `blob` files under a prefix, and updates `_discover_skill_names()` to infer top-level skill dirs from the tree. Tests were updated to mock `/git/trees/...` responses rather than per-directory `/contents/...` listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e8d14b250ad712339d0a931107b6c79b937e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->