### PR TITLE
feature: --mine flag for prime train list

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1396,7 +1396,9 @@ def list_configs(
     )
 
 
-def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> None:
+def _list_runs_impl(
+    team: Optional[str], num: int, page: int, output: str, mine: bool = False
+) -> None:
     """Implementation for listing Hosted Training runs."""
     validate_output_format(output, console)
 
@@ -1412,6 +1414,17 @@ def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> No
         team_id = team or config.team_id
 
         all_runs = rl_client.list_runs(team_id=team_id)
+
+        if mine:
+            current_user_id = config.user_id
+            if not current_user_id:
+                console.print(
+                    "[red]Error:[/red] Cannot filter by user - no user_id configured. "
+                    "Run [bold]prime whoami[/bold] to refresh your config."
+                )
+                raise typer.Exit(1)
+            all_runs = [r for r in all_runs if r.user_id == current_user_id]
+
         total_count = len(all_runs)
 
         # Sort by created_at descending and paginate
@@ -1476,12 +1489,15 @@ def _list_runs_impl(team: Optional[str], num: int, page: int, output: str) -> No
 @app.command("list", rich_help_panel="Commands", epilog=RL_LIST_JSON_HELP)
 def list_runs(
     team: Optional[str] = typer.Option(None, "--team", "-t", help="Filter by team ID"),
+    mine: bool = typer.Option(
+        False, "--mine", help="Filter to only your own runs (useful for admin accounts)"
+    ),
     num: int = typer.Option(20, "--num", "-n", help="Items per page"),
     page: int = typer.Option(1, "--page", "-p", help="Page number"),
     output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ) -> None:
     """List your runs (alias: ls)."""
-    _list_runs_impl(team, num, page, output)
+    _list_runs_impl(team, num, page, output, mine=mine)
 
 
 @app.command("get", rich_help_panel="Commands", epilog=RL_RUN_JSON_HELP)


### PR DESCRIPTION
Accounts see all users' runs by default across teams — add a --mine flag to filter the list to runs owned by the authenticated user. Mirrors the existing pattern in `prime env list --mine` (env.py) and uses client-side filtering by `config.user_id` (same approach as `prime tunnel rm --only-mine`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI-only change that adds optional client-side filtering of listed runs by `config.user_id`. Main failure mode is a new user-facing error when `--mine` is used without a configured user id.
> 
> **Overview**
> Adds a `--mine` flag to `prime train list` to optionally restrict results to runs owned by the currently authenticated user.
> 
> When enabled, the command filters the fetched run list by `config.user_id` and exits with a clear error instructing users to run `prime whoami` if no `user_id` is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f56d8c61cd04763126b32985fac6e4c0451638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->