### PR TITLE
Fix Lab discovery permission errors

### DIFF
--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -945,35 +945,30 @@ def discover_local_eval_runs(
 ) -> list[dict[str, Any]]:
     roots: list[Path] = []
     env_root = (workspace / env_dir).resolve()
-    if env_root.is_dir():
-        for env_path in sorted(env_root.iterdir(), key=lambda path: path.name):
+    if _safe_is_dir(env_root):
+        for env_path in _safe_sorted_children(env_root):
             candidate = env_path / "outputs" / "evals"
-            if candidate.is_dir():
+            if _safe_is_dir(candidate):
                 roots.append(candidate)
 
     global_root = (workspace / outputs_dir / "evals").resolve()
-    if global_root.is_dir():
+    if _safe_is_dir(global_root):
         roots.append(global_root)
 
     runs: list[dict[str, Any]] = []
     for root in roots:
-        for env_model_dir in sorted(root.iterdir(), key=lambda path: path.name):
-            if not env_model_dir.is_dir() or "--" not in env_model_dir.name:
+        for env_model_dir in _safe_sorted_children(root):
+            if not _safe_is_dir(env_model_dir) or "--" not in env_model_dir.name:
                 continue
             env_id, model_part = env_model_dir.name.split("--", 1)
             model = model_part.replace("--", "/")
-            run_dirs = sorted(
-                env_model_dir.iterdir(),
-                key=lambda path: path.name,
-                reverse=True,
-            )
-            for run_dir in run_dirs:
+            for run_dir in _safe_sorted_children(env_model_dir, reverse=True):
                 metadata_path = run_dir / "metadata.json"
                 results_path = run_dir / "results.jsonl"
                 if (
-                    not run_dir.is_dir()
-                    or not metadata_path.is_file()
-                    or not results_path.is_file()
+                    not _safe_is_dir(run_dir)
+                    or not _safe_is_file(metadata_path)
+                    or not _safe_is_file(results_path)
                 ):
                     continue
                 metadata = _read_json_file(metadata_path)
