### PR TITLE
Remove the prime-rl setup flag from Lab setup

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -6,7 +6,6 @@ import argparse
 import hashlib
 import json
 import os
-import platform
 import shutil
 import subprocess
 import sys
@@ -32,11 +31,9 @@ from .lab_agents import (
     write_agent_native_surface,
 )
 
-PRIME_RL_REPO = "primeintellect-ai/prime-rl"
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
 VERIFIERS_REF = "7d8a522df67308327cb9b8931ce6a5873a99834a"
 VERIFIERS_CONFIG_REF = "main"
-PRIME_RL_REF = "38b524925d09ce917b51e54bd99446b822f0a87f"
 DOWNLOAD_ATTEMPTS = 3
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
 
@@ -85,7 +82,6 @@ class SkillSource:
 class LabSetupOptions:
     """Options for initializing a Lab workspace."""
 
-    prime_rl: bool = False
     skip_agents_md: bool = False
     skip_install: bool = False
     agents: tuple[str, ...] = ()
@@ -218,11 +214,6 @@ def parse_lab_setup_args(args: list[str]) -> LabSetupOptions:
         description="Set up a Lab workspace.",
     )
     parser.add_argument(
-        "--prime-rl",
-        action="store_true",
-        help="Install prime-rl.",
-    )
-    parser.add_argument(
         "--skip-agents-md",
         action="store_true",
         help="Skip AGENTS.md, CLAUDE.md, and environments/AGENTS.md.",
@@ -245,7 +236,6 @@ def parse_lab_setup_args(args: list[str]) -> LabSetupOptions:
     )
     namespace = parser.parse_args(args)
     return LabSetupOptions(
-        prime_rl=bool(namespace.prime_rl),
         skip_agents_md=bool(namespace.skip_agents_md),
         skip_install=bool(namespace.skip_install),
         agents=_resolve_setup_agents(
@@ -378,10 +368,6 @@ def _run_lab_setup_steps(
 
     if not options.skip_agents_md:
         _sync_workspace_guidance(workspace, emit, force=True)
-
-    if options.prime_rl:
-        _install_prime_rl(workspace, emit, runner)
-        _install_environments_to_prime_rl(workspace, emit, runner)
 
     _copy_setup_configs(workspace, emit)
     _sync_config_templates(workspace, emit)
@@ -1269,76 +1255,6 @@ def _ensure_uv_project(workspace: Path, emit: Emit, runner: Runner) -> None:
 
     emit("Adding verifiers dependency\n")
     _check_command(["uv", "add", "verifiers"], workspace, emit, runner)
-
-
-def _install_prime_rl(workspace: Path, emit: Emit, runner: Runner) -> None:
-    _ensure_prime_rl_supported_platform()
-    prime_rl_dir = workspace / "prime-rl"
-    if prime_rl_dir.is_dir():
-        emit("prime-rl already exists\n")
-    else:
-        emit(f"Cloning prime-rl at {PRIME_RL_REF}\n")
-        _check_command(
-            [
-                "git",
-                "clone",
-                "--no-checkout",
-                f"https://github.com/{PRIME_RL_REPO}.git",
-                "prime-rl",
-            ],
-            workspace,
-            emit,
-            runner,
-        )
-
-    _check_command(["git", "checkout", PRIME_RL_REF], prime_rl_dir, emit, runner)
-    if (prime_rl_dir / ".venv").is_dir():
-        _check_command(["uv", "sync"], prime_rl_dir, emit, runner)
-        _check_command(["uv", "sync", "--all-extras"], prime_rl_dir, emit, runner)
-    else:
-        _check_command(
-            ["env", "SKIP_CLONE=1", "bash", "scripts/install.sh"],
-            prime_rl_dir,
-            emit,
-            runner,
-        )
-
-
-def _ensure_prime_rl_supported_platform() -> None:
-    host_platform, machine = _prime_rl_platform()
-    supported_machine = machine in {"x86_64", "amd64", "aarch64", "arm64"}
-    if host_platform.startswith("linux") and supported_machine:
-        return
-    raise RuntimeError(
-        f"prime-rl only supports Linux x86_64/aarch64 hosts; detected {host_platform}/{machine}."
-    )
-
-
-def _prime_rl_platform() -> tuple[str, str]:
-    return sys.platform, platform.machine().lower()
-
-
-def _install_environments_to_prime_rl(workspace: Path, emit: Emit, runner: Runner) -> None:
-    envs_dir = workspace / "environments"
-    prime_rl_python = workspace / "prime-rl" / ".venv" / "bin" / "python"
-    if not envs_dir.is_dir() or not prime_rl_python.exists():
-        return
-    env_paths = [
-        str(Path("environments") / path.name)
-        for path in sorted(envs_dir.iterdir())
-        if path.is_dir() and (path / "pyproject.toml").is_file()
-    ]
-    if not env_paths:
-        return
-    emit(f"Installing {len(env_paths)} local environments into prime-rl\n")
-    editable_args = [arg for env_path in env_paths for arg in ("-e", env_path)]
-    code = runner(
-        ["uv", "pip", "install", "--python", str(prime_rl_python), *editable_args],
-        workspace,
-        emit,
-    )
-    if code != 0:
-        emit("Local environment install into prime-rl failed; continuing\n")
 
 
 def _write_lab_docs_index(workspace: Path) -> None:

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -26,6 +26,7 @@ def test_lab_setup_help_flags_use_prime_owned_help():
         assert result.exit_code == 0, result.output
         assert "Set up a Lab workspace." in result.output
         assert "--skip-install" in result.output
+        assert "--prime-rl" not in result.output
 
 
 def test_sanitize_help_removes_vf_eval_aliases():

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -132,6 +132,13 @@ def test_lab_setup_no_interactive_uses_codex_default() -> None:
     assert options.agents == ("codex",)
 
 
+def test_lab_setup_rejects_prime_rl_flag() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_lab_setup_args(["--prime-rl", "--no-interactive"])
+
+    assert exc_info.value.code == 2
+
+
 def test_lab_setup_prompts_for_agent_when_interactive(monkeypatch: Any) -> None:
     class FakeStdin:
         def isatty(self) -> bool:
@@ -298,7 +305,6 @@ def test_lab_setup_uses_existing_verifiers_sources(
     assert result.exit_code == 0
     assert _is_pinned_ref(lab_setup.VERIFIERS_REF)
     assert lab_setup.VERIFIERS_CONFIG_REF == "main"
-    assert _is_pinned_ref(lab_setup.PRIME_RL_REF)
     assert any(
         url.endswith(
             f"/primeintellect-ai/verifiers/{lab_setup.VERIFIERS_REF}/skills/create-environments/SKILL.md"
@@ -346,62 +352,6 @@ def test_lab_setup_downloads_retry_transient_failures(monkeypatch: Any) -> None:
     assert calls == ["https://example.test/file", "https://example.test/file"]
     assert sleeps == [lab_setup.DOWNLOAD_RETRY_DELAY_SECONDS]
     assert emitted == ["Download failed for https://example.test/file; retrying (2/3)\n"]
-
-
-def test_lab_setup_installs_prime_rl_from_pinned_checkout(
-    tmp_path: Path,
-    monkeypatch: Any,
-) -> None:
-    monkeypatch.setattr(lab_setup, "_ensure_prime_rl_supported_platform", lambda: None)
-    commands: list[tuple[list[str], Path]] = []
-
-    def runner(command: Any, cwd: Path, _emit: Any) -> int:
-        command_list = list(command)
-        commands.append((command_list, cwd))
-        if command_list[:3] == ["git", "clone", "--no-checkout"]:
-            (tmp_path / "prime-rl" / "scripts").mkdir(parents=True)
-            (tmp_path / "prime-rl" / "scripts" / "install.sh").write_text(
-                "#!/usr/bin/env bash\n",
-                encoding="utf-8",
-            )
-        return 0
-
-    lab_setup._install_prime_rl(tmp_path, emit=lambda _text: None, runner=runner)
-
-    assert commands == [
-        (
-            [
-                "git",
-                "clone",
-                "--no-checkout",
-                "https://github.com/primeintellect-ai/prime-rl.git",
-                "prime-rl",
-            ],
-            tmp_path,
-        ),
-        (["git", "checkout", lab_setup.PRIME_RL_REF], tmp_path / "prime-rl"),
-        (
-            ["env", "SKIP_CLONE=1", "bash", "scripts/install.sh"],
-            tmp_path / "prime-rl",
-        ),
-    ]
-
-
-def test_lab_setup_prime_rl_fails_early_on_unsupported_platform(
-    tmp_path: Path,
-    monkeypatch: Any,
-) -> None:
-    commands: list[list[str]] = []
-    monkeypatch.setattr(lab_setup, "_prime_rl_platform", lambda: ("darwin", "arm64"))
-
-    with pytest.raises(RuntimeError, match="prime-rl only supports Linux"):
-        lab_setup._install_prime_rl(
-            tmp_path,
-            emit=lambda _text: None,
-            runner=lambda command, _cwd, _emit: commands.append(list(command)) or 0,
-        )
-
-    assert commands == []
 
 
 def test_lab_setup_manifest_tracks_skill_source(
@@ -640,35 +590,6 @@ def test_lab_doctor_warns_on_deprecated_config_fields(tmp_path: Path) -> None:
     assert "configs/rl/old.toml:oversampling_factor" in checks["Config deprecated fields"].message
     assert "configs/rl/old.toml:max_async_level" in checks["Config deprecated fields"].message
     assert "configs/rl/old.toml:max_off_policy_steps" in checks["Config deprecated fields"].message
-
-
-def test_lab_setup_installs_prime_rl_envs_with_split_editable_args(tmp_path: Path) -> None:
-    (tmp_path / "prime-rl" / ".venv" / "bin").mkdir(parents=True)
-    (tmp_path / "prime-rl" / ".venv" / "bin" / "python").write_text("", encoding="utf-8")
-    (tmp_path / "environments" / "foo").mkdir(parents=True)
-    (tmp_path / "environments" / "foo" / "pyproject.toml").write_text(
-        "[project]\nname = 'foo'\n",
-        encoding="utf-8",
-    )
-    commands: list[list[str]] = []
-
-    lab_setup._install_environments_to_prime_rl(
-        tmp_path,
-        emit=lambda _text: None,
-        runner=lambda command, _cwd, _emit: commands.append(list(command)) or 0,
-    )
-
-    assert commands == [
-        [
-            "uv",
-            "pip",
-            "install",
-            "--python",
-            str(tmp_path / "prime-rl" / ".venv" / "bin" / "python"),
-            "-e",
-            "environments/foo",
-        ]
-    ]
 
 
 def test_workspace_agents_from_metadata_ignores_non_string_values(tmp_path: Path) -> None:

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -6501,7 +6501,6 @@ async def test_setup_screen_run_uses_selected_agent(
         assert captured
         options, workspace = captured[0]
         assert options.agents == ("claude",)
-        assert options.prime_rl is False
         assert workspace == tmp_path.resolve()
 
 


### PR DESCRIPTION
Outdated; users should use prime-rl native setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this removes an outdated optional setup path and its platform-specific install logic, but may affect users/scripts still invoking `prime lab setup --prime-rl`.
> 
> **Overview**
> **Removes the deprecated `--prime-rl` flag from `prime lab setup`.** The CLI no longer accepts or documents this option, and `LabSetupOptions` no longer carries a `prime_rl` toggle.
> 
> All prime-rl-specific setup steps were deleted (repo clone/checkout, platform gating, and local environment editable installs), and the test suite was updated to assert the flag is absent, rejected by argparse, and that prime-rl installation behavior is no longer exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a1c939887c71182ec01f7beeabf544a51021b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->