### PR TITLE
release: prime-sandboxes 0.2.23 + prime CLI 0.6.2

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -47,7 +47,7 @@ from .models import (
 )
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.22"
+__version__ = "0.2.23"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.1.0",
+    "prime-sandboxes>=0.2.23",
     "prime-evals>=0.1.3",
     "prime-tunnel>=0.1.0",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
- prime-sandboxes 0.2.22 -> 0.2.23 (adds `guaranteed` field on CreateSandboxRequest)
- prime CLI 0.6.1 -> 0.6.2 (ships `--guaranteed`)
- CLI dep pinned to `prime-sandboxes>=0.2.23` so `--guaranteed` doesn't silently no-op against an older SDK
