### PR TITLE
feat: Enhance idempotency handling for POST requests

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 import httpx
 from tenacity import (
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -13,15 +14,30 @@ from tenacity import (
 
 from .config import Config
 
-# Retry configuration for transient connection errors
-# These errors occur when the server closes idle connections in the pool
-# or when we fail to establish/maintain a connection
-RETRYABLE_EXCEPTIONS = (
+# Retry configuration for transient connection errors. POST only retries errors
+# that happen before the server can process the request; retrying ReadError on a
+# non-idempotent POST can duplicate side effects after a committed response-path
+# failure.
+POST_RETRYABLE_EXCEPTIONS = (
     httpx.RemoteProtocolError,  # Server disconnected unexpectedly
     httpx.ConnectError,  # Connection refused/failed
     httpx.PoolTimeout,  # No connection available in pool
+)
+
+IDEMPOTENT_RETRYABLE_EXCEPTIONS = POST_RETRYABLE_EXCEPTIONS + (
     httpx.ReadError,  # Connection broken while reading response (e.g., TCP reset)
 )
+
+IDEMPOTENT_POST_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+
+
+def _is_idempotent_post_retryable_error(exc: BaseException) -> bool:
+    if isinstance(exc, IDEMPOTENT_RETRYABLE_EXCEPTIONS):
+        return True
+    return (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response.status_code in IDEMPOTENT_POST_RETRYABLE_STATUSES
+    )
 
 
 def _default_user_agent() -> str:
@@ -86,12 +102,12 @@ class APIClient:
             )
 
     @retry(
-        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+        retry=retry_if_exception_type(IDEMPOTENT_RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
         reraise=True,
     )
-    def _request_with_retry(
+    def _idempotent_request_with_retry(
         self,
         method: str,
         url: str,
@@ -99,8 +115,44 @@ class APIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make HTTP request with retry on transient connection errors."""
+        """Make idempotent HTTP request with retry on transient connection errors."""
         return self.client.request(method, url, params=params, json=json, timeout=timeout)
+
+    @retry(
+        retry=retry_if_exception_type(POST_RETRYABLE_EXCEPTIONS),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    def _post_request_with_retry(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> httpx.Response:
+        """Make non-idempotent POST with only pre-processing safe retries."""
+        return self.client.request(method, url, params=params, json=json, timeout=timeout)
+
+    @retry(
+        retry=retry_if_exception(_is_idempotent_post_retryable_error),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    def _idempotent_post_request_with_retry(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> httpx.Response:
+        """Make idempotency-keyed POST with retries for ambiguous transient failures."""
+        response = self.client.request(method, url, params=params, json=json, timeout=timeout)
+        response.raise_for_status()
+        return response
 
     def request(
         self,
@@ -109,6 +161,7 @@ class APIClient:
         params: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
+        idempotent_post: bool = False,
     ) -> Dict[str, Any]:
         """Make a request to the API"""
         self._check_auth_required()
@@ -121,10 +174,17 @@ class APIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            response = self._request_with_retry(
-                method, url, params=params, json=json, timeout=timeout
-            )
-            response.raise_for_status()
+            if method.upper() == "POST":
+                request_fn = (
+                    self._idempotent_post_request_with_retry
+                    if idempotent_post
+                    else self._post_request_with_retry
+                )
+            else:
+                request_fn = self._idempotent_request_with_retry
+            response = request_fn(method, url, params=params, json=json, timeout=timeout)
+            if not idempotent_post:
+                response.raise_for_status()
 
             result = response.json()
             if not isinstance(result, dict):
@@ -197,12 +257,12 @@ class AsyncAPIClient:
             )
 
     @retry(
-        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+        retry=retry_if_exception_type(IDEMPOTENT_RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
         reraise=True,
     )
-    async def _request_with_retry(
+    async def _idempotent_request_with_retry(
         self,
         method: str,
         url: str,
@@ -210,8 +270,44 @@ class AsyncAPIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make async HTTP request with retry on transient connection errors."""
+        """Make async idempotent HTTP request with retry on transient connection errors."""
         return await self.client.request(method, url, params=params, json=json, timeout=timeout)
+
+    @retry(
+        retry=retry_if_exception_type(POST_RETRYABLE_EXCEPTIONS),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    async def _post_request_with_retry(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> httpx.Response:
+        """Make async non-idempotent POST with only pre-processing safe retries."""
+        return await self.client.request(method, url, params=params, json=json, timeout=timeout)
+
+    @retry(
+        retry=retry_if_exception(_is_idempotent_post_retryable_error),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        reraise=True,
+    )
+    async def _idempotent_post_request_with_retry(
+        self,
+        method: str,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None,
+    ) -> httpx.Response:
+        """Make async idempotency-keyed POST with retries for ambiguous transient failures."""
+        response = await self.client.request(method, url, params=params, json=json, timeout=timeout)
+        response.raise_for_status()
+        return response
 
     async def request(
         self,
@@ -220,6 +316,7 @@ class AsyncAPIClient:
         params: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
+        idempotent_post: bool = False,
     ) -> Dict[str, Any]:
         """Make an async request to the API"""
         self._check_auth_required()
@@ -232,10 +329,17 @@ class AsyncAPIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            response = await self._request_with_retry(
-                method, url, params=params, json=json, timeout=timeout
-            )
-            response.raise_for_status()
+            if method.upper() == "POST":
+                request_fn = (
+                    self._idempotent_post_request_with_retry
+                    if idempotent_post
+                    else self._post_request_with_retry
+                )
+            else:
+                request_fn = self._idempotent_request_with_retry
+            response = await request_fn(method, url, params=params, json=json, timeout=timeout)
+            if not idempotent_post:
+                response.raise_for_status()
 
             result = response.json()
             if not isinstance(result, dict):

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -174,16 +174,17 @@ class APIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
+            is_idempotent_post = method.upper() == "POST" and idempotent_post
             if method.upper() == "POST":
                 request_fn = (
                     self._idempotent_post_request_with_retry
-                    if idempotent_post
+                    if is_idempotent_post
                     else self._post_request_with_retry
                 )
             else:
                 request_fn = self._idempotent_request_with_retry
             response = request_fn(method, url, params=params, json=json, timeout=timeout)
-            if not idempotent_post:
+            if not is_idempotent_post:
                 response.raise_for_status()
 
             result = response.json()
@@ -329,16 +330,17 @@ class AsyncAPIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
+            is_idempotent_post = method.upper() == "POST" and idempotent_post
             if method.upper() == "POST":
                 request_fn = (
                     self._idempotent_post_request_with_retry
-                    if idempotent_post
+                    if is_idempotent_post
                     else self._post_request_with_retry
                 )
             else:
                 request_fn = self._idempotent_request_with_retry
             response = await request_fn(method, url, params=params, json=json, timeout=timeout)
-            if not idempotent_post:
+            if not is_idempotent_post:
                 response.raise_for_status()
 
             result = response.json()

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -98,6 +98,7 @@ class CreateSandboxRequest(BaseModel):
     advanced_configs: Optional[AdvancedConfigs] = None
     registry_credentials_id: Optional[str] = None
     guaranteed: bool = False
+    idempotency_key: Optional[str] = None
 
     @model_validator(mode="after")
     def validate_gpu_fields(self) -> "CreateSandboxRequest":

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -579,14 +579,17 @@ class SandboxClient:
 
     def create(self, request: CreateSandboxRequest) -> Sandbox:
         """Create a new sandbox"""
+        payload = request.model_dump(by_alias=False, exclude_none=True)
         # Auto-populate team_id from config if not specified
-        if request.team_id is None:
-            request.team_id = self.client.config.team_id
+        if request.team_id is None and self.client.config.team_id is not None:
+            payload["team_id"] = self.client.config.team_id
+        payload["idempotency_key"] = request.idempotency_key or uuid.uuid4().hex
 
         response = self.client.request(
             "POST",
             "/sandbox",
-            json=request.model_dump(by_alias=False, exclude_none=True),
+            json=payload,
+            idempotent_post=True,
         )
         return Sandbox.model_validate(response)
 
@@ -1473,13 +1476,16 @@ class AsyncSandboxClient:
 
     async def create(self, request: CreateSandboxRequest) -> Sandbox:
         """Create a new sandbox"""
-        if request.team_id is None:
-            request.team_id = self.client.config.team_id
+        payload = request.model_dump(by_alias=False, exclude_none=True)
+        if request.team_id is None and self.client.config.team_id is not None:
+            payload["team_id"] = self.client.config.team_id
+        payload["idempotency_key"] = request.idempotency_key or uuid.uuid4().hex
 
         response = await self.client.request(
             "POST",
             "/sandbox",
-            json=request.model_dump(by_alias=False, exclude_none=True),
+            json=payload,
+            idempotent_post=True,
         )
         return Sandbox.model_validate(response)
 

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -244,6 +244,17 @@ class TestSyncAPIClientRetry:
 
         assert transport.call_count == 1
 
+    def test_get_with_idempotent_post_flag_still_raises_status_error(self):
+        """idempotent_post=True must not bypass status checks for non-POST requests."""
+        transport = StatusThenSucceedTransport(404)
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        with pytest.raises(APIError, match="HTTP 404"):
+            client.request("GET", "test", idempotent_post=True)
+
+        assert transport.call_count == 1
+
 
 class TestAsyncAPIClientRetry:
     """Tests for async AsyncAPIClient retry behavior."""
@@ -305,6 +316,18 @@ class TestAsyncAPIClientRetry:
 
         assert result == {"success": True}
         assert transport.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_with_idempotent_post_flag_still_raises_status_error(self):
+        """Async idempotent_post=True must not bypass status checks for non-POST requests."""
+        transport = AsyncStatusThenSucceedTransport(404)
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        with pytest.raises(APIError, match="HTTP 404"):
+            await client.request("GET", "test", idempotent_post=True)
+
+        assert transport.call_count == 1
 
 
 class TestCreateSandboxIdempotencyPayload:

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -1,9 +1,14 @@
 """Tests for retry logic on transient connection errors."""
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
 import httpx
 import pytest
 
 from prime_sandboxes.core.client import APIClient, APIError, AsyncAPIClient
+from prime_sandboxes.models import CreateSandboxRequest
+from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
 
 
 class FailThenSucceedTransport(httpx.BaseTransport):
@@ -29,6 +34,98 @@ class AlwaysFailTransport(httpx.BaseTransport):
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         self.call_count += 1
         raise httpx.RemoteProtocolError("Server disconnected")
+
+
+class ReadErrorThenSucceedTransport(httpx.BaseTransport):
+    """Transport that raises ReadError once then succeeds."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        if self.call_count == 1:
+            raise httpx.ReadError("Connection broken", request=request)
+        return httpx.Response(200, json={"success": True})
+
+
+class StatusThenSucceedTransport(httpx.BaseTransport):
+    """Transport that returns an HTTP status once then succeeds."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.call_count = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        if self.call_count == 1:
+            return httpx.Response(self.status_code, request=request, text="Bad Gateway")
+        return httpx.Response(200, json={"success": True})
+
+
+class AsyncReadErrorThenSucceedTransport(httpx.AsyncBaseTransport):
+    """Async transport that raises ReadError once then succeeds."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        if self.call_count == 1:
+            raise httpx.ReadError("Connection broken", request=request)
+        return httpx.Response(200, json={"success": True})
+
+
+class AsyncStatusThenSucceedTransport(httpx.AsyncBaseTransport):
+    """Async transport that returns an HTTP status once then succeeds."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.call_count = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.call_count += 1
+        if self.call_count == 1:
+            return httpx.Response(self.status_code, request=request, text="Bad Gateway")
+        return httpx.Response(200, json={"success": True})
+
+
+def _sandbox_response(sandbox_id: str = "sandbox-1"):
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "id": sandbox_id,
+        "name": sandbox_id,
+        "docker_image": "python:3.11-slim",
+        "cpu_cores": 1.0,
+        "memory_gb": 2.0,
+        "disk_size_gb": 5.0,
+        "disk_mount_path": "/workspace",
+        "gpu_count": 0,
+        "status": "RUNNING",
+        "timeout_minutes": 60,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+class RecordingCreateAPIClient:
+    def __init__(self):
+        self.config = SimpleNamespace(team_id="team-1")
+        self.calls = []
+
+    def request(self, method: str, path: str, **kwargs):
+        self.calls.append((method, path, kwargs))
+        return _sandbox_response(f"sandbox-{len(self.calls)}")
+
+
+class AsyncRecordingCreateAPIClient:
+    def __init__(self):
+        self.config = SimpleNamespace(team_id="team-1")
+        self.calls = []
+
+    async def request(self, method: str, path: str, **kwargs):
+        self.calls.append((method, path, kwargs))
+        return _sandbox_response(f"sandbox-{len(self.calls)}")
 
 
 class AsyncFailThenSucceedTransport(httpx.AsyncBaseTransport):
@@ -81,6 +178,72 @@ class TestSyncAPIClientRetry:
 
         assert transport.call_count == 3
 
+    def test_get_retries_read_error(self):
+        """GET retries ReadError because it is idempotent."""
+        transport = ReadErrorThenSucceedTransport()
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        result = client.request("GET", "test")
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
+    def test_post_does_not_retry_read_error(self):
+        """POST does not retry ReadError because the server may have committed."""
+        transport = ReadErrorThenSucceedTransport()
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        with pytest.raises(APIError, match="ReadError"):
+            client.request("POST", "test", json={"name": "sandbox"})
+
+        assert transport.call_count == 1
+
+    def test_idempotent_post_retries_read_error(self):
+        """Idempotency-keyed POST retries ReadError safely."""
+        transport = ReadErrorThenSucceedTransport()
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        result = client.request(
+            "POST",
+            "test",
+            json={"name": "sandbox", "idempotency_key": "key-1"},
+            idempotent_post=True,
+        )
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    def test_idempotent_post_retries_transient_gateway_statuses(self, status_code):
+        """Idempotency-keyed POST retries transient gateway failures."""
+        transport = StatusThenSucceedTransport(status_code)
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        result = client.request(
+            "POST",
+            "test",
+            json={"name": "sandbox", "idempotency_key": "key-1"},
+            idempotent_post=True,
+        )
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
+    def test_post_does_not_retry_502(self):
+        """Generic POST still does not retry 502."""
+        transport = StatusThenSucceedTransport(502)
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        with pytest.raises(APIError, match="HTTP 502"):
+            client.request("POST", "test", json={"name": "sandbox"})
+
+        assert transport.call_count == 1
+
 
 class TestAsyncAPIClientRetry:
     """Tests for async AsyncAPIClient retry behavior."""
@@ -108,6 +271,77 @@ class TestAsyncAPIClientRetry:
             await client.request("GET", "test")
 
         assert transport.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_idempotent_post_retries_read_error(self):
+        """Async idempotency-keyed POST retries ReadError safely."""
+        transport = AsyncReadErrorThenSucceedTransport()
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        result = await client.request(
+            "POST",
+            "test",
+            json={"name": "sandbox", "idempotency_key": "key-1"},
+            idempotent_post=True,
+        )
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_idempotent_post_retries_502(self):
+        """Async idempotency-keyed POST retries transient gateway failures."""
+        transport = AsyncStatusThenSucceedTransport(502)
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        result = await client.request(
+            "POST",
+            "test",
+            json={"name": "sandbox", "idempotency_key": "key-1"},
+            idempotent_post=True,
+        )
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
+
+class TestCreateSandboxIdempotencyPayload:
+    def test_sync_create_does_not_reuse_generated_idempotency_key_on_request_reuse(self):
+        client = SandboxClient(APIClient(api_key="test-key"))
+        recording = RecordingCreateAPIClient()
+        client.client = recording
+        request = CreateSandboxRequest(name="sandbox", docker_image="python:3.11-slim")
+
+        client.create(request)
+        client.create(request)
+
+        first_payload = recording.calls[0][2]["json"]
+        second_payload = recording.calls[1][2]["json"]
+        assert first_payload["idempotency_key"] != second_payload["idempotency_key"]
+        assert first_payload["team_id"] == "team-1"
+        assert second_payload["team_id"] == "team-1"
+        assert request.idempotency_key is None
+        assert request.team_id is None
+
+    @pytest.mark.asyncio
+    async def test_async_create_does_not_reuse_generated_idempotency_key_on_request_reuse(self):
+        client = AsyncSandboxClient(api_key="test-key")
+        recording = AsyncRecordingCreateAPIClient()
+        client.client = recording
+        request = CreateSandboxRequest(name="sandbox", docker_image="python:3.11-slim")
+
+        await client.create(request)
+        await client.create(request)
+
+        first_payload = recording.calls[0][2]["json"]
+        second_payload = recording.calls[1][2]["json"]
+        assert first_payload["idempotency_key"] != second_payload["idempotency_key"]
+        assert first_payload["team_id"] == "team-1"
+        assert second_payload["team_id"] == "team-1"
+        assert request.idempotency_key is None
+        assert request.team_id is None
 
 
 class TestSyncGatewayRetry:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes retry semantics for POST requests and introduces a new idempotent-POST code path; misclassification or missing idempotency keys could cause unexpected retries or error handling differences on write operations.
> 
> **Overview**
> **Adds an explicit idempotent-POST retry mode to the SDK HTTP clients.** `APIClient`/`AsyncAPIClient` now split retry behavior between idempotent methods (including `ReadError` retries) and non-idempotent POSTs (connection-level retries only), with an opt-in `idempotent_post=True` path that also retries transient `502/503/504` and ambiguous failures.
> 
> **Sandbox creation is made idempotency-keyed by default.** `CreateSandboxRequest` gains an optional `idempotency_key`, and `SandboxClient.create` / `AsyncSandboxClient.create` now generate and send a key (without mutating the request object) while continuing to auto-fill `team_id` into the payload.
> 
> **Tests expanded** to cover the new retry matrix (GET vs POST vs idempotent POST, including status-based retries) and to assert create payloads generate unique idempotency keys across request reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1372980f732eca323cdc37c71a49e2a8dfd88b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->