### PR TITLE
sandbox auth retries

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -29,6 +29,7 @@ IDEMPOTENT_RETRYABLE_EXCEPTIONS = POST_RETRYABLE_EXCEPTIONS + (
 )
 
 IDEMPOTENT_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+IDEMPOTENT_HTTP_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS"})
 
 
 def _is_idempotent_request_retryable_error(exc: BaseException) -> bool:
@@ -126,7 +127,7 @@ class APIClient:
         wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
-    def _post_request_with_retry(
+    def _non_idempotent_request_with_retry(
         self,
         method: str,
         url: str,
@@ -134,7 +135,7 @@ class APIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make non-idempotent POST with only pre-processing safe retries."""
+        """Make non-idempotent request with only pre-processing safe retries."""
         return self.client.request(method, url, params=params, json=json, timeout=timeout)
 
     @retry(
@@ -176,15 +177,18 @@ class APIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            is_idempotent_post = method.upper() == "POST" and idempotent_post
-            if method.upper() == "POST":
+            method_upper = method.upper()
+            is_idempotent_post = method_upper == "POST" and idempotent_post
+            if method_upper == "POST":
                 request_fn = (
                     self._idempotent_post_request_with_retry
                     if is_idempotent_post
-                    else self._post_request_with_retry
+                    else self._non_idempotent_request_with_retry
                 )
-            else:
+            elif method_upper in IDEMPOTENT_HTTP_METHODS:
                 request_fn = self._idempotent_request_with_retry
+            else:
+                request_fn = self._non_idempotent_request_with_retry
             response = request_fn(method, url, params=params, json=json, timeout=timeout)
             if not is_idempotent_post:
                 response.raise_for_status()
@@ -284,7 +288,7 @@ class AsyncAPIClient:
         wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
-    async def _post_request_with_retry(
+    async def _non_idempotent_request_with_retry(
         self,
         method: str,
         url: str,
@@ -292,7 +296,7 @@ class AsyncAPIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make async non-idempotent POST with only pre-processing safe retries."""
+        """Make async non-idempotent request with only pre-processing safe retries."""
         return await self.client.request(method, url, params=params, json=json, timeout=timeout)
 
     @retry(
@@ -334,15 +338,18 @@ class AsyncAPIClient:
         url = f"{self.base_url}{endpoint}"
 
         try:
-            is_idempotent_post = method.upper() == "POST" and idempotent_post
-            if method.upper() == "POST":
+            method_upper = method.upper()
+            is_idempotent_post = method_upper == "POST" and idempotent_post
+            if method_upper == "POST":
                 request_fn = (
                     self._idempotent_post_request_with_retry
                     if is_idempotent_post
-                    else self._post_request_with_retry
+                    else self._non_idempotent_request_with_retry
                 )
-            else:
+            elif method_upper in IDEMPOTENT_HTTP_METHODS:
                 request_fn = self._idempotent_request_with_retry
+            else:
+                request_fn = self._non_idempotent_request_with_retry
             response = await request_fn(method, url, params=params, json=json, timeout=timeout)
             if not is_idempotent_post:
                 response.raise_for_status()

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -9,7 +9,7 @@ from tenacity import (
     retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
-    wait_exponential,
+    wait_random_exponential,
 )
 
 from .config import Config
@@ -28,15 +28,15 @@ IDEMPOTENT_RETRYABLE_EXCEPTIONS = POST_RETRYABLE_EXCEPTIONS + (
     httpx.ReadError,  # Connection broken while reading response (e.g., TCP reset)
 )
 
-IDEMPOTENT_POST_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+IDEMPOTENT_RETRYABLE_STATUSES = frozenset({502, 503, 504})
 
 
-def _is_idempotent_post_retryable_error(exc: BaseException) -> bool:
+def _is_idempotent_request_retryable_error(exc: BaseException) -> bool:
     if isinstance(exc, IDEMPOTENT_RETRYABLE_EXCEPTIONS):
         return True
     return (
         isinstance(exc, httpx.HTTPStatusError)
-        and exc.response.status_code in IDEMPOTENT_POST_RETRYABLE_STATUSES
+        and exc.response.status_code in IDEMPOTENT_RETRYABLE_STATUSES
     )
 
 
@@ -102,9 +102,9 @@ class APIClient:
             )
 
     @retry(
-        retry=retry_if_exception_type(IDEMPOTENT_RETRYABLE_EXCEPTIONS),
+        retry=retry_if_exception(_is_idempotent_request_retryable_error),
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
     def _idempotent_request_with_retry(
@@ -115,13 +115,15 @@ class APIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make idempotent HTTP request with retry on transient connection errors."""
-        return self.client.request(method, url, params=params, json=json, timeout=timeout)
+        """Make idempotent HTTP request with retry on transient failures."""
+        response = self.client.request(method, url, params=params, json=json, timeout=timeout)
+        response.raise_for_status()
+        return response
 
     @retry(
         retry=retry_if_exception_type(POST_RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
     def _post_request_with_retry(
@@ -136,9 +138,9 @@ class APIClient:
         return self.client.request(method, url, params=params, json=json, timeout=timeout)
 
     @retry(
-        retry=retry_if_exception(_is_idempotent_post_retryable_error),
+        retry=retry_if_exception(_is_idempotent_request_retryable_error),
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
     def _idempotent_post_request_with_retry(
@@ -149,7 +151,7 @@ class APIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make idempotency-keyed POST with retries for ambiguous transient failures."""
+        """Make idempotent POST with retries for ambiguous transient failures."""
         response = self.client.request(method, url, params=params, json=json, timeout=timeout)
         response.raise_for_status()
         return response
@@ -258,9 +260,9 @@ class AsyncAPIClient:
             )
 
     @retry(
-        retry=retry_if_exception_type(IDEMPOTENT_RETRYABLE_EXCEPTIONS),
+        retry=retry_if_exception(_is_idempotent_request_retryable_error),
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
     async def _idempotent_request_with_retry(
@@ -271,13 +273,15 @@ class AsyncAPIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make async idempotent HTTP request with retry on transient connection errors."""
-        return await self.client.request(method, url, params=params, json=json, timeout=timeout)
+        """Make async idempotent HTTP request with retry on transient failures."""
+        response = await self.client.request(method, url, params=params, json=json, timeout=timeout)
+        response.raise_for_status()
+        return response
 
     @retry(
         retry=retry_if_exception_type(POST_RETRYABLE_EXCEPTIONS),
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
     async def _post_request_with_retry(
@@ -292,9 +296,9 @@ class AsyncAPIClient:
         return await self.client.request(method, url, params=params, json=json, timeout=timeout)
 
     @retry(
-        retry=retry_if_exception(_is_idempotent_post_retryable_error),
+        retry=retry_if_exception(_is_idempotent_request_retryable_error),
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=0.1, min=0.1, max=2),
+        wait=wait_random_exponential(multiplier=0.1, max=2),
         reraise=True,
     )
     async def _idempotent_post_request_with_retry(
@@ -305,7 +309,7 @@ class AsyncAPIClient:
         json: Optional[Dict[str, Any]] = None,
         timeout: Optional[int] = None,
     ) -> httpx.Response:
-        """Make async idempotency-keyed POST with retries for ambiguous transient failures."""
+        """Make async idempotent POST with retries for ambiguous transient failures."""
         response = await self.client.request(method, url, params=params, json=json, timeout=timeout)
         response.raise_for_status()
         return response

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -332,7 +332,11 @@ class SandboxAuthCache:
                 continue
 
             try:
-                response = self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+                response = self.client.request(
+                    "POST",
+                    f"/sandbox/{sandbox_id}/auth",
+                    idempotent_post=True,
+                )
                 with self._lock:
                     self._auth_cache[sandbox_id] = response
                     self._save_cache()
@@ -433,7 +437,11 @@ class AsyncSandboxAuthCache:
                 continue
 
             try:
-                response = await self.client.request("POST", f"/sandbox/{sandbox_id}/auth")
+                response = await self.client.request(
+                    "POST",
+                    f"/sandbox/{sandbox_id}/auth",
+                    idempotent_post=True,
+                )
                 async with self._lock:
                     self._auth_cache[sandbox_id] = response
                     await self._save_cache()

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -8,7 +8,12 @@ import pytest
 
 from prime_sandboxes.core.client import APIClient, APIError, AsyncAPIClient
 from prime_sandboxes.models import CreateSandboxRequest
-from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
+from prime_sandboxes.sandbox import (
+    AsyncSandboxAuthCache,
+    AsyncSandboxClient,
+    SandboxAuthCache,
+    SandboxClient,
+)
 
 
 class FailThenSucceedTransport(httpx.BaseTransport):
@@ -52,15 +57,18 @@ class ReadErrorThenSucceedTransport(httpx.BaseTransport):
 class StatusThenSucceedTransport(httpx.BaseTransport):
     """Transport that returns an HTTP status once then succeeds."""
 
-    def __init__(self, status_code: int):
+    def __init__(self, status_code: int, payload: dict | None = None):
         self.status_code = status_code
+        self.payload = payload or {"success": True}
         self.call_count = 0
+        self.requests: list[httpx.Request] = []
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         self.call_count += 1
+        self.requests.append(request)
         if self.call_count == 1:
             return httpx.Response(self.status_code, request=request, text="Bad Gateway")
-        return httpx.Response(200, json={"success": True})
+        return httpx.Response(200, request=request, json=self.payload)
 
 
 class AsyncReadErrorThenSucceedTransport(httpx.AsyncBaseTransport):
@@ -79,15 +87,18 @@ class AsyncReadErrorThenSucceedTransport(httpx.AsyncBaseTransport):
 class AsyncStatusThenSucceedTransport(httpx.AsyncBaseTransport):
     """Async transport that returns an HTTP status once then succeeds."""
 
-    def __init__(self, status_code: int):
+    def __init__(self, status_code: int, payload: dict | None = None):
         self.status_code = status_code
+        self.payload = payload or {"success": True}
         self.call_count = 0
+        self.requests: list[httpx.Request] = []
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.call_count += 1
+        self.requests.append(request)
         if self.call_count == 1:
             return httpx.Response(self.status_code, request=request, text="Bad Gateway")
-        return httpx.Response(200, json={"success": True})
+        return httpx.Response(200, request=request, json=self.payload)
 
 
 def _sandbox_response(sandbox_id: str = "sandbox-1"):
@@ -105,6 +116,16 @@ def _sandbox_response(sandbox_id: str = "sandbox-1"):
         "timeout_minutes": 60,
         "created_at": now,
         "updated_at": now,
+    }
+
+
+def _auth_response():
+    return {
+        "gateway_url": "https://gateway.example",
+        "token": "test-token",
+        "user_ns": "test-ns",
+        "job_id": "job-123",
+        "expires_at": "2099-01-01T00:00:00Z",
     }
 
 
@@ -185,6 +206,18 @@ class TestSyncAPIClientRetry:
         client.client = httpx.Client(transport=transport)
 
         result = client.request("GET", "test")
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    def test_get_retries_transient_gateway_statuses(self, status_code):
+        """GET retries transient gateway failures from the public API/LB path."""
+        transport = StatusThenSucceedTransport(status_code)
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        result = client.request("GET", "sandbox/sandbox-1")
 
         assert result == {"success": True}
         assert transport.call_count == 2
@@ -283,6 +316,19 @@ class TestAsyncAPIClientRetry:
 
         assert transport.call_count == 3
 
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.asyncio
+    async def test_get_retries_transient_gateway_statuses(self, status_code):
+        """Async GET retries transient gateway failures from the public API/LB path."""
+        transport = AsyncStatusThenSucceedTransport(status_code)
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        result = await client.request("GET", "sandbox/sandbox-1")
+
+        assert result == {"success": True}
+        assert transport.call_count == 2
+
     @pytest.mark.asyncio
     async def test_idempotent_post_retries_read_error(self):
         """Async idempotency-keyed POST retries ReadError safely."""
@@ -365,6 +411,38 @@ class TestCreateSandboxIdempotencyPayload:
         assert second_payload["team_id"] == "team-1"
         assert request.idempotency_key is None
         assert request.team_id is None
+
+
+class TestSandboxAuthRetry:
+    def test_sync_auth_refresh_retries_transient_gateway_status(self, tmp_path):
+        """Auth POST is idempotent and retries transient public API 502s."""
+        transport = StatusThenSucceedTransport(502, payload=_auth_response())
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+        cache = SandboxAuthCache(tmp_path / "auth_cache.json", client)
+
+        result = cache.get_or_refresh("sandbox-1")
+
+        assert result["token"] == "test-token"
+        assert transport.call_count == 2
+        assert [request.method for request in transport.requests] == ["POST", "POST"]
+        assert str(transport.requests[0].url).endswith("/api/v1/sandbox/sandbox-1/auth")
+
+    @pytest.mark.asyncio
+    async def test_async_auth_refresh_retries_transient_gateway_status(self, tmp_path):
+        """Async auth POST is idempotent and retries transient public API 502s."""
+        transport = AsyncStatusThenSucceedTransport(502, payload=_auth_response())
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+        cache = AsyncSandboxAuthCache(tmp_path / "auth_cache.json", client)
+
+        result = await cache.get_or_refresh("sandbox-1")
+
+        assert result["token"] == "test-token"
+        assert transport.call_count == 2
+        assert [request.method for request in transport.requests] == ["POST", "POST"]
+        assert str(transport.requests[0].url).endswith("/api/v1/sandbox/sandbox-1/auth")
+        await client.client.aclose()
 
 
 class TestSyncGatewayRetry:

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -222,6 +222,29 @@ class TestSyncAPIClientRetry:
         assert result == {"success": True}
         assert transport.call_count == 2
 
+    def test_patch_does_not_retry_read_error(self):
+        """PATCH does not retry ReadError because the server may have committed."""
+        transport = ReadErrorThenSucceedTransport()
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        with pytest.raises(APIError, match="ReadError"):
+            client.request("PATCH", "test", json={"name": "sandbox"})
+
+        assert transport.call_count == 1
+
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    def test_patch_does_not_retry_transient_gateway_statuses(self, status_code):
+        """PATCH does not retry transient gateway statuses without explicit idempotency."""
+        transport = StatusThenSucceedTransport(status_code)
+        client = APIClient(api_key="test-key")
+        client.client = httpx.Client(transport=transport)
+
+        with pytest.raises(APIError, match=f"HTTP {status_code}"):
+            client.request("PATCH", "test", json={"name": "sandbox"})
+
+        assert transport.call_count == 1
+
     def test_post_does_not_retry_read_error(self):
         """POST does not retry ReadError because the server may have committed."""
         transport = ReadErrorThenSucceedTransport()
@@ -328,6 +351,31 @@ class TestAsyncAPIClientRetry:
 
         assert result == {"success": True}
         assert transport.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_patch_does_not_retry_read_error(self):
+        """Async PATCH does not retry ReadError because the server may have committed."""
+        transport = AsyncReadErrorThenSucceedTransport()
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        with pytest.raises(APIError, match="ReadError"):
+            await client.request("PATCH", "test", json={"name": "sandbox"})
+
+        assert transport.call_count == 1
+
+    @pytest.mark.parametrize("status_code", [502, 503, 504])
+    @pytest.mark.asyncio
+    async def test_patch_does_not_retry_transient_gateway_statuses(self, status_code):
+        """Async PATCH does not retry transient gateway statuses without explicit idempotency."""
+        transport = AsyncStatusThenSucceedTransport(status_code)
+        client = AsyncAPIClient(api_key="test-key")
+        client.client = httpx.AsyncClient(transport=transport)
+
+        with pytest.raises(APIError, match=f"HTTP {status_code}"):
+            await client.request("PATCH", "test", json={"name": "sandbox"})
+
+        assert transport.call_count == 1
 
     @pytest.mark.asyncio
     async def test_idempotent_post_retries_read_error(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes SDK retry behavior to automatically retry idempotent methods (and idempotent POSTs) on 502/503/504 and adds new method routing, which could alter client-side error/retry patterns under load balancer failures.
> 
> **Overview**
> Improves SDK retry logic by treating `GET/HEAD/PUT/DELETE/OPTIONS` as idempotent and retrying them on transient connection failures *and* `502/503/504` responses, while keeping non-idempotent methods on connection-only retries.
> 
> Marks sandbox auth token refresh (`POST /sandbox/<id>/auth`) as `idempotent_post=True` so it also retries on transient gateway `5xx`, switches backoff to `wait_random_exponential`, and expands tests to cover the new status-based retry behavior for sync/async clients and auth cache refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd52faa173aecdc0da7c0fa64e8fc6a405083a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->