### PR TITLE
Limit Lab config downloads to training and eval folders

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -39,6 +39,7 @@ VERIFIERS_CONFIG_REF = "main"
 PRIME_RL_REF = "38b524925d09ce917b51e54bd99446b822f0a87f"
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
+LAB_CONFIG_FOLDERS = ("rl", "gepa", "eval", "sft", "opd", "fft")
 
 SUPPORTED_AGENTS = known_agent_names()
 LAB_GITIGNORE_PATTERNS = (
@@ -503,6 +504,7 @@ def _download_repo_directory(
     emit: Emit,
     *,
     force: bool = True,
+    missing_ok: bool = False,
 ) -> None:
     normalized_source_path = _normalize_repo_path(source_path)
     tree_entries = _repo_tree_entries(repo, ref)
@@ -516,6 +518,8 @@ def _download_repo_directory(
         if entry_type == "blob" and path.startswith(prefix)
     ]
     if not source_exists and not file_entries:
+        if missing_ok:
+            return
         raise RuntimeError(f"Expected a directory listing for {repo}/{source_path}.")
     for entry_path, relative_path in sorted(file_entries):
         _download_file(
@@ -587,14 +591,20 @@ def _read_prime_skills_manifest(skills_dir: Path) -> dict[str, Any]:
 
 
 def _copy_setup_configs(workspace: Path, emit: Emit) -> None:
-    _download_repo_directory(
-        VERIFIERS_REPO,
-        VERIFIERS_CONFIG_REF,
-        "configs",
-        workspace / "configs",
-        emit,
-        force=False,
-    )
+    _download_lab_config_folders(workspace / "configs", emit, force=False)
+
+
+def _download_lab_config_folders(dest: Path, emit: Emit, *, force: bool = True) -> None:
+    for folder in LAB_CONFIG_FOLDERS:
+        _download_repo_directory(
+            VERIFIERS_REPO,
+            VERIFIERS_CONFIG_REF,
+            f"configs/{folder}",
+            dest / folder,
+            emit,
+            force=force,
+            missing_ok=True,
+        )
 
 
 def _sync_config_templates(workspace: Path, emit: Emit) -> None:
@@ -605,13 +615,7 @@ def _sync_config_templates(workspace: Path, emit: Emit) -> None:
         dir=str(global_template_root.parent),
     ) as staging_dir:
         staging_template_root = Path(staging_dir) / "templates"
-        _download_repo_directory(
-            VERIFIERS_REPO,
-            VERIFIERS_CONFIG_REF,
-            "configs",
-            staging_template_root / "configs",
-            emit,
-        )
+        _download_lab_config_folders(staging_template_root / "configs", emit)
         _remove_path(global_template_root)
         shutil.move(str(staging_template_root), str(global_template_root))
     emit(f"Refreshed {global_template_root}\n")

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -215,7 +215,9 @@ def test_lab_setup_service_downloads_upstream_assets_without_agent_installs(
     assert not (home / ".pi" / "agent" / "skills").exists()
     assert (tmp_path / "configs" / "rl" / "gsm8k.toml").is_file()
     assert (tmp_path / "configs" / "eval" / "debug.toml").is_file()
-    assert (tmp_path / "configs" / "zero3.yaml").is_file()
+    assert not (tmp_path / "configs" / "endpoints.toml").exists()
+    assert not (tmp_path / "configs" / "local").exists()
+    assert not (tmp_path / "configs" / "zero3.yaml").exists()
     assert (tmp_path / ".prime" / "lab" / "templates" / "configs" / "rl" / "gsm8k.toml").is_file()
     assert (tmp_path / ".prime" / "lab" / "docs" / "index.md").is_file()
     gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
@@ -315,6 +317,46 @@ def test_lab_setup_uses_existing_verifiers_sources(
         url.endswith(f"/primeintellect-ai/verifiers/{lab_setup.VERIFIERS_REF}/assets/lab/AGENTS.md")
         for url in fake_lab_asset_downloads
     )
+    assert not any("/configs/endpoints.toml" in url for url in fake_lab_asset_downloads)
+    assert not any("/configs/local/" in url for url in fake_lab_asset_downloads)
+    assert not any("/configs/zero3.yaml" in url for url in fake_lab_asset_downloads)
+
+
+def test_lab_config_downloader_targets_known_config_folders(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    calls: list[tuple[str, Path, bool]] = []
+
+    def fake_download_repo_directory(
+        _repo: str,
+        _ref: str,
+        source_path: str,
+        dest: Path,
+        _emit: Any,
+        *,
+        force: bool = True,
+        missing_ok: bool = False,
+    ) -> None:
+        assert missing_ok is True
+        calls.append((source_path, dest, force))
+
+    monkeypatch.setattr(lab_setup, "_download_repo_directory", fake_download_repo_directory)
+
+    lab_setup._download_lab_config_folders(
+        tmp_path / "configs",
+        emit=lambda _text: None,
+        force=False,
+    )
+
+    assert calls == [
+        ("configs/rl", tmp_path / "configs" / "rl", False),
+        ("configs/gepa", tmp_path / "configs" / "gepa", False),
+        ("configs/eval", tmp_path / "configs" / "eval", False),
+        ("configs/sft", tmp_path / "configs" / "sft", False),
+        ("configs/opd", tmp_path / "configs" / "opd", False),
+        ("configs/fft", tmp_path / "configs" / "fft", False),
+    ]
 
 
 def test_lab_setup_downloads_retry_transient_failures(monkeypatch: Any) -> None:
@@ -509,7 +551,9 @@ def test_lab_sync_fully_refreshes_global_and_workspace_config_templates(
         assert not (root / "configs" / "old.toml").exists()
         assert (root / "configs" / "eval" / "debug.toml").is_file()
         assert (root / "configs" / "eval" / "wordle.toml").is_file()
-        assert (root / "configs" / "zero3.yaml").is_file()
+        assert not (root / "configs" / "endpoints.toml").exists()
+        assert not (root / "configs" / "local").exists()
+        assert not (root / "configs" / "zero3.yaml").exists()
 
 
 def test_lab_doctor_reports_missing_selected_agent_guidance(


### PR DESCRIPTION
## Summary
- Restrict Lab setup and template sync to `rl`, `gepa`, `eval`, `sft`, `opd`, and `fft` config folders.
- Skip missing future folders quietly so setup stays forward-compatible.
- Update tests to cover the narrower download surface and to assert top-level config files like `endpoints.toml` and `zero3.yaml` are no longer pulled in.

## Testing
- `uv run pytest packages/prime/tests/test_lab_setup.py -q`
- `uv run pytest packages/prime/tests/test_lab_view.py::test_prime_lab_sync_service_refreshes_agent_assets -q`
- `uv run ruff check packages/prime/src/prime_cli/lab_setup.py packages/prime/tests/test_lab_setup.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which config assets are fetched during `prime lab setup/sync`, potentially surprising users who relied on previously downloaded top-level or `local/` configs; changes are small and covered by updated tests.
> 
> **Overview**
> **Lab setup/sync now only downloads a curated subset of config directories** from `verifiers` (`rl`, `gepa`, `eval`, `sft`, `opd`, `fft`) instead of pulling the entire `configs/` tree.
> 
> Adds `missing_ok` support to `_download_repo_directory` and uses it when fetching these folders so missing/future folders are skipped quietly. Tests are updated to assert that top-level config files (e.g. `endpoints.toml`, `zero3.yaml`) and `configs/local/` are no longer downloaded, and to cover the new folder-targeting helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e799325628287b1712c41e20f9672521bdb793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->