### PR TITLE
release: prime-evals 0.2.1

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Core HTTP Client & Config

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1014,10 +1014,9 @@ def _require_published_environment_for_eval_push(env_name: str, eval_path: Path)
         f"[yellow]Push '{env_name}' before uploading this evaluation:[/yellow] "
         f"prime env push {env_name}"
     )
-    console.print(
-        "[dim]Then retry with an owner-qualified environment, e.g. "
-        f"`prime eval push {eval_path} --env <owner>/{env_name}`.[/dim]"
-    )
+    console.print("[dim]Then retry with an owner-qualified environment:[/dim]")
+    console.print(f"[dim]  --env <owner>/{env_name}[/dim]")
+    console.print(f"[dim]Example: prime eval push {eval_path} --env <owner>/{env_name}[/dim]")
     raise typer.Exit(1)
 
 


### PR DESCRIPTION
Stacked on #643. Bumps prime-evals to 0.2.1. Merge #643 first, then merge this PR and wait for prime-evals 0.2.1 to publish before merging the stacked prime CLI release (#639).