@@ -989,6 +984,27 @@ def discover_local_eval_runs(
                 if len(runs) >= limit:
                     return runs
     return runs
+
+
+def _safe_sorted_children(path: Path, *, reverse: bool = False) -> list[Path]:
+    try:
+        return sorted(path.iterdir(), key=lambda child: child.name, reverse=reverse)
+    except OSError:
+        return []
+
+
+def _safe_is_dir(path: Path) -> bool:
+    try:
+        return path.is_dir()
+    except OSError:
+        return False
+
+
+def _safe_is_file(path: Path) -> bool:
+    try:
+        return path.is_file()
+    except OSError:
+        return False
 
 
 def _local_eval_items(options: LabLoadOptions, *, section: str) -> list[LabItem]:
@@ -1441,7 +1457,7 @@ def _lab_workspace_search_roots(active_workspace: Path) -> list[Path]:
             root = candidate.resolve()
         except OSError:
             continue
-        if not root.is_dir() or root in seen:
+        if not _safe_is_dir(root) or root in seen:
             continue
         roots.append(root)
         seen.add(root)
@@ -1469,9 +1485,9 @@ def _iter_lab_workspace_markers(root: Path) -> list[Path]:
             depth = len(current_path.relative_to(root).parts)
         except ValueError:
             depth = 0
-        if (current_path / ".prime" / "lab.json").is_file() or (
+        if _safe_is_file(current_path / ".prime" / "lab.json") or _safe_is_file(
             current_path / ".prime" / "lab_setup.json"
-        ).is_file():
+        ):
             workspaces.append(current_path)
         if depth >= max_depth:
             dirs[:] = []
@@ -1488,7 +1504,7 @@ def _read_lab_workspace_metadata(workspace: Path) -> dict[str, Any] | None:
     metadata: dict[str, Any] = {}
     for filename in ("lab_setup.json", "lab.json"):
         path = workspace / ".prime" / filename
-        if not path.is_file():
+        if not _safe_is_file(path):
             continue
         try:
             loaded = json.loads(path.read_text(encoding="utf-8"))

--- a/packages/prime/src/prime_lab_app/environment_records.py
+++ b/packages/prime/src/prime_lab_app/environment_records.py
@@ -159,15 +159,21 @@ def _local_environment_records(
     limit: int,
 ) -> list[LocalEnvironmentRecord]:
     env_root = _workspace_path(workspace, env_dir)
-    if not env_root.is_dir():
+    try:
+        if not env_root.is_dir():
+            return []
+    except OSError:
         return []
 
     records: list[LocalEnvironmentRecord] = []
-    for path in sorted(child for child in env_root.iterdir() if child.is_dir()):
+    for path in _safe_environment_dirs(env_root):
         if path.name.startswith("."):
             continue
         project = _read_pyproject(path)
-        hub_metadata = get_environment_metadata(path) or {}
+        try:
+            hub_metadata = get_environment_metadata(path) or {}
+        except OSError:
+            hub_metadata = {}
         readme_path, readme_preview = _read_readme_preview(path)
         records.append(
             LocalEnvironmentRecord(
@@ -185,6 +191,21 @@ def _local_environment_records(
         if len(records) >= limit:
             break
     return records
+
+
+def _safe_environment_dirs(env_root: Path) -> list[Path]:
+    try:
+        children = sorted(env_root.iterdir(), key=lambda child: child.name)
+    except OSError:
+        return []
+    dirs: list[Path] = []
+    for child in children:
+        try:
+            if child.is_dir():
+                dirs.append(child)
+        except OSError:
+            continue
+    return dirs
 
 
 def _environment_item_from_record(
@@ -315,9 +336,9 @@ def _platform_slug(env: dict[str, Any]) -> str:
 
 def _read_pyproject(path: Path) -> dict[str, Any]:
     pyproject_path = path / "pyproject.toml"
-    if not pyproject_path.is_file():
-        return {}
     try:
+        if not pyproject_path.is_file():
+            return {}
         parsed = toml.loads(pyproject_path.read_text(encoding="utf-8"))
     except (OSError, toml.TomlDecodeError):
         return {}
@@ -335,12 +356,12 @@ def _local_content_hash(path: Path) -> str:
 def _read_readme_preview(path: Path) -> tuple[str | None, str]:
     for name in ("README.md", "README.rst", "README.txt", "README"):
         readme = path / name
-        if not readme.is_file():
-            continue
         try:
+            if not readme.is_file():
+                continue
             text = readme.read_text(encoding="utf-8", errors="replace")
         except OSError:
-            return str(readme), ""
+            continue
         preview = " ".join(text.strip().split())
         return str(readme), preview[:500]
     return None, ""
@@ -362,11 +383,18 @@ def _relative_path(path: Path, root: Path) -> str:
 
 def _interesting_child_files(path: Path) -> list[str]:
     names = []
-    for child in sorted(path.iterdir()):
+    try:
+        children = sorted(path.iterdir())
+    except OSError:
+        return names
+    for child in children:
         if child.name.startswith("."):
             continue
-        if child.is_file() and child.suffix in {".py", ".toml", ".md", ".json"}:
-            names.append(child.name)
+        try:
+            if child.is_file() and child.suffix in {".py", ".toml", ".md", ".json"}:
+                names.append(child.name)
+        except OSError:
+            continue
     return names[:12]
 
 

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -132,7 +132,13 @@ from prime_lab_app.config_screen import (
     build_config_from_fields,
     launch_command_for_config,
 )
-from prime_lab_app.data import LabDataSource, LabLoadOptions, discover_local_eval_runs
+from prime_lab_app.data import (
+    LabDataSource,
+    LabLoadOptions,
+    _iter_lab_workspace_markers,
+    discover_local_eval_runs,
+)
+from prime_lab_app.environment_records import local_environment_items
 from prime_lab_app.environment_screen import (
     AddWorkspaceScreen,
     EnvironmentAction,
@@ -1691,6 +1697,49 @@ def test_discover_local_eval_runs(tmp_path: Path) -> None:
             "metadata": {"avg_reward": 0.5, "num_examples": 1, "rollouts_per_example": 2},
         }
     ]
+
+
+def test_discover_local_eval_runs_skips_unreadable_output_dirs(tmp_path: Path) -> None:
+    blocked = tmp_path / "outputs" / "evals" / "gsm8k--openai--gpt-4"
+    blocked.mkdir(parents=True)
+    blocked.chmod(0)
+    try:
+        if os.access(blocked, os.R_OK | os.X_OK):
+            pytest.skip("filesystem permissions do not block the current test user")
+        assert discover_local_eval_runs(tmp_path) == []
+    finally:
+        blocked.chmod(0o700)
+
+
+def test_iter_lab_workspace_markers_skips_unreadable_siblings(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / ".prime").mkdir(parents=True)
+    (workspace / ".prime" / "lab.json").write_text("{}", encoding="utf-8")
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    blocked.chmod(0)
+    try:
+        if os.access(blocked, os.R_OK | os.X_OK):
+            pytest.skip("filesystem permissions do not block the current test user")
+        assert _iter_lab_workspace_markers(tmp_path) == [workspace]
+    finally:
+        blocked.chmod(0o700)
+
+
+def test_local_environment_items_tolerates_unreadable_environment_dirs(tmp_path: Path) -> None:
+    blocked = tmp_path / "environments" / "blocked-env"
+    blocked.mkdir(parents=True)
+    blocked.chmod(0)
+    try:
+        if os.access(blocked, os.R_OK | os.X_OK):
+            pytest.skip("filesystem permissions do not block the current test user")
+        items = local_environment_items(tmp_path, "./environments", 10, section="environments")
+    finally:
+        blocked.chmod(0o700)
+
+    assert len(items) == 1
+    assert items[0].title == "blocked-env"
+    assert items[0].raw["local"]["files"] == []
 
 
 def test_local_eval_lazy_records_and_overview_stats(tmp_path: Path) -> None:


### PR DESCRIPTION
Skips unreadable local Lab discovery paths so restricted sibling directories and output folders no longer crash prime lab.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local filesystem traversal and add defensive `OSError` handling plus tests to prevent crashes when directories are unreadable.
> 
> **Overview**
> Fixes Lab TUI local discovery crashes when encountering *permission-restricted* directories by wrapping `Path.is_dir`/`is_file` and `iterdir` calls in safe helpers and skipping unreadable paths.
> 
> Adds targeted tests covering unreadable eval output folders, unreadable sibling directories during workspace marker scans, and unreadable environment directories (ensuring discovery continues and returns empty file lists rather than erroring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d8f60d778febff012d89152c768c4e30b11402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->