### PR TITLE
release: prime CLI 0.6.4

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,8 +10,8 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.23",
-    "prime-evals>=0.1.3",
+    "prime-sandboxes>=0.2.26",
+    "prime-evals>=0.2.1",
     "prime-tunnel>=0.1.0",
     "httpx>=0.25.0",
     "pydantic>=2.0.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 __all__ = [
     "APIClient",

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1014,10 +1014,9 @@ def _require_published_environment_for_eval_push(env_name: str, eval_path: Path)
         f"[yellow]Push '{env_name}' before uploading this evaluation:[/yellow] "
         f"prime env push {env_name}"
     )
-    console.print(
-        "[dim]Then retry with an owner-qualified environment, e.g. "
-        f"`prime eval push {eval_path} --env <owner>/{env_name}`.[/dim]"
-    )
+    console.print("[dim]Then retry with an owner-qualified environment:[/dim]")
+    console.print(f"[dim]  --env <owner>/{env_name}[/dim]")
+    console.print(f"[dim]Example: prime eval push {eval_path} --env <owner>/{env_name}[/dim]")
     raise typer.Exit(1)
 
 


### PR DESCRIPTION
Stacked on #642. Bumps prime CLI to 0.6.4 and raises package floors to prime-evals>=0.2.1 and prime-sandboxes>=0.2.26. Merge order: #643, then #642, wait for prime-evals 0.2.1 to publish, then retarget/merge this PR into main.