### PR TITLE
fix: Raise eval push payload limit to 25 MiB

### DIFF
--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -212,7 +212,7 @@ class EvalsClient:
         self,
         evaluation_id: str,
         samples: List[Dict[str, Any]],
-        max_payload_bytes: int = 2 * 1024 * 1024,
+        max_payload_bytes: int = 25 * 1024 * 1024,
         max_workers: int = 4,
     ) -> Dict[str, Any]:
         """Push evaluation samples in adaptive batches with concurrent uploads."""
@@ -562,7 +562,7 @@ class AsyncEvalsClient:
         self,
         evaluation_id: str,
         samples: List[Dict[str, Any]],
-        max_payload_bytes: int = 2 * 1024 * 1024,
+        max_payload_bytes: int = 25 * 1024 * 1024,
         max_concurrent: int = 4,
     ) -> Dict[str, Any]:
         """Push evaluation samples in adaptive batches with concurrent uploads."""

--- a/packages/prime-evals/src/prime_evals/evals.py
+++ b/packages/prime-evals/src/prime_evals/evals.py
@@ -258,7 +258,7 @@ class EvalsClient:
             reraise=True,
         )
         def do_upload() -> int:
-            response = httpx.post(url, json={"samples": batch}, headers=headers, timeout=30.0)
+            response = httpx.post(url, json={"samples": batch}, headers=headers, timeout=300.0)
             response.raise_for_status()
             return len(batch)
 
@@ -593,7 +593,7 @@ class AsyncEvalsClient:
                 reraise=True,
             )
             async def do_upload() -> int:
-                async with httpx.AsyncClient(timeout=30.0) as client:
+                async with httpx.AsyncClient(timeout=300.0) as client:
                     response = await client.post(url, json={"samples": batch}, headers=headers)
                     response.raise_for_status()
                     return len(batch)


### PR DESCRIPTION
## Summary
- Raise `max_payload_bytes` default from 2 MiB → 25 MiB in both sync and async `push_samples`
- Fixes multimodal samples (images, audio) being silently skipped on `prime eval push`

## Why
The 2 MiB per-request cap in `prime-evals/evals.py` was unjustified by anything on the server side. Reviewed `primeintellect-ai/platform`:

- No FastAPI body-size middleware (`backend/app/main.py`)
- `PushSamplesRequest` schema has no `max_length` and allows arbitrary extras (`schemas.py:362`, `:115`)
- Gunicorn config sets no body cap (`gunicorn/gunicorn_conf.py`)
- No nginx / ingress body-size annotations anywhere in the repo
- Storage layer writes one Parquet object per request to R2 and explicitly enables `arrow_large_buffer_size=true` for >2 GB merges (`duckdb_storage.py:324`)
- The platform's own hosted uploader batches by sample count (`MAX_BATCH_SIZE = 200`), not bytes (`hosted_eval_partial_uploader.py:33`)

25 MiB stays comfortably under common cloud LB ceilings (Cloud Run: 32 MiB) and covers typical multimodal samples (a base64 1024×1024 PNG is ~1.7 MB). Anything larger should reference blob storage rather than embed bytes.

## Test plan
- [ ] Push an eval containing samples with base64-encoded images (>2 MiB each) and confirm they upload instead of being skipped
- [ ] Push a normal text-only eval and confirm batching/concurrency still works
- [ ] Confirm server accepts a ~20 MiB request body end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes client-side batching limits and HTTP timeouts, which can increase memory/bandwidth usage and make uploads block longer if the server/network misbehaves.
> 
> **Overview**
> Raises the default `push_samples` batch size cap from **2 MiB to 25 MiB** for both sync and async clients so large (e.g., multimodal) samples aren’t skipped during batching.
> 
> Increases the sample-upload request timeout from **30s to 300s** for both `httpx.post` and `httpx.AsyncClient` uploads to accommodate larger payloads and slower transfers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627dbf47b17e0c00671e5d85a9f34b40b2da27c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->