### PR TITLE
Use PyPI Trusted Publishing for all package releases

### DIFF
--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -72,6 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/prime-evals/dist

--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,11 +61,6 @@ jobs:
         run: |
           uv build --out-dir dist
 
-          # Install twine for publishing
-          uv venv
-          source .venv/bin/activate
-          uv pip install twine
-
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -76,10 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        working-directory: packages/prime-evals
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          packages-dir: packages/prime-evals/dist

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,11 +61,6 @@ jobs:
         run: |
           uv build --out-dir dist
 
-          # Install twine for publishing
-          uv venv
-          source .venv/bin/activate
-          uv pip install twine
-
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -76,10 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        working-directory: packages/prime-mcp-server
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          packages-dir: packages/prime-mcp-server/dist

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -72,6 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/prime-mcp-server/dist

--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -123,7 +123,7 @@ jobs:
       # Publish to PyPI via Trusted Publishing (OIDC)
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/prime/dist
 

--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       release_created: ${{ steps.release_status.outputs.created }}
@@ -103,11 +104,6 @@ jobs:
         run: |
           uv build --out-dir dist
 
-          # Install twine for publishing
-          uv venv
-          source .venv/bin/activate
-          uv pip install twine
-
       - name: Upload build artifacts
         if: steps.check_tag.outputs.exists != 'true'
         uses: actions/upload-artifact@v4
@@ -124,16 +120,12 @@ jobs:
           files: packages/prime/dist/*
           generate_release_notes: true
 
-      # Publish to PyPI
+      # Publish to PyPI via Trusted Publishing (OIDC)
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true'
-        working-directory: packages/prime
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          packages-dir: packages/prime/dist
 
       - name: Notify Slack
         if: steps.check_tag.outputs.exists != 'true'

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,11 +61,6 @@ jobs:
         run: |
           uv build --out-dir dist
 
-          # Install twine for publishing
-          uv venv
-          source .venv/bin/activate
-          uv pip install twine
-
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -76,10 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        working-directory: packages/prime-sandboxes
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          packages-dir: packages/prime-sandboxes/dist

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -72,6 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/prime-sandboxes/dist

--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -72,6 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/prime-tunnel/dist

--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,11 +61,6 @@ jobs:
         run: |
           uv build --out-dir dist
 
-          # Install twine for publishing
-          uv venv
-          source .venv/bin/activate
-          uv pip install twine
-
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -76,10 +72,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        working-directory: packages/prime-tunnel
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          packages-dir: packages/prime-tunnel/dist


### PR DESCRIPTION
Replaces twine + `PYPI_TOKEN` with `pypa/gh-action-pypi-publish` (OIDC) across all 5 release workflows.

- `release-prime.yml`, `release-evals.yml`, `release-mcp.yml`, `release-sandboxes.yml`, `release-tunnel.yml`
- Adds `id-token: write` permission to each publish job
- Drops the `twine` install step from the build
- Removes the dependency on the long-lived `PYPI_TOKEN` secret — can be rotated/deleted after merge once a release has been confirmed

Trusted Publishers are already configured on PyPI for all 5 projects.

Follow-ups (separate PRs):
- Wire a `pypi-prod` GitHub Environment with required reviewers and scope OIDC on PyPI side to that environment
- Add CODEOWNERS for `.github/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation for all packages and changes the auth mechanism used to publish to PyPI; a misconfiguration would block releases but does not affect runtime code.
> 
> **Overview**
> Updates the 5 release GitHub Actions workflows to publish to PyPI using `pypa/gh-action-pypi-publish` (Trusted Publishing via OIDC) instead of `twine` + `PYPI_TOKEN`.
> 
> Each workflow adds `permissions: id-token: write`, removes the virtualenv/`twine` install + `twine upload` commands, and publishes from the built `dist` output via `packages-dir`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a716f5d01ca6979534ccfeb47521a58252f96d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->