### PR TITLE
Skip CLAUDE.md setup unless Claude is selected

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -400,6 +400,9 @@ def _run_lab_sync_steps(
     (workspace / "environments").mkdir(exist_ok=True)
     emit(f"Syncing Lab assets in {workspace}\n")
     agents = _resolve_sync_agents(workspace, options.agents, no_agent=options.no_agent)
+    guidance_agents = agents
+    if not guidance_agents and options.no_agent:
+        guidance_agents = _workspace_agents_from_metadata(workspace)
 
     managed_skill_names = _sync_prime_skills(emit)
     _prepare_workspace_skill_dir(workspace, managed_skill_names, emit)
@@ -413,8 +416,8 @@ def _run_lab_sync_steps(
     _sync_config_templates(workspace, emit)
 
     if not options.skip_docs:
-        _sync_workspace_guidance(workspace, agents, emit, force=True)
-        _write_lab_docs_index(workspace, agents)
+        _sync_workspace_guidance(workspace, guidance_agents, emit, force=True)
+        _write_lab_docs_index(workspace, guidance_agents)
 
     emit("Lab sync completed\n")
 

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -377,7 +377,7 @@ def _run_lab_setup_steps(
     _sync_lab_metadata(workspace, options.agents, setup_source="prime lab setup")
 
     if not options.skip_agents_md:
-        _sync_workspace_guidance(workspace, emit, force=True)
+        _sync_workspace_guidance(workspace, options.agents, emit, force=True)
 
     if options.prime_rl:
         _install_prime_rl(workspace, emit, runner)
@@ -385,7 +385,7 @@ def _run_lab_setup_steps(
 
     _copy_setup_configs(workspace, emit)
     _sync_config_templates(workspace, emit)
-    _write_lab_docs_index(workspace)
+    _write_lab_docs_index(workspace, options.agents)
     emit("Lab setup completed\n")
 
 
@@ -413,15 +413,22 @@ def _run_lab_sync_steps(
     _sync_config_templates(workspace, emit)
 
     if not options.skip_docs:
-        _sync_workspace_guidance(workspace, emit, force=True)
-        _write_lab_docs_index(workspace)
+        _sync_workspace_guidance(workspace, agents, emit, force=True)
+        _write_lab_docs_index(workspace, agents)
 
     emit("Lab sync completed\n")
 
 
-def _sync_workspace_guidance(workspace: Path, emit: Emit, *, force: bool = False) -> None:
+def _sync_workspace_guidance(
+    workspace: Path,
+    agents: tuple[str, ...],
+    emit: Emit,
+    *,
+    force: bool = False,
+) -> None:
     _download_file(AGENTS_MD_SRC, workspace / "AGENTS.md", emit, force=force)
-    _download_file(CLAUDE_MD_SRC, workspace / "CLAUDE.md", emit, force=force)
+    if "claude" in agents:
+        _download_file(CLAUDE_MD_SRC, workspace / "CLAUDE.md", emit, force=force)
     _download_file(
         ENVS_AGENTS_MD_SRC,
         workspace / "environments" / "AGENTS.md",
@@ -1341,9 +1348,15 @@ def _install_environments_to_prime_rl(workspace: Path, emit: Emit, runner: Runne
         emit("Local environment install into prime-rl failed; continuing\n")
 
 
-def _write_lab_docs_index(workspace: Path) -> None:
+def _write_lab_docs_index(workspace: Path, agents: tuple[str, ...]) -> None:
     docs_dir = workspace / ".prime" / "lab" / "docs"
     docs_dir.mkdir(parents=True, exist_ok=True)
+    guidance_files = [
+        "- `AGENTS.md`",
+        "- `environments/AGENTS.md`",
+    ]
+    if "claude" in agents:
+        guidance_files.insert(1, "- `CLAUDE.md`")
     index = docs_dir / "index.md"
     index.write_text(
         "\n".join(
@@ -1354,9 +1367,7 @@ def _write_lab_docs_index(workspace: Path) -> None:
                 "",
                 "## Local workspace guidance",
                 "",
-                "- `AGENTS.md`",
-                "- `CLAUDE.md`",
-                "- `environments/AGENTS.md`",
+                *guidance_files,
                 "- `~/.prime/skills/*/SKILL.md`",
                 "- `.prime/lab/templates/configs/**`",
                 "",

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -412,7 +412,12 @@ def _run_lab_sync_steps(
         _prepare_agent_native_surfaces(workspace, agents, emit)
         _sync_lab_metadata(workspace, agents, setup_source="prime lab sync")
     else:
-        emit("Skipped coding-agent skill roots (--no-agent)\n")
+        reason = (
+            "--no-agent"
+            if options.no_agent
+            else "no configured agent; pass --agent to configure one"
+        )
+        emit(f"Skipped coding-agent skill roots ({reason})\n")
     _sync_config_templates(workspace, emit)
 
     if not options.skip_docs:
@@ -1439,7 +1444,7 @@ def _resolve_sync_agents(
     stored_agents = _workspace_agents_from_metadata(workspace)
     if stored_agents:
         return stored_agents
-    raise RuntimeError("No configured coding agent found. Run prime lab setup or pass --agent.")
+    return ()
 
 
 def _download_file(url: str, dest: Path, emit: Emit, *, force: bool = False) -> None:

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -315,6 +315,42 @@ def test_lab_sync_refreshes_existing_workspace_guidance(
     assert not any("already exists" in line for line in emitted)
 
 
+def test_lab_sync_no_agent_keeps_stored_claude_guidance(
+    tmp_path: Path,
+    monkeypatch: Any,
+    fake_lab_asset_downloads: list[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    (tmp_path / ".prime").mkdir()
+    (tmp_path / ".prime" / "lab.json").write_text(
+        json.dumps({"choices": {"agents": ["claude"], "primary_agent": "claude"}}),
+        encoding="utf-8",
+    )
+    for path in (
+        tmp_path / "AGENTS.md",
+        tmp_path / "CLAUDE.md",
+        tmp_path / "environments" / "AGENTS.md",
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("stale guidance\n", encoding="utf-8")
+    emitted: list[str] = []
+
+    result = run_lab_sync_service(
+        LabSyncOptions(skip_docs=False, no_agent=True),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
+    assert "- `CLAUDE.md`" in docs_index
+    assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+    assert not (tmp_path / ".claude" / "skills").exists()
+    assert any("Skipped coding-agent skill roots (--no-agent)" in line for line in emitted)
+
+
 def test_lab_setup_uses_existing_verifiers_sources(
     tmp_path: Path,
     monkeypatch: Any,

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -228,6 +228,7 @@ def test_lab_setup_service_downloads_upstream_assets_without_agent_installs(
 def test_lab_setup_refreshes_existing_workspace_guidance(
     tmp_path: Path,
     monkeypatch: Any,
+    fake_lab_asset_downloads: list[str],
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
@@ -248,14 +249,42 @@ def test_lab_setup_refreshes_existing_workspace_guidance(
     )
 
     assert result.exit_code == 0
-    for path in existing_files:
+    for path in (
+        tmp_path / "AGENTS.md",
+        tmp_path / "environments" / "AGENTS.md",
+    ):
         assert path.read_text(encoding="utf-8").startswith("downloaded from ")
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8") == "workspace claude\n"
+    docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
+    assert "- `CLAUDE.md`" not in docs_index
+    assert not any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
     assert not any("already exists" in line for line in emitted)
+
+
+def test_lab_setup_refreshes_claude_guidance_for_claude_agent(
+    tmp_path: Path,
+    monkeypatch: Any,
+    fake_lab_asset_downloads: list[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+
+    result = run_lab_setup_service(
+        LabSetupOptions(skip_install=True, skip_agents_md=False, agents=("claude",)),
+        workspace=tmp_path,
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    docs_index = (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(encoding="utf-8")
+    assert "- `CLAUDE.md`" in docs_index
+    assert any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
 
 
 def test_lab_sync_refreshes_existing_workspace_guidance(
     tmp_path: Path,
     monkeypatch: Any,
+    fake_lab_asset_downloads: list[str],
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
@@ -276,8 +305,13 @@ def test_lab_sync_refreshes_existing_workspace_guidance(
     )
 
     assert result.exit_code == 0
-    for path in existing_files:
+    for path in (
+        tmp_path / "AGENTS.md",
+        tmp_path / "environments" / "AGENTS.md",
+    ):
         assert path.read_text(encoding="utf-8").startswith("downloaded from ")
+    assert (tmp_path / "CLAUDE.md").read_text(encoding="utf-8") == "stale guidance\n"
+    assert not any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
     assert not any("already exists" in line for line in emitted)
 
 

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -315,6 +315,39 @@ def test_lab_sync_refreshes_existing_workspace_guidance(
     assert not any("already exists" in line for line in emitted)
 
 
+def test_lab_sync_without_configured_agent_refreshes_shared_assets(
+    tmp_path: Path,
+    monkeypatch: Any,
+    fake_lab_asset_downloads: list[str],
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(AGENT_WHICH, lambda _command: "/bin/tool")
+    emitted: list[str] = []
+
+    result = run_lab_sync_service(
+        LabSyncOptions(skip_docs=False),
+        workspace=tmp_path,
+        emit=emitted.append,
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".prime" / "skills" / "create-environments" / "SKILL.md").is_file()
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8").startswith("downloaded from ")
+    assert (
+        (tmp_path / "environments" / "AGENTS.md")
+        .read_text(encoding="utf-8")
+        .startswith("downloaded from ")
+    )
+    assert not (tmp_path / "CLAUDE.md").exists()
+    assert "- `CLAUDE.md`" not in (tmp_path / ".prime" / "lab" / "docs" / "index.md").read_text(
+        encoding="utf-8"
+    )
+    assert (tmp_path / ".prime" / "lab" / "templates" / "configs" / "rl" / "gsm8k.toml").is_file()
+    assert not (tmp_path / ".agents" / "skills").exists()
+    assert not any("/assets/lab/CLAUDE.md" in url for url in fake_lab_asset_downloads)
+    assert any("no configured agent; pass --agent to configure one" in line for line in emitted)
+
+
 def test_lab_sync_no_agent_keeps_stored_claude_guidance(
     tmp_path: Path,
     monkeypatch: Any,


### PR DESCRIPTION
## Summary
- Make `prime lab setup` and `prime lab sync` download `CLAUDE.md` only when `claude` is among the selected agents.
- Keep existing non-Claude `CLAUDE.md` files untouched during setup/sync.
- Update the generated Lab docs index so it only lists `CLAUDE.md` for Claude workspaces.

## Testing
- Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to which guidance files are downloaded and listed during `prime lab setup/sync`, with added handling for sync runs without configured agents.
> 
> **Overview**
> `prime lab setup`/`prime lab sync` now **only download/refresh `CLAUDE.md`** when `claude` is among the selected agents, leaving any existing non-Claude `CLAUDE.md` untouched.
> 
> Lab docs index generation is updated to **conditionally include `CLAUDE.md`** based on selected/stored agents, and `prime lab sync` improves messaging/behavior when run with no agent configured (including `--no-agent`) while still refreshing shared assets and guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334878a1ecca276a2c92453bcf6af444c3898fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->