### PR TITLE
[codex] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all repository changes.
+* @JannikSt @d42me @kcoopermiller @willccbb @burnpiro @JohannesHa


### PR DESCRIPTION
## Summary

Adds a repo-wide CODEOWNERS file that assigns default ownership for all paths to the requested maintainers.

## Impact

GitHub can now identify code owners for changes across the repository. Requiring code owner approval still depends on enabling `require_code_owner_review` in the active branch ruleset.

## Validation

- `git diff --cached --check`
- Commit hooks ran and skipped Python checks because no Python files changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a `.github/CODEOWNERS` file to set default reviewers for all paths; no runtime code is changed.
> 
> **Overview**
> Adds a repo-wide `.github/CODEOWNERS` entry (`*`) assigning default code owners to a set of maintainers, enabling GitHub to auto-request reviews/ownership for any changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d8002d5bc42fa2214d35e9c9676f50df6b904fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->