### PR TITLE
Add max_retries to env config

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -291,6 +291,7 @@ class EnvConfig(BaseModel):
     id: str
     name: str | None = None
     args: Dict[str, Any] = Field(default_factory=dict)
+    max_retries: int | None = Field(default=None, ge=0)
     version: str | None = None
 
     @model_validator(mode="after")
@@ -309,6 +310,8 @@ class EnvConfig(BaseModel):
             result["name"] = self.name
         if self.args:
             result["args"] = self.args
+        if self.max_retries is not None:
+            result["max_retries"] = self.max_retries
         if self.version is not None:
             result["version"] = self.version
         return result
@@ -322,6 +325,7 @@ class EvalEnvConfig(BaseModel):
     args: Dict[str, Any] = Field(default_factory=dict)
     num_examples: int | None = None
     rollouts_per_example: int | None = None
+    max_retries: int | None = Field(default=None, ge=0)
     version: str | None = None
 
     @model_validator(mode="after")
@@ -344,6 +348,8 @@ class EvalEnvConfig(BaseModel):
             result["num_examples"] = self.num_examples
         if self.rollouts_per_example is not None:
             result["rollouts_per_example"] = self.rollouts_per_example
+        if self.max_retries is not None:
+            result["max_retries"] = self.max_retries
         if self.version is not None:
             result["version"] = self.version
         return result


### PR DESCRIPTION
- Adds optional `max_retries` to `EnvConfig` and `EvalEnvConfig` so it can be set per-env in the TOML.
- Matches the field added on the platform side in PrimeIntellect-ai/platform#2275.

Without this, `max_retries = N` in `[[environments]]` or `[[eval.env]]` fails CLI validation due to `extra="forbid"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional validated field to config models and only affects TOML validation/serialization for env definitions.
> 
> **Overview**
> Allows per-environment `max_retries` to be set in Hosted Training TOML configs by adding an optional `max_retries` (>= 0) field to `EnvConfig` and `EvalEnvConfig`.
> 
> When provided, `max_retries` is now included in the payload generated by `to_api_dict()`, preventing config validation failures caused by `extra="forbid"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72db56ca1fa74420facde9163c24a54cd47a1b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->