### PR TITLE
fix: don't crash prime lab view on TCC-protected dirs

### DIFF
--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -1448,16 +1448,8 @@ def _lab_workspace_search_roots(active_workspace: Path) -> list[Path]:
     return roots
 
 
-def _safe_is_file(path: Path) -> bool:
-    try:
-        return path.is_file()
-    except OSError:
-        return False
-
-
-def _iter_lab_workspace_markers(root: Path) -> list[Path]:
-    workspaces: list[Path] = []
-    skip_dirs = {
+_LAB_BASE_SKIP_DIRS = frozenset(
+    {
         ".git",
         ".mypy_cache",
         ".pytest_cache",
@@ -1468,16 +1460,30 @@ def _iter_lab_workspace_markers(root: Path) -> list[Path]:
         "dist",
         "node_modules",
         "outputs",
-        # macOS user-home dirs that are typically TCC-protected or noisy.
-        "Applications",
-        "Desktop",
-        "Downloads",
-        "Library",
-        "Movies",
-        "Music",
-        "Pictures",
-        "Public",
     }
+)
+
+# Top-level dirs under $HOME that are TCC-protected on macOS — stat'ing files
+# inside them raises PermissionError without Full Disk Access. Only skip these
+# when we are walking $HOME itself, not at arbitrary depths in the tree.
+_HOME_SKIP_DIRS = frozenset(
+    {"Applications", "Desktop", "Downloads", "Library", "Movies", "Pictures"}
+)
+
+
+def _safe_is_file(path: Path) -> bool:
+    try:
+        return path.is_file()
+    except PermissionError:
+        return False
+
+
+def _iter_lab_workspace_markers(root: Path) -> list[Path]:
+    workspaces: list[Path] = []
+    try:
+        home = Path.home()
+    except (OSError, RuntimeError):
+        home = None
     max_depth = 3
     for current, dirs, _files in os.walk(root, onerror=lambda _err: None):
         current_path = Path(current)
@@ -1492,10 +1498,13 @@ def _iter_lab_workspace_markers(root: Path) -> list[Path]:
         if depth >= max_depth:
             dirs[:] = []
             continue
+        skip = _LAB_BASE_SKIP_DIRS
+        if home is not None and current_path == home:
+            skip = skip | _HOME_SKIP_DIRS
         dirs[:] = [
             directory
             for directory in dirs
-            if directory not in skip_dirs and not directory.startswith(".")
+            if directory not in skip and not directory.startswith(".")
         ]
     return sorted(workspaces, key=lambda path: path.name.lower())
 

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -1448,6 +1448,13 @@ def _lab_workspace_search_roots(active_workspace: Path) -> list[Path]:
     return roots
 
 
+def _safe_is_file(path: Path) -> bool:
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
 def _iter_lab_workspace_markers(root: Path) -> list[Path]:
     workspaces: list[Path] = []
     skip_dirs = {
@@ -1461,17 +1468,26 @@ def _iter_lab_workspace_markers(root: Path) -> list[Path]:
         "dist",
         "node_modules",
         "outputs",
+        # macOS user-home dirs that are typically TCC-protected or noisy.
+        "Applications",
+        "Desktop",
+        "Downloads",
+        "Library",
+        "Movies",
+        "Music",
+        "Pictures",
+        "Public",
     }
     max_depth = 3
-    for current, dirs, _files in os.walk(root):
+    for current, dirs, _files in os.walk(root, onerror=lambda _err: None):
         current_path = Path(current)
         try:
             depth = len(current_path.relative_to(root).parts)
         except ValueError:
             depth = 0
-        if (current_path / ".prime" / "lab.json").is_file() or (
+        if _safe_is_file(current_path / ".prime" / "lab.json") or _safe_is_file(
             current_path / ".prime" / "lab_setup.json"
-        ).is_file():
+        ):
             workspaces.append(current_path)
         if depth >= max_depth:
             dirs[:] = []
@@ -1488,7 +1504,7 @@ def _read_lab_workspace_metadata(workspace: Path) -> dict[str, Any] | None:
     metadata: dict[str, Any] = {}
     for filename in ("lab_setup.json", "lab.json"):
         path = workspace / ".prime" / filename
-        if not path.is_file():
+        if not _safe_is_file(path):
             continue
         try:
             loaded = json.loads(path.read_text(encoding="utf-8"))

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -132,7 +132,12 @@ from prime_lab_app.config_screen import (
     build_config_from_fields,
     launch_command_for_config,
 )
-from prime_lab_app.data import LabDataSource, LabLoadOptions, discover_local_eval_runs
+from prime_lab_app.data import (
+    LabDataSource,
+    LabLoadOptions,
+    _iter_lab_workspace_markers,
+    discover_local_eval_runs,
+)
 from prime_lab_app.environment_screen import (
     AddWorkspaceScreen,
     EnvironmentAction,
@@ -7353,3 +7358,32 @@ def _local_eval_item(
             "metadata": metadata,
         },
     )
+
+
+def test_iter_lab_workspace_markers_skips_unreadable_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Real lab workspace that should still be discovered.
+    good = tmp_path / "good"
+    (good / ".prime").mkdir(parents=True)
+    (good / ".prime" / "lab.json").write_text("{}", encoding="utf-8")
+
+    # A sibling whose .prime/lab.json triggers PermissionError on stat,
+    # mirroring macOS TCC behaviour for protected user dirs.
+    blocked = tmp_path / "blocked"
+    (blocked / ".prime").mkdir(parents=True)
+    blocked_marker = blocked / ".prime" / "lab.json"
+
+    real_is_file = Path.is_file
+
+    def fake_is_file(self: Path) -> bool:
+        if self == blocked_marker:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", fake_is_file)
+
+    result = _iter_lab_workspace_markers(tmp_path)
+
+    assert good in result
+    assert blocked not in result


### PR DESCRIPTION
- `prime lab view` walks `$HOME` while looking for sibling Lab workspaces and crashes on macOS dirs like `~/Downloads` where `stat()` returns `EACCES`.
- Wrap `is_file()` in a safe helper, ignore `os.walk` errors, and skip the standard macOS user dirs (`Downloads`, `Desktop`, `Library`, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrowly scoped error-handling changes to local filesystem walking/stat calls plus a targeted regression test; main risk is skipping a workspace in an unusual directory layout.
> 
> **Overview**
> Prevents `prime lab view` from crashing during local workspace discovery when encountering unreadable (macOS TCC-protected) directories.
> 
> Workspace scanning now ignores `os.walk` errors, uses a `_safe_is_file` helper to treat `PermissionError` as “not a file”, and adds an extra skip list for top-level `$HOME` protected folders. A new test covers the `PermissionError` case to ensure readable workspaces are still discovered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c004ff1853aa305d88120fc5e52eba41bce5dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->