### PR TITLE
bump sdbx bg job timeout

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -935,7 +935,7 @@ class SandboxClient:
 
         # Outer nohup redirects to /dev/null since output goes to log files inside sh -c
         bg_cmd = f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
-        self.execute_command(sandbox_id, bg_cmd, timeout=10)
+        self.execute_command(sandbox_id, bg_cmd, timeout=30)
 
         return BackgroundJob(
             job_id=job_id,
@@ -1843,7 +1843,7 @@ class AsyncSandboxClient:
 
         # Outer nohup redirects to /dev/null since output goes to log files inside sh -c
         bg_cmd = f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
-        await self.execute_command(sandbox_id, bg_cmd, timeout=10)
+        await self.execute_command(sandbox_id, bg_cmd, timeout=30)
 
         return BackgroundJob(
             job_id=job_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only increases the `execute_command` timeout when launching background jobs, reducing spurious timeouts without changing job execution semantics.
> 
> **Overview**
> **Background job launch is now more tolerant of slow gateways/runtimes.** The timeout used when starting a background job (the `nohup sh -c ... &` kickoff command) is increased from `10s` to `30s` in both `SandboxClient.start_background_job` and `AsyncSandboxClient.start_background_job`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba30dede72efa652254fcf54c22928fa237c10c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->