### PR TITLE
fix: disable exclude-newer-package for environment installs

### DIFF
--- a/packages/prime/src/prime_cli/commands/env.py
+++ b/packages/prime/src/prime_cli/commands/env.py
@@ -3205,6 +3205,10 @@ def _build_install_command(
             if url_dependencies:
                 cmd.extend(url_dependencies)
             cmd.extend(["--extra-index-url", simple_index_url])
+            # Hub simple index doesn't emit PEP 700 upload-time metadata, so any
+            # exclude-newer cutoff on the consumer side filters hub wheels
+            # regardless of how permissive the cutoff is. Disable per-package.
+            cmd.extend(["--exclude-newer-package", f"{normalized_name}=false"])
             if prerelease:
                 cmd.append("--prerelease=allow")
             return cmd


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the generated `uv pip install` command for hub simple-index installs, but it could change which wheel versions are considered when users have `--exclude-newer` configured.
> 
> **Overview**
> Updates environment installs via `uv` + hub `simple_index_url` to append `--exclude-newer-package <pkg>=false`, ensuring hub wheels aren’t filtered out when a consumer has an `exclude-newer` cutoff (hub doesn’t provide PEP 700 upload-time metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94be3472096e75ec36f6e817ff5b28aee0bd204d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->