### PR TITLE
release: prime CLI 0.6.6

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI to 0.6.6. Includes the endpoint registry resolution restore from #645 since the 0.6.5 release.\n\nValidation:\n- uv run ruff check packages/prime\n- uv run ruff format --check packages/prime\n- uv run ty check packages/prime/src\n- uv run --package prime pytest packages/prime/tests -q\n- uv build --package prime --wheel --sdist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the exported `__version__` string with no functional code changes.
> 
> **Overview**
> Updates `prime_cli.__version__` from `0.6.5` to `0.6.6` for the Prime CLI release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d595ddd24ca1a597e3bd081fe70145e0e7e71d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->