### PR TITLE
Fix eval push environment hint wrapping

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1014,10 +1014,9 @@ def _require_published_environment_for_eval_push(env_name: str, eval_path: Path)
         f"[yellow]Push '{env_name}' before uploading this evaluation:[/yellow] "
         f"prime env push {env_name}"
     )
-    console.print(
-        "[dim]Then retry with an owner-qualified environment, e.g. "
-        f"`prime eval push {eval_path} --env <owner>/{env_name}`.[/dim]"
-    )
+    console.print("[dim]Then retry with an owner-qualified environment:[/dim]")
+    console.print(f"[dim]  --env <owner>/{env_name}[/dim]")
+    console.print(f"[dim]Example: prime eval push {eval_path} --env <owner>/{env_name}[/dim]")
     raise typer.Exit(1)
 
 


### PR DESCRIPTION
Prints the owner-qualified --env hint on its own line so Rich wrapping cannot split the assertion-visible flag/value pair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI error messaging/formatting with no behavior, API, or data-flow changes.
> 
> **Overview**
> Improves the `prime eval push` error hint shown when an environment hasn’t been published by splitting the owner-qualified `--env <owner>/<name>` guidance onto separate lines, preventing Rich from wrapping and separating the flag/value pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83602333b2519771a6de1f24b8a9ac4c5f893700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->