### PR TITLE
Fix eval config env id fallback

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "textual>=6.1.0",
     "textual-plot>=0.10.1",
     "cryptography>=41.0.0",
-    "verifiers>=0.1.12.dev6",
+    "verifiers>=0.1.14",
     "build>=1.0.0",
     "gitignore-parser>=0.1.13",
     "pyyaml>=6.0.0",
@@ -64,7 +64,7 @@ dev = [
 prime-sandboxes = { workspace = true }
 prime-evals = { workspace = true }
 prime-tunnel = { workspace = true }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.12.dev6" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.14" }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -85,13 +85,17 @@ EVAL_TABLE_MAX_TEXT_WIDTH = 30
 EVAL_RUN_EXAMPLE_COMMAND = "prime eval run gsm8k -n 10"
 EVAL_HOSTED_LABEL = "HOSTED"
 EVAL_LOCAL_LABEL = "LOCAL"
+# Legacy verifiers config fields/flags are accepted through the parser only so
+# Prime can reject them with the hosted-specific unsupported-option message.
 HOSTED_EVAL_CONFIG_EXTRA_FIELDS = {
+    "debug",
     "timeout_minutes",
     "allow_sandbox_access",
     "allow_instances_access",
     "allow_tunnel_access",
     "eval_name",
 }
