### PR TITLE
Require pushed environments for eval uploads

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -987,6 +987,19 @@ def _resolve_eval_viewer_url(evaluation_id: str, response: Optional[dict[str, An
     return get_eval_viewer_url(evaluation_id)
 
 
+def _require_published_environment_for_eval_push(env_name: str, eval_path: Path) -> None:
+    console.print("[red]Error:[/red] Evaluation uploads require a pushed environment.")
+    console.print(
+        f"[yellow]Push '{env_name}' before uploading this evaluation:[/yellow] "
+        f"prime env push {env_name}"
+    )
+    console.print(
+        "[dim]Then retry with an owner-qualified environment, e.g. "
+        f"`prime eval push {eval_path} --env <owner>/{env_name}`.[/dim]"
+    )
+    raise typer.Exit(1)
+
+
 def _push_single_eval(
     config_path: str,
     env_slug: Optional[str],
@@ -1006,14 +1019,9 @@ def _push_single_eval(
 
     environments = None
     if env_slug and not run_id and not eval_id:
-        # Determine if env_slug is a slug (owner/name) or a name
-        # Use appropriate key so _resolve_environments can properly resolve it
-        if "/" in env_slug:
-            # It's a slug (owner/name format)
-            environments = [{"slug": env_slug}]
-        else:
-            # It's a name (will be resolved by _resolve_environments)
-            environments = [{"name": env_slug}]
+        if "/" not in env_slug:
+            _require_published_environment_for_eval_push(env_slug, path)
+        environments = [{"slug": env_slug}]
 
     console.print()
 
@@ -1116,7 +1124,10 @@ def push_eval(
         "--env",
         "--env-id",
         "-e",
-        help="Environment name (e.g., 'gsm8k' or 'owner/gsm8k')",
+        help=(
+            "Published environment slug (owner/name). "
+            "Push local environments with `prime env push` first."
+        ),
     ),
     run_id: Optional[str] = typer.Option(
         None,
@@ -1150,7 +1161,7 @@ def push_eval(
     Examples:
         prime eval push                                    # Push current dir or auto-discover
         prime eval push outputs/evals/gsm8k--gpt-4/abc123  # Push specific directory
-        prime eval push --env gsm8k                        # Push with environment override
+        prime eval push --env owner/gsm8k                  # Push with environment override
         prime eval push --name "gsm8k smoke test"         # Override evaluation display name
         prime eval push --public                           # Create a public evaluation
         prime eval push --eval xyz789 --name "rerun"      # Update an existing evaluation name
@@ -1243,8 +1254,8 @@ def push_eval(
         console.print("[yellow]Tip:[/yellow] You must provide one of:")
         console.print("  --eval <eval_id>     (to update an existing evaluation)")
         console.print("  --run-id <run_id>    (to link to an existing training run)")
-        console.print("  --env <env>          (environment name, e.g., 'gsm8k' or 'owner/gsm8k')")
-        console.print("  [or ensure 'env' or 'env_id' is set in metadata.json]")
+        console.print("  --env <env>          (published environment slug, e.g., 'owner/gsm8k')")
+        console.print("  [or ensure owner/name 'env' or 'env_id' is set in metadata.json]")
         raise typer.Exit(1)
     except KeyError as e:
         console.print(f"[red]Error:[/red] Missing required field: {e}")

--- a/packages/prime/tests/test_eval_push.py
+++ b/packages/prime/tests/test_eval_push.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+import typer
 from prime_cli.commands.evals import (
     _has_eval_files,
     _load_eval_directory,
@@ -9,6 +10,7 @@ from prime_cli.commands.evals import (
 )
 from prime_cli.main import app
 from typer.testing import CliRunner
+from typing_extensions import cast
 
 runner = CliRunner()
 
@@ -185,7 +187,7 @@ def test_push_eval_forwards_name_override(monkeypatch, tmp_path):
 
 class TestPushSingleEval:
     def test_create_evaluation_defaults_to_private(self, tmp_path, monkeypatch):
-        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 
@@ -210,9 +212,24 @@ class TestPushSingleEval:
 
         assert eval_id == "eval-123"
         assert captured["is_public"] is False
+        assert captured["environments"] == [{"slug": "owner/gsm8k"}]
+
+    def test_create_evaluation_requires_pushed_environment(self, tmp_path, capsys):
+        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+        (tmp_path / "results.jsonl").write_text("")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            _push_single_eval(str(tmp_path), None, None, None)
+
+        assert cast(typer.Exit, exc_info.value).exit_code == 1
+        output = capsys.readouterr().out
+        assert "Evaluation uploads require a pushed environment" in output
+        assert "prime env push gsm8k" in output
+        assert "--env <owner>/gsm8k" in output
 
     def test_create_evaluation_passes_public_flag(self, tmp_path, monkeypatch):
-        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 
@@ -239,7 +256,7 @@ class TestPushSingleEval:
         assert captured["is_public"] is True
 
     def test_create_evaluation_prefers_explicit_name_override(self, tmp_path, monkeypatch):
-        metadata = {"env": "gsm8k", "model": "gpt-4", "eval_name": "metadata name"}
+        metadata = {"env": "owner/gsm8k", "model": "gpt-4", "eval_name": "metadata name"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 
@@ -297,7 +314,7 @@ class TestPushSingleEval:
         assert captured["name"] == "explicit override"
 
     def test_push_single_eval_prints_returned_viewer_url(self, tmp_path, monkeypatch, capsys):
-        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 
@@ -331,7 +348,7 @@ class TestPushSingleEval:
     def test_push_single_eval_falls_back_to_configured_viewer_url(
         self, tmp_path, monkeypatch, capsys
     ):
-        metadata = {"env": "gsm8k", "model": "gpt-4"}
+        metadata = {"env": "owner/gsm8k", "model": "gpt-4"}
         (tmp_path / "metadata.json").write_text(json.dumps(metadata))
         (tmp_path / "results.jsonl").write_text("")
 


### PR DESCRIPTION
## Summary
- Block `prime eval push` from creating uploads against bare local environment names.
- Prompt users to run `prime env push <env>` and retry with an owner-qualified environment slug before uploading.
- Update eval push help/tests to reflect that uploads require a published environment.

## Validation
- `uv run pytest packages/prime/tests/test_eval_push.py -q`
- `uv run pytest packages/prime/tests/test_eval_help.py packages/prime/tests/test_eval_push.py -q`
- `uv run ruff check packages/prime/src/prime_cli/commands/evals.py packages/prime/tests/test_eval_push.py`
- `uv run ty check packages/prime/src/prime_cli/commands/evals.py packages/prime/tests/test_eval_push.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `prime eval push` behavior to hard-fail when given an unqualified environment name, which may break existing workflows/scripts that relied on local env names.
> 
> **Overview**
> `prime eval push` now **requires a published environment slug (`owner/name`)** when associating an environment with an uploaded evaluation; passing a bare env name triggers a clear error prompting `prime env push` and a retry with an owner-qualified slug.
> 
> CLI help text, examples, and error tips were updated accordingly, and tests were adjusted/added to assert the new enforcement and that the API receives `environments=[{"slug": ...}]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854710b0d30bf9883a523534d4f357403b2ddc01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->