### PR TITLE
release prime-evals 0.2.2

### DIFF
--- a/packages/prime-evals/src/prime_evals/__init__.py
+++ b/packages/prime-evals/src/prime_evals/__init__.py
@@ -34,7 +34,7 @@ from .models import (
     SamplesResponse,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     # Core HTTP Client & Config


### PR DESCRIPTION
- Bumps `prime-evals` to `0.2.2`
- First release exercising the new OIDC publish flow from #652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the `prime-evals` package version constant and does not change runtime logic or APIs.
> 
> **Overview**
> Updates `prime_evals.__version__` from `0.2.1` to `0.2.2` to cut the `prime-evals` `0.2.2` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbc42342e1b95d7e1309e3132ea7da6a360b1040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->