### PR TITLE
read file retries

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -84,6 +84,11 @@ GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS = GATEWAY_CONNECTION_RETRYABLE_EXCEPTION
     httpx.ReadError,  # TCP connection broken while reading response
 )
 
+READ_FILE_RETRYABLE_EXCEPTIONS = GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS + (
+    httpx.ConnectTimeout,  # Timed out before the request reached the gateway
+    httpx.ReadTimeout,  # Timed out waiting for an idempotent read response
+)
+
 # Retryable HTTP 5xx status codes (e.g. Cloudflare 524 timeout, server errors)
 RETRYABLE_5XX_STATUSES = frozenset({500, 502, 503, 504, 524})
 
@@ -95,6 +100,20 @@ RETRY_409_BASE_DELAY = 0.25  # 250ms, 500ms, 1000ms, 2000ms with exponential bac
 def _is_retryable_gateway_error(exc: BaseException) -> bool:
     """Check if an exception is retryable for idempotent gateway requests."""
     if isinstance(exc, GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS):
+        return True
+    if (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code in RETRYABLE_5XX_STATUSES
+    ):
+        if _is_gateway_sandbox_not_found(exc.response):
+            return False
+        return True
+    return False
+
+
+def _is_retryable_read_file_error(exc: BaseException) -> bool:
+    """Check if an exception is retryable for read-file gateway requests."""
+    if isinstance(exc, READ_FILE_RETRYABLE_EXCEPTIONS):
         return True
     if (
         isinstance(exc, httpx.HTTPStatusError)
@@ -120,6 +139,16 @@ _gateway_retry = retry(
 # retrying POSTs on those risks duplicate side effects).
 _gateway_post_retry = retry(
     retry=retry_if_exception_type(GATEWAY_CONNECTION_RETRYABLE_EXCEPTIONS),
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=1, min=1, max=30),
+    reraise=True,
+)
+
+# Retry decorator for read-file requests. read_file is idempotent and often used
+# as a polling primitive, so transient read/connect/pool timeouts should not fail
+# the operation on the first missed gateway response.
+_read_file_retry = retry(
+    retry=retry_if_exception(_is_retryable_read_file_error),
     stop=stop_after_attempt(4),
     wait=wait_exponential(multiplier=1, min=1, max=30),
     reraise=True,
@@ -505,6 +534,21 @@ class SandboxClient:
         timeout: float,
     ) -> httpx.Response:
         """Make a GET request to the gateway with retry on transient errors."""
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(url, params=params, headers=headers)
+        if response.status_code in RETRYABLE_5XX_STATUSES:
+            response.raise_for_status()
+        return response
+
+    @staticmethod
+    @_read_file_retry
+    def _gateway_read_file_get(
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any],
+        timeout: float,
+    ) -> httpx.Response:
+        """Make a read-file GET request to the gateway with read-timeout retries."""
         with httpx.Client(timeout=timeout) as client:
             response = client.get(url, params=params, headers=headers)
         if response.status_code in RETRYABLE_5XX_STATUSES:
@@ -1242,14 +1286,15 @@ class SandboxClient:
 
         for attempt in range(MAX_409_RETRIES):
             try:
-                response = self._gateway_get(
+                response = self._gateway_read_file_get(
                     url, headers=headers, params=params, timeout=effective_timeout
                 )
                 response.raise_for_status()
                 return ReadFileResponse.model_validate(response.json())
             except httpx.TimeoutException as e:
                 raise APIError(
-                    f"Read file timed out after {effective_timeout}s: {file_path}"
+                    f"Read file timed out after {effective_timeout}s "
+                    f"({e.__class__.__name__}): {file_path}"
                 ) from e
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 404:
@@ -1399,6 +1444,21 @@ class AsyncSandboxClient:
         timeout: float,
     ) -> httpx.Response:
         """Make a GET request to the gateway with retry on transient errors."""
+        gateway_client = self._get_gateway_client()
+        response = await gateway_client.get(url, params=params, headers=headers, timeout=timeout)
+        if response.status_code in RETRYABLE_5XX_STATUSES:
+            response.raise_for_status()
+        return response
+
+    @_read_file_retry
+    async def _gateway_read_file_get(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any],
+        timeout: float,
+    ) -> httpx.Response:
+        """Make a read-file GET request to the gateway with read-timeout retries."""
         gateway_client = self._get_gateway_client()
         response = await gateway_client.get(url, params=params, headers=headers, timeout=timeout)
         if response.status_code in RETRYABLE_5XX_STATUSES:
