### PR TITLE
release: cli 0.6.1

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bump the Prime CLI package version to 0.6.1.

## Validation
- `uv run pytest tests/test_cli_startup.py -q`
- `uv build --out-dir /private/tmp/prime-dist-0.6.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-only change that bumps the package version with no functional or behavioral code modifications.
> 
> **Overview**
> Bumps the Prime CLI package version from `0.6.0` to `0.6.1` in `prime_cli/__init__.py` for the `0.6.1` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1e9e56405d763a554dfb52babac4dc7dbdf680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->