### PR TITLE
improvement: add log search/level/since flags to 'prime train logs'

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -390,12 +390,35 @@ class RLClient:
                 raise APIError(f"Failed to get Hosted Training run: {e.response.text}")
             raise APIError(f"Failed to get Hosted Training run: {str(e)}")
 
-    def get_logs(self, run_id: str, tail_lines: int = 1000) -> str:
-        """Get orchestrator logs for a Hosted Training run."""
+    def get_logs(
+        self,
+        run_id: str,
+        tail_lines: int = 1000,
+        *,
+        search: Optional[str] = None,
+        regex: bool = False,
+        level: Optional[str] = None,
+        since_seconds: Optional[int] = None,
+    ) -> str:
+        """Get orchestrator logs for a Hosted Training run.
+
+        Optional filters narrow the result via the platform's log search
+        backend:
+          - search: substring (or regex if regex=True) line filter
+          - level:  one of ERROR/WARNING/SUCCESS/INFO/DEBUG
+          - since_seconds: how far back to look (60–86400)
+        """
+        params: Dict[str, object] = {"tail_lines": tail_lines}
+        if search:
+            params["search"] = search
+        if regex:
+            params["regex"] = True
+        if level:
+            params["level"] = level
+        if since_seconds is not None:
+            params["since_seconds"] = since_seconds
         try:
-            response = self.client.get(
-                f"/rft/runs/{run_id}/logs", params={"tail_lines": tail_lines}
-            )
+            response = self.client.get(f"/rft/runs/{run_id}/logs", params=params)
             return response.get("logs", "")
         except Exception as e:
             if hasattr(e, "response") and hasattr(e.response, "text"):
@@ -418,16 +441,30 @@ class RLClient:
         env_name: str,
         env_index: int = 0,
         tail_lines: int = 1000,
+        *,
+        search: Optional[str] = None,
+        regex: bool = False,
+        level: Optional[str] = None,
+        since_seconds: Optional[int] = None,
     ) -> str:
         """Get logs for a specific env-server pod of a Hosted Training run."""
+        params: Dict[str, object] = {
+            "env_name": env_name,
+            "env_index": env_index,
+            "tail_lines": tail_lines,
+        }
+        if search:
+            params["search"] = search
+        if regex:
+            params["regex"] = True
+        if level:
+            params["level"] = level
+        if since_seconds is not None:
+            params["since_seconds"] = since_seconds
         try:
             response = self.client.get(
                 f"/rft/runs/{run_id}/env-server-logs",
-                params={
-                    "env_name": env_name,
-                    "env_index": env_index,
-                    "tail_lines": tail_lines,
-                },
+                params=params,
             )
             return response.get("logs", "")
         except Exception as e:

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1773,6 +1773,36 @@ def _handle_logs_api_error(e: APIError) -> None:
     raise typer.Exit(1)
 
 
+_SINCE_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86_400}
+
+
+def _parse_since(since: Optional[str]) -> Optional[int]:
+    """Convert a ``--since`` flag to a seconds value the backend accepts.
+
+    Accepts forms like ``15m``, ``1h``, ``6h``, ``24h``, ``900``. Returns
+    None when the flag isn't set (backend default applies)."""
+    if since is None:
+        return None
+    raw = since.strip().lower()
+    if not raw:
+        return None
+    if raw[-1] in _SINCE_UNIT_SECONDS and raw[:-1].isdigit():
+        seconds = int(raw[:-1]) * _SINCE_UNIT_SECONDS[raw[-1]]
+    elif raw.isdigit():
+        seconds = int(raw)
+    else:
+        raise typer.BadParameter(
+            f"Invalid --since value '{since}'. Use e.g. '15m', '1h', '6h', '24h', or seconds.",
+            param_hint="--since",
+        )
+    if seconds < 60 or seconds > 86_400:
+        raise typer.BadParameter(
+            "--since must be between 60s and 24h (86400s).",
+            param_hint="--since",
+        )
+    return seconds
+
+
 def _parse_env_qualifier(env: str) -> tuple[str, int]:
     """Parse 'name' or 'name/<int>' into (env_name, env_index).
 
@@ -1810,6 +1840,33 @@ def get_logs(
     tail: int = typer.Option(1000, "--tail", "-n", help="Number of lines to show"),
     follow: bool = typer.Option(False, "--follow", "-f", help="Follow log output"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Show raw logs without formatting"),
+    search: Optional[str] = typer.Option(
+        None,
+        "--search",
+        help=(
+            "Filter to lines containing this text. "
+            "Combine with --regex to use a regular expression instead of a substring."
+        ),
+    ),
+    regex: bool = typer.Option(
+        False,
+        "--regex",
+        help="Treat --search as a regex (RE2 syntax).",
+    ),
+    level: Optional[str] = typer.Option(
+        None,
+        "--level",
+        help="Filter to one log level: ERROR | WARNING | SUCCESS | INFO | DEBUG.",
+    ),
+    since: Optional[str] = typer.Option(
+        None,
+        "--since",
+        help=(
+            "Time window for filtered queries. Accepts e.g. '15m', '1h', '6h', "
+            "'24h', or a raw integer seconds value. Default 15m. "
+            "Applies when --search or --level is set."
+        ),
+    ),
 ) -> None:
     """Get logs for a run.
 