@@ -2150,14 +2210,15 @@ class AsyncSandboxClient:
 
         for attempt in range(MAX_409_RETRIES):
             try:
-                response = await self._gateway_get(
+                response = await self._gateway_read_file_get(
                     url, headers=headers, params=params, timeout=effective_timeout
                 )
                 response.raise_for_status()
                 return ReadFileResponse.model_validate(response.json())
             except httpx.TimeoutException as e:
                 raise APIError(
-                    f"Read file timed out after {effective_timeout}s: {file_path}"
+                    f"Read file timed out after {effective_timeout}s "
+                    f"({e.__class__.__name__}): {file_path}"
                 ) from e
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 404:

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -408,3 +408,98 @@ class TestSyncGatewayPostRetry:
             read_error_on_post()
 
         assert call_count == 1  # no retry
+
+
+class DummySandboxAuthCache:
+    """Minimal auth cache for read_file unit tests."""
+
+    def get_or_refresh(self, sandbox_id: str):
+        return {
+            "gateway_url": "https://gateway.example",
+            "user_ns": "test-ns",
+            "job_id": sandbox_id,
+            "token": "test-token",
+        }
+
+
+class TestReadFileRetry:
+    """Tests for read_file-specific retry behavior."""
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout],
+    )
+    def test_read_file_retry_on_timeout_types(self, exc_cls):
+        """read_file retries transient timeout classes before succeeding."""
+        from prime_sandboxes.sandbox import _read_file_retry
+
+        call_count = 0
+        request = httpx.Request("GET", "https://gateway.example/read-file")
+
+        @_read_file_retry
+        def timeout_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise exc_cls("temporary timeout", request=request)
+            return "success"
+
+        result = timeout_then_succeed()
+
+        assert result == "success"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_read_file_retry_works_for_async_functions(self):
+        """The shared decorator retries async read_file helpers too."""
+        from prime_sandboxes.sandbox import _read_file_retry
+
+        call_count = 0
+        request = httpx.Request("GET", "https://gateway.example/read-file")
+
+        @_read_file_retry
+        async def timeout_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise httpx.ReadTimeout("temporary timeout", request=request)
+            return "success"
+
+        result = await timeout_then_succeed()
+
+        assert result == "success"
+        assert call_count == 2
+
+    @pytest.mark.parametrize(
+        "exc_cls, expected_name",
+        [
+            (httpx.ReadTimeout, "ReadTimeout"),
+            (httpx.ConnectTimeout, "ConnectTimeout"),
+            (httpx.PoolTimeout, "PoolTimeout"),
+        ],
+    )
+    def test_read_file_timeout_error_names_timeout_type(self, monkeypatch, exc_cls, expected_name):
+        """Final read_file timeout errors include the concrete timeout class."""
+        from prime_sandboxes.sandbox import SandboxClient
+
+        request = httpx.Request("GET", "https://gateway.example/read-file")
+
+        def raise_timeout(url, headers, params, timeout):
+            raise exc_cls("temporary timeout", request=request)
+
+        monkeypatch.setattr(
+            SandboxClient,
+            "_gateway_read_file_get",
+            staticmethod(raise_timeout),
+        )
+
+        client = SandboxClient.__new__(SandboxClient)
+        client._auth_cache = DummySandboxAuthCache()
+
+        with pytest.raises(APIError) as exc_info:
+            client.read_file("sandbox-123", "/tmp/job.exit", timeout=12)
+
+        message = str(exc_info.value)
+        assert "Read file timed out after 12s" in message
+        assert f"({expected_name})" in message
+        assert "/tmp/job.exit" in message


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `read_file` to retry on additional timeout conditions (including `ReadTimeout`/`ConnectTimeout`) for both sync and async clients, which could alter perceived latency and increase gateway traffic under degraded network conditions.
> 
> **Overview**
> Improves `read_file` resilience by introducing a dedicated `_read_file_retry` policy that retries transient gateway failures (including read/connect/pool timeouts and retryable 5xx) for both sync and async paths.
> 
> Updates `read_file` to use new `_gateway_read_file_get` helpers and enhances timeout error messages to include the specific timeout exception class; adds unit tests covering the new retry behavior and message formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a808cd0ebc2e1f37dfa8ee03f53ffddde18e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->