### PR TITLE
Update PyPI changelog link

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 Homepage = "https://github.com/PrimeIntellect-ai/prime-cli"
 Documentation = "https://github.com/PrimeIntellect-ai/prime-cli#readme"
 Repository = "https://github.com/PrimeIntellect-ai/prime-cli.git"
-Changelog = "https://github.com/PrimeIntellect-ai/prime-cli/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/PrimeIntellect-ai/prime/releases"
 
 [project.scripts]
 prime = "prime_cli.main:run"


### PR DESCRIPTION
Updates the prime package metadata so PyPI's Changelog link points to the GitHub Releases history.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that updates the PyPI project URL for the changelog; no runtime code paths are affected.
> 
> **Overview**
> Updates `packages/prime/pyproject.toml` project metadata so the `Changelog` URL points to GitHub Releases (`.../prime/releases`) instead of the `CHANGELOG.md` file link, improving the PyPI "Changelog" button target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8693caf49ec22dfd2b5d9f8cd6e7180f04638fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->