@@ -1824,6 +1881,9 @@ def get_logs(
 
         prime train logs <run_id>
         prime train logs <run_id> -f
+        prime train logs <run_id> --search Backpressure
+        prime train logs <run_id> --level ERROR --since 1h
+        prime train logs <run_id> --search 'Step \\d+' --regex
         prime train logs <run_id> --env reverse-text
         prime train logs <run_id> --env reverse-text/1 -f
     """
@@ -1846,6 +1906,17 @@ def get_logs(
             param_hint="--env",
         )
 
+    normalized_level: Optional[str] = None
+    if level:
+        normalized_level = level.upper()
+        if normalized_level not in {"ERROR", "WARNING", "SUCCESS", "INFO", "DEBUG"}:
+            raise typer.BadParameter(
+                f"Invalid level '{level}'. Use ERROR, WARNING, SUCCESS, INFO, or DEBUG.",
+                param_hint="--level",
+            )
+
+    since_seconds = _parse_since(since)
+
     try:
         api_client = APIClient()
         rl_client = RLClient(api_client)
@@ -1853,7 +1924,14 @@ def get_logs(
         if component == "orchestrator":
 
             def fetch(t: int) -> str:
-                return rl_client.get_logs(run_id, tail_lines=t)
+                return rl_client.get_logs(
+                    run_id,
+                    tail_lines=t,
+                    search=search,
+                    regex=regex,
+                    level=normalized_level,
+                    since_seconds=since_seconds,
+                )
 
             label = "orchestrator"
         else:
@@ -1866,6 +1944,10 @@ def get_logs(
                     env_name=env_name,
                     env_index=env_index,
                     tail_lines=t,
+                    search=search,
+                    regex=regex,
+                    level=normalized_level,
+                    since_seconds=since_seconds,
                 )
 
             label = f"env-server {env}"

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1915,6 +1915,12 @@ def get_logs(
                 param_hint="--level",
             )
 
+    if regex and not search:
+        raise typer.BadParameter(
+            "--regex has no effect without --search. Pass --search <pattern> too.",
+            param_hint="--regex",
+        )
+
     since_seconds = _parse_since(since)
 
     try:

--- a/packages/prime/tests/test_rl_logs.py
+++ b/packages/prime/tests/test_rl_logs.py
@@ -306,6 +306,7 @@ def test_logs_env_server_follow_dedupes(monkeypatch: pytest.MonkeyPatch) -> None
         env_name: str,
         env_index: int = 0,
         tail_lines: int = 1000,
+        **_kwargs: Any,
     ) -> str:
         call_count["n"] += 1
         if call_count["n"] == 1:


### PR DESCRIPTION
Surfaces the new log-search backend params on `prime train logs` / `prime rl logs`.

```
prime train logs <id> --search Backpressure
prime train logs <id> --level ERROR --since 1h
prime train logs <id> --search 'Step \d+' --regex
prime train logs <id> --env reverse-text --level WARNING --since 6h
```

- `--search` / `--regex` for substring or RE2 line filter
- `--level` for ERROR / WARNING / SUCCESS / INFO / DEBUG
- `--since 15m|1h|6h|24h|<seconds>` time window (60s–24h)
- All flags apply to env-server logs too

Backend changes (separate platform PR): https://github.com/PrimeIntellect-ai/platform/pull/2204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `prime train logs`/`prime rl logs` request parameters and adds new CLI validation/parsing that could alter log retrieval behavior (especially with backend support for filtering).
> 
> **Overview**
> Adds log filtering support to `prime train logs` by surfacing backend query params for **text/regex search**, **log level**, and a bounded **time window** via a new `--since` flag.
> 
> Updates the `RLClient` log endpoints to pass these optional filters through to `/logs` and `/env-server-logs`, and adds CLI-side validation/normalization (`--level`, `--regex` requires `--search`, and `--since` parsing to 60–86400s). Tests are adjusted to tolerate the expanded `get_env_server_logs` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946c44a76ce5e27ec691553a9b4a7e2d6072492b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->