+HOSTED_LEGACY_UNSUPPORTED_FLAGS = {"--debug", "--tui", "-u"}
 HOSTED_EVAL_CONFIG_FIELD_TYPES: dict[str, tuple[type[Any], str]] = {
     "env_dir_path": (str, "a non-empty string"),
     "num_examples": (int, "an integer"),
@@ -303,6 +307,23 @@ def _reject_unsupported_hosted_verifiers_args(
         for dest, option_name in option_names_by_dest.items()
         if dest in provided_dests and dest not in HOSTED_SUPPORTED_VERIFIERS_FIELDS
     ]
+    if not unsupported_flags:
+        return
+
+    console.print(
+        "[red]Error:[/red] hosted eval CLI does not support: "
+        + ", ".join(f"`{flag}`" for flag in unsupported_flags)
+    )
+    raise typer.Exit(1)
+
+
+def _reject_legacy_unsupported_hosted_flags(passthrough_args: list[str]) -> None:
+    unsupported_flags = []
+    for arg in passthrough_args:
+        flag = arg.split("=", 1)[0]
+        if flag in HOSTED_LEGACY_UNSUPPORTED_FLAGS and flag not in unsupported_flags:
+            unsupported_flags.append(flag)
+
     if not unsupported_flags:
         return
 
@@ -1436,6 +1457,7 @@ def run_eval_cmd(
             raise typer.Exit(1)
 
     if hosted:
+        _reject_legacy_unsupported_hosted_flags(passthrough_args)
         parsed_verifiers_args, cli_overrides, option_names_by_dest = (
             _parse_verifiers_eval_namespace(
                 environment,

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -211,7 +211,9 @@ def run_eval_tui(env_dir: Optional[str], outputs_dir: Optional[str]) -> None:
     _run_command(command, env=env)
 
 
-def _parse_value_option(args: list[str], long_flag: str, short_flag: str) -> Optional[str]:
+def _parse_value_option(
+    args: list[str], long_flag: str, short_flag: Optional[str]
+) -> Optional[str]:
     for idx, arg in enumerate(args):
         if arg == long_flag or arg == short_flag:
             if idx + 1 < len(args):
@@ -715,7 +717,7 @@ def _collect_eval_config_envs(config_path: Path, fallback_env_dir: str) -> list[
     for entry in eval_entries:
         if not isinstance(entry, dict):
             continue
-        env_id = entry.get("env_id")
+        env_id = entry.get("env_id") or entry.get("id")
         if not isinstance(env_id, str) or not env_id:
             continue
         env_dir_path = entry.get("env_dir_path")
@@ -727,6 +729,11 @@ def _collect_eval_config_envs(config_path: Path, fallback_env_dir: str) -> list[
         seen.add(key)
         resolved.append(key)
     return resolved
+
+
+def _env_name_from_reference(env_reference: str) -> str:
+    base_ref, _version = _split_version(env_reference)
+    return base_ref.rsplit("/", 1)[-1]
 
 
 def _collect_gepa_config_env(config_path: Path, fallback_env_dir: str) -> Optional[tuple[str, str]]:
@@ -892,14 +899,16 @@ def run_eval_passthrough(
     _validate_model(model, base_url, configured_base_url)
     _preflight_inference_billing(model, base_url, configured_base_url)
 
-    env_dir_path = _parse_value_option(args, "--env-dir-path", "-p") or DEFAULT_ENV_DIR_PATH
+    env_dir_path = _parse_value_option(args, "--env-dir-path", None) or DEFAULT_ENV_DIR_PATH
     run_target = environment
     upstream_slug: Optional[str] = None
     env_name_for_upload: Optional[str] = None
     resolved_env: Optional[ResolvedEnvironment] = None
+    config_envs: list[tuple[str, str]] = []
 
     if _is_config_target(environment):
-        for env_ref, ref_env_dir in _collect_eval_config_envs(Path(environment), env_dir_path):
+        config_envs = _collect_eval_config_envs(Path(environment), env_dir_path)
+        for env_ref, ref_env_dir in config_envs:
             _prepare_single_environment(plugin, env_ref, ref_env_dir)
     else:
         resolved_env = _prepare_single_environment(plugin, environment, env_dir_path)
@@ -914,7 +923,11 @@ def run_eval_passthrough(
     if not skip_upload and not _has_flag(args, "--save-results", "-s"):
         args.append("-s")
 
-    job_target = env_name_for_upload or Path(environment).stem
+    job_target = env_name_for_upload
+    if job_target is None and config_envs:
+        job_target = _env_name_from_reference(config_envs[0][0])
+    if job_target is None:
+        job_target = Path(environment).stem
     job_id = _build_job_id(job_target, model)
     args.extend(["--header", f"X-PI-Job-Id: {job_id}"])
 
@@ -996,7 +1009,7 @@ def run_gepa_passthrough(environment_or_config: str, passthrough_args: list[str]
         raise typer.Exit(1)
 
     args, env, _model, _base_url = _add_default_inference_and_key_args(passthrough_args, config)
-    env_dir_path = _parse_value_option(args, "--env-dir-path", "-p") or DEFAULT_ENV_DIR_PATH
+    env_dir_path = _parse_value_option(args, "--env-dir-path", None) or DEFAULT_ENV_DIR_PATH
 
     run_target = environment_or_config
     if _is_config_target(environment_or_config):

--- a/packages/prime/tests/test_eval_billing.py
+++ b/packages/prime/tests/test_eval_billing.py
@@ -215,6 +215,93 @@ def test_eval_run_continues_when_billing_preflight_times_out(monkeypatch):
     assert seen_billing_timeouts[1].read == 300.0
 
 
+@pytest.mark.parametrize("env_id_field", ["env_id", "id"])
+def test_eval_config_job_id_uses_config_env_id(monkeypatch, tmp_path, env_id_field):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr("prime_cli.verifiers_bridge._validate_model", lambda *args: None)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._preflight_inference_billing",
+        lambda *args: None,
+    )
+
+    config_path = tmp_path / "reverse-text.toml"
+    config_path.write_text(
+        f"""
+model = "openai/gpt-4.1-mini"
+
+[[eval]]
+{env_id_field} = "primeintellect/wordle"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    prepared = []
+    commands = []
+
+    def fake_prepare(_plugin, env_reference, env_dir_path):
+        prepared.append((env_reference, env_dir_path))
+
+    def fake_run_command(command, env=None):
+        commands.append(command)
+
+    monkeypatch.setattr("prime_cli.verifiers_bridge._prepare_single_environment", fake_prepare)
+    monkeypatch.setattr("prime_cli.verifiers_bridge._run_command", fake_run_command)
+
+    run_eval_passthrough(
+        environment=str(config_path),
+        passthrough_args=[],
+        skip_upload=True,
+        env_path=None,
+    )
+
+    assert prepared == [("primeintellect/wordle", "./environments")]
+    assert commands
+    assert commands[0][1] == str(config_path)
+    assert any(arg.startswith("X-PI-Job-Id: wordle_") for arg in commands[0]), commands[0]
+    assert not any(arg.startswith("X-PI-Job-Id: reverse_text_") for arg in commands[0]), commands[0]
+
+
+def test_eval_provider_short_flag_is_not_treated_as_env_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge.load_verifiers_prime_plugin", lambda console: DummyPlugin()
+    )
+    monkeypatch.setattr("prime_cli.verifiers_bridge.Config", lambda: DummyConfig())
+    monkeypatch.setattr("prime_cli.verifiers_bridge._validate_model", lambda *args: None)
+    monkeypatch.setattr(
+        "prime_cli.verifiers_bridge._preflight_inference_billing",
+        lambda *args: None,
+    )
+
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+[[eval]]
+env_id = "wiki-search"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    prepared = []
+
+    def fake_prepare(_plugin, env_reference, env_dir_path):
+        prepared.append((env_reference, env_dir_path))
+
+    monkeypatch.setattr("prime_cli.verifiers_bridge._prepare_single_environment", fake_prepare)
+    monkeypatch.setattr("prime_cli.verifiers_bridge._run_command", lambda *args, **kwargs: None)
+
+    run_eval_passthrough(
+        environment=str(config_path),
+        passthrough_args=["-p", "openai"],
+        skip_upload=True,
+        env_path=None,
+    )
+
+    assert prepared == [("wiki-search", "./environments")]
+
+
 def test_inference_client_uses_custom_timeout(monkeypatch):
     monkeypatch.setattr("prime_cli.api.inference.Config", lambda: DummyConfig())
 

--- a/packages/prime/tests/test_hosted_eval.py
+++ b/packages/prime/tests/test_hosted_eval.py
@@ -1169,6 +1169,22 @@ env_id = "gsm8k"
     }
 
 
+def test_hosted_eval_config_accepts_id_alias(tmp_path):
+    config_path = tmp_path / "eval.toml"
+    config_path.write_text(
+        """
+model = "openai/gpt-4.1-mini"
+
+[[eval]]
+id = "gsm8k"
+""".strip()
+    )
+
+    loaded = _load_hosted_eval_configs(str(config_path))[0]
+
+    assert loaded["env_id"] == "gsm8k"
+
+
 def test_eval_run_hosted_endpoint_id_uses_default_endpoints_path_from_cwd(monkeypatch, tmp_path):
     config_dir = tmp_path / "configs"
     config_dir.mkdir()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ override-dependencies = ["prime-tunnel>=0.1.6"]
 
 [tool.uv.sources]
 prime-tunnel = { workspace = true }
-verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.12.dev6" }
+verifiers = { git = "https://github.com/PrimeIntellect-ai/verifiers.git", tag = "v0.1.14" }
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/uv.lock
+++ b/uv.lock
@@ -2056,7 +2056,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.0a6" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.0" },
-    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.12.dev6" },
+    { name = "verifiers", git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.14" },
 ]
 provides-extras = ["dev"]
 
@@ -3638,13 +3638,14 @@ wheels = [
 
 [[package]]
 name = "verifiers"
-version = "0.1.12.dev6"
-source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.12.dev6#89fb7271322cc04eb8566098d54d7eaadb645c3b" }
+version = "0.1.14"
+source = { git = "https://github.com/PrimeIntellect-ai/verifiers.git?tag=v0.1.14#2fbd2b7fab0236cb039c4aa5afb25ad9c5f17134" }
 dependencies = [
     { name = "aiolimiter" },
     { name = "anthropic" },
     { name = "datasets" },
     { name = "gepa" },
+    { name = "httpx" },
     { name = "jinja2" },
     { name = "math-verify" },
     { name = "mcp" },


### PR DESCRIPTION
## Summary
- Use the first configured eval environment from TOML when preparing config-driven `prime eval run`, so job ids and preinstall use `[[eval]].env_id` or `[[eval]].id` instead of falling back to the config filename stem.
- Stop treating `-p` as a short form of `--env-dir-path` in eval/gepa passthrough parsing, fixing provider shorthand handling while keeping explicit `--env-dir-path` support.
- Bump the minimum/source `verifiers` version to `0.1.14`, refresh the lockfile, and keep hosted eval rejection behavior stable across the newer parser.

## Testing
- `uv run ruff check packages/prime/src/prime_cli/commands/evals.py packages/prime/src/prime_cli/verifiers_bridge.py packages/prime/tests/test_eval_billing.py packages/prime/tests/test_hosted_eval.py`
- `uv run ty check packages/prime/src/prime_cli/commands/evals.py packages/prime/src/prime_cli/verifiers_bridge.py`
- `uv run pytest packages/prime/tests/test_eval_billing.py packages/prime/tests/test_hosted_eval.py -q`
- `uv run python -c "import verifiers; print(verifiers.__version__)"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval/GEPA CLI passthrough argument parsing and how config-driven eval runs derive job IDs, which can affect environment preinstall and downstream result grouping. Also bumps the `verifiers` dependency, so behavior depends on the updated external parser.
> 
> **Overview**
> Config-driven `prime eval run` now pre-installs environments and builds `X-PI-Job-Id` from the first `[[eval]]` entry’s `env_id` (or `id` alias) instead of falling back to the TOML filename.
> 
> Eval/GEPA passthrough parsing stops treating `-p` as a short flag for `--env-dir-path` (only the long flag is recognized), and hosted evals explicitly reject legacy unsupported flags (`--debug`, `--tui`, `-u`) to preserve the hosted-only error messaging.
> 
> Updates `verifiers` to `v0.1.14` (and lockfile) to align with the newer upstream CLI/parser behavior, with added tests covering the new env-id aliasing and flag parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f6d4557d3c3fcd69133dadf230c851b0101376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->