### PR TITLE
Move eval TUI into prime

### DIFF
--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1147,6 +1147,7 @@ def tui_cmd(
 ) -> None:
     """Deprecated alias for the evaluation viewer."""
     console.print("[yellow]Deprecated:[/yellow] `prime eval tui` has moved. Use `prime eval view`.")
+    raise typer.Exit(1)
 
 
 @subcommands_app.command("push", epilog=PUSH_EVAL_JSON_HELP)

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -39,7 +39,7 @@ from ..verifiers_bridge import (
     is_help_request,
     print_eval_run_help,
     run_eval_passthrough,
-    run_eval_tui,
+    run_eval_view,
 )
 
 console = get_console()
@@ -1116,8 +1116,8 @@ def _push_single_eval(
     return eval_id
 
 
-@subcommands_app.command("tui")
-def tui_cmd(
+@subcommands_app.command("view")
+def view_cmd(
     limit: int = typer.Option(50, "--limit", "-n", help="Max evaluation rows to load"),
     env_dir: Optional[str] = typer.Option(
         None, "--env-dir", "-e", help="Path to environments directory"
@@ -1126,11 +1126,27 @@ def tui_cmd(
         None, "--outputs-dir", "-o", help="Path to outputs directory"
     ),
 ) -> None:
-    """Launch TUI for viewing eval results."""
+    """Launch the interactive evaluation viewer."""
     if limit < 1:
         console.print("[red]Error:[/red] --limit must be at least 1")
         raise typer.Exit(1)
-    run_eval_tui(env_dir=env_dir, outputs_dir=outputs_dir, limit=limit)
+    run_eval_view(env_dir=env_dir, outputs_dir=outputs_dir, limit=limit)
+
+
+@subcommands_app.command("tui")
+def tui_cmd(
+    _limit: int = typer.Option(
+        50, "--limit", "-n", help="Deprecated; use `prime eval view --limit`."
+    ),
+    _env_dir: Optional[str] = typer.Option(
+        None, "--env-dir", "-e", help="Deprecated; use `prime eval view --env-dir`."
+    ),
+    _outputs_dir: Optional[str] = typer.Option(
+        None, "--outputs-dir", "-o", help="Deprecated; use `prime eval view --outputs-dir`."
+    ),
+) -> None:
+    """Deprecated alias for the evaluation viewer."""
+    console.print("[yellow]Deprecated:[/yellow] `prime eval tui` has moved. Use `prime eval view`.")
 
 
 @subcommands_app.command("push", epilog=PUSH_EVAL_JSON_HELP)

--- a/packages/prime/src/prime_cli/commands/evals.py
+++ b/packages/prime/src/prime_cli/commands/evals.py
@@ -1118,6 +1118,7 @@ def _push_single_eval(
 
 @subcommands_app.command("tui")
 def tui_cmd(
+    limit: int = typer.Option(50, "--limit", "-n", help="Max evaluation rows to load"),
     env_dir: Optional[str] = typer.Option(
         None, "--env-dir", "-e", help="Path to environments directory"
     ),
@@ -1126,7 +1127,10 @@ def tui_cmd(
     ),
 ) -> None:
     """Launch TUI for viewing eval results."""
-    run_eval_tui(env_dir=env_dir, outputs_dir=outputs_dir)
+    if limit < 1:
+        console.print("[red]Error:[/red] --limit must be at least 1")
+        raise typer.Exit(1)
+    run_eval_tui(env_dir=env_dir, outputs_dir=outputs_dir, limit=limit)
 
 
 @subcommands_app.command("push", epilog=PUSH_EVAL_JSON_HELP)

--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -1370,7 +1370,7 @@ def _post_setup_call_to_action(options: LabSetupOptions) -> Panel:
     command_table.add_row(
         "[bold green]$[/bold green]", "prime eval run my-env -m openai/gpt-5.4-nano -n 5"
     )
-    command_table.add_row("[bold green]$[/bold green]", "prime eval tui")
+    command_table.add_row("[bold green]$[/bold green]", "prime eval view")
     command_table.add_row("[bold green]$[/bold green]", "prime rl run configs/rl/qwen-3-5.toml")
     command_table.add_row(
         "[bold green]$[/bold green]", "prime gepa run my-env -m openai/gpt-5.4-nano"

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -209,13 +209,15 @@ def print_lab_setup_help() -> None:
     _write_help(help_text)
 
 
-def run_eval_tui(env_dir: Optional[str], outputs_dir: Optional[str]) -> None:
-    plugin = load_verifiers_prime_plugin(console=console)
-    env = os.environ.copy()
-    env["VF_ENV_DIR"] = env_dir or "./environments"
-    env["VF_OUTPUTS_DIR"] = outputs_dir or "./outputs"
-    command = plugin.build_module_command(plugin.tui_module)
-    _run_command(command, env=env)
+def run_eval_tui(env_dir: Optional[str], outputs_dir: Optional[str], limit: int = 50) -> None:
+    from prime_lab_app import run_eval_tui as run_prime_eval_tui
+
+    run_prime_eval_tui(
+        limit=limit,
+        env_dir=env_dir or "./environments",
+        outputs_dir=outputs_dir or "./outputs",
+        workspace=Path.cwd(),
+    )
 
 
 def _parse_value_option(

--- a/packages/prime/src/prime_cli/verifiers_bridge.py
+++ b/packages/prime/src/prime_cli/verifiers_bridge.py
@@ -40,7 +40,7 @@ MODULE_TO_PRIME_COMMAND = {
     "verifiers.cli.commands.install": "prime env install",
     "verifiers.cli.commands.build": "prime env build",
     "verifiers.cli.commands.setup": "prime lab setup",
-    "verifiers.cli.tui": "prime eval tui",
+    "verifiers.cli.tui": "prime eval view",
 }
 
 
@@ -209,10 +209,10 @@ def print_lab_setup_help() -> None:
     _write_help(help_text)
 
 
-def run_eval_tui(env_dir: Optional[str], outputs_dir: Optional[str], limit: int = 50) -> None:
-    from prime_lab_app import run_eval_tui as run_prime_eval_tui
+def run_eval_view(env_dir: Optional[str], outputs_dir: Optional[str], limit: int = 50) -> None:
+    from prime_lab_app import run_eval_view as run_prime_eval_view
 
-    run_prime_eval_tui(
+    run_prime_eval_view(
         limit=limit,
         env_dir=env_dir or "./environments",
         outputs_dir=outputs_dir or "./outputs",

--- a/packages/prime/src/prime_lab_app/__init__.py
+++ b/packages/prime/src/prime_lab_app/__init__.py
@@ -7,8 +7,15 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .app import PrimeLabView, run_lab_view
     from .eval_screen import LocalEvalRunScreen
+    from .eval_tui import build_eval_tui_app, run_eval_tui
 
-__all__ = ["LocalEvalRunScreen", "PrimeLabView", "run_lab_view"]
+__all__ = [
+    "LocalEvalRunScreen",
+    "PrimeLabView",
+    "build_eval_tui_app",
+    "run_eval_tui",
+    "run_lab_view",
+]
 
 
 def __getattr__(name: str) -> Any:
@@ -16,6 +23,13 @@ def __getattr__(name: str) -> Any:
         from .app import PrimeLabView, run_lab_view
 
         return {"PrimeLabView": PrimeLabView, "run_lab_view": run_lab_view}[name]
+    if name in {"build_eval_tui_app", "run_eval_tui"}:
+        from .eval_tui import build_eval_tui_app, run_eval_tui
+
+        return {
+            "build_eval_tui_app": build_eval_tui_app,
+            "run_eval_tui": run_eval_tui,
+        }[name]
     if name == "LocalEvalRunScreen":
         from .eval_screen import LocalEvalRunScreen
 

--- a/packages/prime/src/prime_lab_app/__init__.py
+++ b/packages/prime/src/prime_lab_app/__init__.py
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .app import PrimeLabView, run_lab_view
     from .eval_screen import LocalEvalRunScreen
-    from .eval_tui import build_eval_tui_app, run_eval_tui
+    from .eval_view import build_eval_view_app, run_eval_view
 
 __all__ = [
     "LocalEvalRunScreen",
     "PrimeLabView",
-    "build_eval_tui_app",
-    "run_eval_tui",
+    "build_eval_view_app",
+    "run_eval_view",
     "run_lab_view",
 ]
 
@@ -23,12 +23,12 @@ def __getattr__(name: str) -> Any:
         from .app import PrimeLabView, run_lab_view
 
         return {"PrimeLabView": PrimeLabView, "run_lab_view": run_lab_view}[name]
-    if name in {"build_eval_tui_app", "run_eval_tui"}:
-        from .eval_tui import build_eval_tui_app, run_eval_tui
+    if name in {"build_eval_view_app", "run_eval_view"}:
+        from .eval_view import build_eval_view_app, run_eval_view
 
         return {
-            "build_eval_tui_app": build_eval_tui_app,
-            "run_eval_tui": run_eval_tui,
+            "build_eval_view_app": build_eval_view_app,
+            "run_eval_view": run_eval_view,
         }[name]
     if name == "LocalEvalRunScreen":
         from .eval_screen import LocalEvalRunScreen

--- a/packages/prime/src/prime_lab_app/app.py
+++ b/packages/prime/src/prime_lab_app/app.py
@@ -1744,8 +1744,10 @@ class PrimeLabView(App[None]):
         if item.section == "evaluations" and item.raw.get("type") == "local_eval":
             self.push_screen(LocalEvalRunScreen(LocalEvalRun.from_item(item)))
             return
-        if item.section == "evaluations":
+        if item.section == "evaluations" and item.raw.get("source") == "hosted":
             self.push_screen(HostedEvalSamplesScreen(item, self._detail_loader))
+            return
+        if item.section == "evaluations":
             return
         if self._detail_loader is None:
             return

--- a/packages/prime/src/prime_lab_app/app.py
+++ b/packages/prime/src/prime_lab_app/app.py
@@ -52,7 +52,7 @@ from .eval_render import (
     numeric_reward,
     reward_style,
 )
-from .eval_screen import LocalEvalRunScreen
+from .eval_screen import HostedEvalSamplesScreen, LocalEvalRunScreen
 from .evaluation_browser import (
     EVALUATION_VIEWS,
     evaluation_env_tree_label,
@@ -366,6 +366,9 @@ class PrimeLabView(App[None]):
         ladder_loader: Callable[[int], LabSnapshot] | None = None,
         ladder_limits: tuple[int, ...] = (),
         workspace_switcher: WorkspaceSwitcher | None = None,
+        initial_section_key: str = "workspace",
+        show_launch_screen: bool = True,
+        sync_agent_runtime: bool = True,
     ):
         super().__init__()
         self._loader = loader
@@ -374,10 +377,12 @@ class PrimeLabView(App[None]):
         self._ladder_loader = ladder_loader
         self._ladder_limits = ladder_limits
         self._workspace_switcher = workspace_switcher
+        self._show_launch_screen = show_launch_screen
+        self._sync_agent_runtime_enabled = sync_agent_runtime
         self._loaded_section_limit = 0
         self._requested_section_limit = max(ladder_limits, default=0)
         self._snapshot: LabSnapshot | None = None
-        self._active_section_key = "workspace"
+        self._active_section_key = initial_section_key
         self._filter = ""
         self._visible_items: list[LabItem] = []
         self._items_by_key: dict[str, LabItem] = {}
@@ -449,7 +454,8 @@ class PrimeLabView(App[None]):
         evaluation_tree.show_root = False
         evaluation_tree.auto_expand = False
         evaluation_tree.guide_depth = 2
-        self._open_launch_screen()
+        if self._show_launch_screen:
+            self._open_launch_screen()
         self._show_initial_snapshot()
         self._reload()
 
@@ -496,6 +502,7 @@ class PrimeLabView(App[None]):
             | AgentChatScreen
             | TrainingRunScreen
             | FilterScreen
+            | HostedEvalSamplesScreen
             | LocalEvalRunScreen,
         ) and action in {
             "refresh",
@@ -517,7 +524,8 @@ class PrimeLabView(App[None]):
         }:
             return False
         if action in {"search", "load_more_rows"} and isinstance(
-            self.screen, TrainingRunScreen | FilterScreen | LocalEvalRunScreen
+            self.screen,
+            TrainingRunScreen | FilterScreen | HostedEvalSamplesScreen | LocalEvalRunScreen,
         ):
             return False
         if action == "load_detail":
@@ -885,7 +893,8 @@ class PrimeLabView(App[None]):
         self._render_tree()
         self._render_active_section()
         self._sync_launch_screen()
-        self._sync_agent_runtime(snapshot)
+        if self._sync_agent_runtime_enabled:
+            self._sync_agent_runtime(snapshot)
 
     @work(thread=True, exclusive=True, group="detail-load")
     def _load_detail_worker(self, item: LabItem, include_logs: bool) -> None:
@@ -1735,6 +1744,9 @@ class PrimeLabView(App[None]):
         if item.section == "evaluations" and item.raw.get("type") == "local_eval":
             self.push_screen(LocalEvalRunScreen(LocalEvalRun.from_item(item)))
             return
+        if item.section == "evaluations":
+            self.push_screen(HostedEvalSamplesScreen(item, self._detail_loader))
+            return
         if self._detail_loader is None:
             return
         if item.section == "training":
@@ -2021,6 +2033,7 @@ def _is_lab_child_screen(screen: object) -> bool:
         | AgentChatScreen
         | TrainingRunScreen
         | FilterScreen
+        | HostedEvalSamplesScreen
         | LocalEvalRunScreen,
     )
 

--- a/packages/prime/src/prime_lab_app/app.py
+++ b/packages/prime/src/prime_lab_app/app.py
@@ -34,6 +34,7 @@ from .agent_sessions import (
 from .agent_widgets import handle_lab_widget_tool_call
 from .config_screen import ConfigLaunchScreen, ConfigRunScreen
 from .data import LabLoadOptions
+from .detail_loader import DetailLoader
 from .details import (
     evaluation_detail_chunks as _evaluation_detail_chunks,
 )
@@ -108,7 +109,6 @@ from .snapshots import merge_snapshot_rows
 from .training_screen import (
     _LOG_TAIL_STEPS,
     _RUN_METRIC_PREVIEW_LIMIT,
-    DetailLoader,
     TrainingRunScreen,
     _has_training_detail,
     _merge_training_detail,

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -156,6 +156,63 @@ class LabDataSource:
             sections=tuple(sections),
         )
 
+    def load_evaluations(self, options: LabLoadOptions) -> LabSnapshot:
+        """Load only the Evaluations section for the standalone eval TUI."""
+        warnings: list[str] = []
+        config = self._config_factory()
+        authenticated = bool(config.api_key)
+        team = config.team_name or config.team_id
+        cache_key = _row_cache_key(options, config, team)
+        detail_cache_key = _account_cache_key(config, team)
+        cached_sections = load_cached_lab_sections(cache_key, limit=options.limit)
+
+        sections = [
+            self._evaluation_section(options, config, authenticated, warnings),
+        ]
+        sections = _hydrate_platform_sections(detail_cache_key, sections, cached_sections)
+        sections = _mark_live_sections(sections, refreshed_at=_utc_now_iso())
+
+        return LabSnapshot(
+            workspace=options.workspace.resolve(),
+            base_url=config.base_url,
+            frontend_url=config.frontend_url,
+            authenticated=authenticated,
+            team=team,
+            sections=tuple(sections),
+            warnings=tuple(warnings),
+        )
+
+    def load_evaluations_initial(self, options: LabLoadOptions) -> LabSnapshot:
+        """Load local/cached evaluation rows while the live eval request runs."""
+        config = self._config_factory()
+        authenticated = bool(config.api_key)
+        team = config.team_name or config.team_id
+        cache_key = _row_cache_key(options, config, team)
+        detail_cache_key = _account_cache_key(config, team)
+        cached_sections = load_cached_lab_sections(cache_key, limit=options.limit)
+        local_eval_items = tuple(_local_eval_items(options, section="evaluations"))
+
+        sections = [
+            _cached_or_loading_section(
+                "evaluations",
+                "Evaluations",
+                "Local and platform evaluation runs.",
+                authenticated=authenticated,
+                local_items=local_eval_items,
+                cached_section=cached_sections.get("evaluations"),
+            ),
+        ]
+        sections = _hydrate_platform_sections(detail_cache_key, sections, cached_sections)
+
+        return LabSnapshot(
+            workspace=options.workspace.resolve(),
+            base_url=config.base_url,
+            frontend_url=config.frontend_url,
+            authenticated=authenticated,
+            team=team,
+            sections=tuple(sections),
+        )
+
     def load_item_detail(
         self,
         item: LabItem,

--- a/packages/prime/src/prime_lab_app/data.py
+++ b/packages/prime/src/prime_lab_app/data.py
@@ -172,7 +172,7 @@ class LabDataSource:
         sections = _hydrate_platform_sections(detail_cache_key, sections, cached_sections)
         sections = _mark_live_sections(sections, refreshed_at=_utc_now_iso())
 
-        return LabSnapshot(
+        snapshot = LabSnapshot(
             workspace=options.workspace.resolve(),
             base_url=config.base_url,
             frontend_url=config.frontend_url,
@@ -181,6 +181,8 @@ class LabDataSource:
             sections=tuple(sections),
             warnings=tuple(warnings),
         )
+        write_cached_lab_sections(cache_key, snapshot.sections)
+        return snapshot
 
     def load_evaluations_initial(self, options: LabLoadOptions) -> LabSnapshot:
         """Load local/cached evaluation rows while the live eval request runs."""

--- a/packages/prime/src/prime_lab_app/detail_loader.py
+++ b/packages/prime/src/prime_lab_app/detail_loader.py
@@ -1,0 +1,9 @@
+"""Shared Lab item detail loader types."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .models import LabItem
+
+DetailLoader = Callable[[LabItem, bool, int, int, int | None], LabItem]

--- a/packages/prime/src/prime_lab_app/environment_screen.py
+++ b/packages/prime/src/prime_lab_app/environment_screen.py
@@ -24,6 +24,7 @@ from textual.widgets._option_list import Option
 from .cache import CachedEnvironmentSource, cached_environment_source, ensure_environment_source
 from .config_factory import evaluation_config, format_lab_config, rl_config
 from .config_screen import ConfigLaunchScreen, ConfigRunScreen
+from .detail_loader import DetailLoader
 from .environment_records import environment_platform_url
 from .models import LabItem
 from .palette import BUTTON_CSS, PRIMARY, STATUS_ERROR
@@ -33,7 +34,6 @@ from .shell import lab_header
 from .source_browser import SourceEntry, format_size, readme_path, source_entries, source_preview
 from .widgets import ClearableInput, LoadingChart
 
-DetailLoader = Callable[[LabItem, bool, int, int, int | None], LabItem]
 WorkspaceSwitcher = Callable[[Path], None]
 WorkspaceMemoryAction = Callable[[Path], None]
 SetupCompleteAction = Callable[[], None]

--- a/packages/prime/src/prime_lab_app/eval_screen.py
+++ b/packages/prime/src/prime_lab_app/eval_screen.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from rich.markup import escape
 from rich.text import Text
-from textual import events, on
+from textual import events, on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, VerticalScroll
@@ -73,6 +73,7 @@ from .eval_render import (
     tool_group_preview,
     tool_output_preview,
 )
+from .models import LabItem
 from .palette import ROLLOUT_SUCCESS, ROLLOUT_WARNING, STATUS_ERROR, TOOL_CALL
 from .widgets import ClearableInput
 
@@ -1608,6 +1609,146 @@ class RolloutViewer(Container):
         if raw_text:
             items.append(RolloutCopyItem(key="raw", label="Raw JSON", body=raw_text))
         return items
+
+
+EvaluationDetailLoader = Callable[[LabItem, bool, int, int, int | None], LabItem]
+
+
+class HostedEvalSamplesScreen(Screen[None]):
+    """Full-page hosted eval sample viewer."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", key_display="Esc"),
+        Binding("b", "back", "Back", key_display="B"),
+    ]
+
+    CSS = """
+    HostedEvalSamplesScreen {
+        background: $background;
+        color: $foreground;
+        layout: vertical;
+    }
+
+    #hosted-eval-samples-container {
+        height: 100%;
+        layout: vertical;
+        padding: 0 1;
+    }
+
+    #hosted-eval-samples-summary {
+        height: auto;
+        min-height: 3;
+        max-height: 5;
+        padding: 0 1;
+        border-bottom: solid $primary;
+    }
+
+    #hosted-eval-samples-body {
+        height: 1fr;
+    }
+    """
+
+    def __init__(
+        self,
+        item: LabItem,
+        detail_loader: EvaluationDetailLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self.item = item
+        self._detail_loader = detail_loader
+        self._load_error = ""
+
+    def compose(self) -> ComposeResult:
+        with Container(id="hosted-eval-samples-container"):
+            yield Static("", id="hosted-eval-samples-summary", markup=False)
+            with Container(id="hosted-eval-samples-body"):
+                yield Static(Text("Loading samples ...", style="dim"), markup=False)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self._sample_records():
+            self._render_samples()
+            return
+        if self._detail_loader is None:
+            self._render_samples()
+            return
+        self._load_detail_worker()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    @work(thread=True, exclusive=True)
+    def _load_detail_worker(self) -> None:
+        if self._detail_loader is None:
+            return
+        try:
+            item = self._detail_loader(self.item, False, 50, 10, None)
+        except Exception as exc:
+            self.call_from_thread(self._set_load_error, str(exc))
+            return
+        self.call_from_thread(self._set_loaded_item, item)
+
+    def _set_loaded_item(self, item: LabItem) -> None:
+        self.item = item
+        self._render_samples()
+
+    def _set_load_error(self, message: str) -> None:
+        self._load_error = message
+        self._render_samples()
+
+    def _sample_payload(self) -> dict[str, Any]:
+        payload = self.item.raw.get("samples_preview")
+        return payload if isinstance(payload, dict) else {}
+
+    def _sample_records(self) -> list[dict[str, Any]]:
+        samples = self._sample_payload().get("samples")
+        if not isinstance(samples, list):
+            return []
+        return [sample for sample in samples if isinstance(sample, dict)]
+
+    def _render_samples(self) -> None:
+        self.query_one("#hosted-eval-samples-summary", Static).update(self._summary_text())
+        body = self.query_one("#hosted-eval-samples-body", Container)
+        body.remove_children()
+
+        records = self._sample_records()
+        if records:
+            body.mount(
+                RolloutViewer(
+                    records,
+                    metadata=self.item.raw.get("metadata")
+                    if isinstance(self.item.raw.get("metadata"), dict)
+                    else {},
+                    title="Samples",
+                    id="hosted-eval-rollout-viewer",
+                )
+            )
+            self.call_after_refresh(lambda: self.query_one(RolloutViewer)._focus_primary_content())
+            return
+
+        error = self._load_error or str(self._sample_payload().get("error") or "")
+        message = f"Failed to load samples: {error}" if error else "No samples found."
+        body.mount(Static(Text(message, style=STATUS_ERROR if error else "dim"), markup=False))
+
+    def _summary_text(self) -> Text:
+        payload = self._sample_payload()
+        total = payload.get("total")
+        page = payload.get("page")
+        limit = payload.get("limit")
+
+        text = Text()
+        text.append("Evaluation Samples\n", style="bold")
+        text.append(self.item.title, style="bold")
+        if self.item.subtitle:
+            text.append("  ")
+            text.append(self.item.subtitle, style="dim")
+        text.append("\n")
+        text.append(f"loaded {len(self._sample_records())}", style="dim")
+        if total is not None:
+            text.append(f" / {total}", style="dim")
+        if page is not None and limit is not None:
+            text.append(f"  page {page}  limit {limit}", style="dim")
+        return text
 
 
 class LocalEvalRunScreen(Screen[None]):

--- a/packages/prime/src/prime_lab_app/eval_screen.py
+++ b/packages/prime/src/prime_lab_app/eval_screen.py
@@ -31,6 +31,7 @@ from textual.widgets import (
 from textual.widgets._option_list import Option
 from textual.widgets._tabbed_content import ContentTabs
 
+from .detail_loader import DetailLoader
 from .eval_markdown import MathMarkdown
 from .eval_records import (
     HistorySectionData,
@@ -1611,9 +1612,6 @@ class RolloutViewer(Container):
         return items
 
 
-EvaluationDetailLoader = Callable[[LabItem, bool, int, int, int | None], LabItem]
-
-
 class HostedEvalSamplesScreen(Screen[None]):
     """Full-page hosted eval sample viewer."""
 
@@ -1651,7 +1649,7 @@ class HostedEvalSamplesScreen(Screen[None]):
     def __init__(
         self,
         item: LabItem,
-        detail_loader: EvaluationDetailLoader | None = None,
+        detail_loader: DetailLoader | None = None,
     ) -> None:
         super().__init__()
         self.item = item

--- a/packages/prime/src/prime_lab_app/eval_screen.py
+++ b/packages/prime/src/prime_lab_app/eval_screen.py
@@ -1682,9 +1682,9 @@ class HostedEvalSamplesScreen(Screen[None]):
         try:
             item = self._detail_loader(self.item, False, 50, 10, None)
         except Exception as exc:
-            self.call_from_thread(self._set_load_error, str(exc))
+            self.app.call_from_thread(self._set_load_error, str(exc))
             return
-        self.call_from_thread(self._set_loaded_item, item)
+        self.app.call_from_thread(self._set_loaded_item, item)
 
     def _set_loaded_item(self, item: LabItem) -> None:
         self.item = item

--- a/packages/prime/src/prime_lab_app/eval_tui.py
+++ b/packages/prime/src/prime_lab_app/eval_tui.py
@@ -1,0 +1,65 @@
+"""Standalone evaluation viewer for `prime eval tui`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .app import PrimeLabView
+from .data import LabDataSource, LabLoadOptions
+
+DEFAULT_EVAL_TUI_LIMIT = 50
+
+
+def build_eval_tui_app(
+    *,
+    limit: int = DEFAULT_EVAL_TUI_LIMIT,
+    env_dir: str = "./environments",
+    outputs_dir: str = "./outputs",
+    workspace: Path | None = None,
+    data_source: LabDataSource | None = None,
+) -> PrimeLabView:
+    if limit < 1:
+        raise ValueError("limit must be at least 1")
+
+    current_workspace = (workspace or Path.cwd()).resolve()
+    source = data_source or LabDataSource()
+
+    def options_for(current_limit: int) -> LabLoadOptions:
+        return LabLoadOptions(
+            limit=current_limit,
+            workspace=current_workspace,
+            env_dir=env_dir,
+            outputs_dir=outputs_dir,
+        )
+
+    return PrimeLabView(
+        lambda: source.load_evaluations(options_for(limit)),
+        lambda item, include_logs, log_tail_lines, metrics_limit, metrics_min_step: (
+            source.load_item_detail(
+                item,
+                include_logs=include_logs,
+                log_tail_lines=log_tail_lines,
+                metrics_limit=metrics_limit,
+                metrics_min_step=metrics_min_step,
+            )
+        ),
+        lambda: source.load_evaluations_initial(options_for(limit)),
+        initial_section_key="evaluations",
+        show_launch_screen=False,
+        sync_agent_runtime=False,
+    )
+
+
+def run_eval_tui(
+    *,
+    limit: int = DEFAULT_EVAL_TUI_LIMIT,
+    env_dir: str = "./environments",
+    outputs_dir: str = "./outputs",
+    workspace: Path | None = None,
+) -> None:
+    build_eval_tui_app(
+        limit=limit,
+        env_dir=env_dir,
+        outputs_dir=outputs_dir,
+        workspace=workspace,
+    ).run()

--- a/packages/prime/src/prime_lab_app/eval_view.py
+++ b/packages/prime/src/prime_lab_app/eval_view.py
@@ -1,4 +1,4 @@
-"""Standalone evaluation viewer for `prime eval tui`."""
+"""Standalone evaluation viewer for `prime eval view`."""
 
 from __future__ import annotations
 
@@ -7,12 +7,12 @@ from pathlib import Path
 from .app import PrimeLabView
 from .data import LabDataSource, LabLoadOptions
 
-DEFAULT_EVAL_TUI_LIMIT = 50
+DEFAULT_EVAL_VIEW_LIMIT = 50
 
 
-def build_eval_tui_app(
+def build_eval_view_app(
     *,
-    limit: int = DEFAULT_EVAL_TUI_LIMIT,
+    limit: int = DEFAULT_EVAL_VIEW_LIMIT,
     env_dir: str = "./environments",
     outputs_dir: str = "./outputs",
     workspace: Path | None = None,
@@ -50,14 +50,14 @@ def build_eval_tui_app(
     )
 
 
-def run_eval_tui(
+def run_eval_view(
     *,
-    limit: int = DEFAULT_EVAL_TUI_LIMIT,
+    limit: int = DEFAULT_EVAL_VIEW_LIMIT,
     env_dir: str = "./environments",
     outputs_dir: str = "./outputs",
     workspace: Path | None = None,
 ) -> None:
-    build_eval_tui_app(
+    build_eval_view_app(
         limit=limit,
         env_dir=env_dir,
         outputs_dir=outputs_dir,

--- a/packages/prime/src/prime_lab_app/training_screen.py
+++ b/packages/prime/src/prime_lab_app/training_screen.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import math
 import time
 import webbrowser
-from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -21,6 +20,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Footer, Static, Tab, Tabs
 
 from .config_screen import ConfigRunScreen
+from .detail_loader import DetailLoader
 from .filters import FilterChoice, FilterScreen
 from .logs import visible_system_renderable as _visible_system_renderable
 from .models import LabItem
@@ -82,7 +82,6 @@ from .values import int_value as _int_value
 from .values import list_value as _list_value
 from .widgets import LoadingChart, LoadingMessage
 
-DetailLoader = Callable[[LabItem, bool, int, int, int | None], LabItem]
 _RUN_METRIC_PREVIEW_LIMIT = 10
 _RUN_METRIC_FULL_LIMIT = 500
 _METRIC_REVEAL_INTERVAL_SECONDS = 0.04

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -46,3 +46,34 @@ def test_append_eval_options_mentions_tunnel_access():
     help_text = _append_eval_options("Usage: prime eval run [-h] environment\n")
 
     assert "--allow-tunnel-access" in help_text
+
+
+def test_eval_tui_uses_prime_viewer(monkeypatch):
+    calls = {}
+
+    def fake_run_eval_tui(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setattr("prime_lab_app.run_eval_tui", fake_run_eval_tui)
+
+    result = runner.invoke(
+        app,
+        ["eval", "tui", "--limit", "25", "--env-dir", "envs", "--outputs-dir", "outs"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["limit"] == 25
+    assert calls["env_dir"] == "envs"
+    assert calls["outputs_dir"] == "outs"
+
+
+def test_eval_tui_rejects_non_positive_limit():
+    result = runner.invoke(
+        app,
+        ["eval", "tui", "--limit", "0"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 1
+    assert "--limit must be at least 1" in result.output

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -86,6 +86,6 @@ def test_eval_tui_points_to_eval_view():
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1
     assert "Deprecated" in result.output
     assert "prime eval view" in result.output

--- a/packages/prime/tests/test_eval_help.py
+++ b/packages/prime/tests/test_eval_help.py
@@ -48,17 +48,17 @@ def test_append_eval_options_mentions_tunnel_access():
     assert "--allow-tunnel-access" in help_text
 
 
-def test_eval_tui_uses_prime_viewer(monkeypatch):
+def test_eval_view_uses_prime_viewer(monkeypatch):
     calls = {}
 
-    def fake_run_eval_tui(**kwargs):
+    def fake_run_eval_view(**kwargs):
         calls.update(kwargs)
 
-    monkeypatch.setattr("prime_lab_app.run_eval_tui", fake_run_eval_tui)
+    monkeypatch.setattr("prime_lab_app.run_eval_view", fake_run_eval_view)
 
     result = runner.invoke(
         app,
-        ["eval", "tui", "--limit", "25", "--env-dir", "envs", "--outputs-dir", "outs"],
+        ["eval", "view", "--limit", "25", "--env-dir", "envs", "--outputs-dir", "outs"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
 
@@ -68,12 +68,24 @@ def test_eval_tui_uses_prime_viewer(monkeypatch):
     assert calls["outputs_dir"] == "outs"
 
 
-def test_eval_tui_rejects_non_positive_limit():
+def test_eval_view_rejects_non_positive_limit():
     result = runner.invoke(
         app,
-        ["eval", "tui", "--limit", "0"],
+        ["eval", "view", "--limit", "0"],
         env={"PRIME_DISABLE_VERSION_CHECK": "1"},
     )
 
     assert result.exit_code == 1
     assert "--limit must be at least 1" in result.output
+
+
+def test_eval_tui_points_to_eval_view():
+    result = runner.invoke(
+        app,
+        ["eval", "tui", "--limit", "0", "--env-dir", "envs", "--outputs-dir", "outs"],
+        env={"PRIME_DISABLE_VERSION_CHECK": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Deprecated" in result.output
+    assert "prime eval view" in result.output

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -148,7 +148,13 @@ from prime_lab_app.environment_screen import (
 from prime_lab_app.eval_markdown import MathMarkdown, make_math_parser
 from prime_lab_app.eval_records import LazyRunResults, LocalEvalRun
 from prime_lab_app.eval_render import compute_run_overview_stats, history_groups
-from prime_lab_app.eval_screen import LocalEvalRunScreen, RolloutCopyScreen, RolloutViewer
+from prime_lab_app.eval_screen import (
+    HostedEvalSamplesScreen,
+    LocalEvalRunScreen,
+    RolloutCopyScreen,
+    RolloutViewer,
+)
+from prime_lab_app.eval_tui import build_eval_tui_app
 from prime_lab_app.evaluation_browser import (
     evaluation_index,
     evaluation_model_selection_details,
@@ -599,6 +605,37 @@ def test_lab_view_evaluation_rows_mark_source_and_keep_status_consistent(tmp_pat
     assert local.status == "COMPLETED"
     assert local.metadata[2] == ("Type", "local")
     assert [badge["label"] for badge in local.raw["badges"]] == ["LOCAL", "COMPLETED"]
+
+
+@pytest.mark.asyncio
+async def test_eval_tui_starts_on_evaluations_and_includes_hosted_runs(tmp_path: Path) -> None:
+    run_dir = tmp_path / "outputs" / "evals" / "gsm8k--openai--gpt-4" / "run-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "metadata.json").write_text(
+        '{"avg_reward": 0.75, "num_examples": 1}',
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text('{"reward": 0.75}\n', encoding="utf-8")
+
+    app = build_eval_tui_app(limit=10, workspace=tmp_path, data_source=make_source())
+
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+
+        assert app._launch_screen is None
+        assert app._active_section_key == "evaluations"
+        assert [section.key for section in app._snapshot.sections] == ["evaluations"]
+        titles = [item.title for item in app._visible_items]
+        assert "eval-1" in titles
+        assert "run-a" in titles
+
+        local_index = titles.index("run-a")
+        app.query_one("#item-list", OptionList).highlighted = local_index
+        app._show_item(app._visible_items[local_index])
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert isinstance(app.screen, LocalEvalRunScreen)
 
 
 def test_lab_view_merges_local_and_platform_environments(tmp_path: Path) -> None:
@@ -1325,6 +1362,47 @@ def test_training_data_tab_uses_rollout_viewer() -> None:
     widgets = _training_run_widgets(item, include_logs=False, active_tab="data")
 
     assert any(isinstance(widget, RolloutViewer) for widget in widgets)
+
+
+@pytest.mark.asyncio
+async def test_prime_lab_app_opens_hosted_eval_samples_screen(tmp_path: Path) -> None:
+    source = make_source()
+    snapshot = source.load(LabLoadOptions(limit=10, workspace=tmp_path))
+    app = PrimeLabView(
+        lambda: snapshot,
+        lambda item, include_logs, log_tail_lines, metrics_limit, metrics_min_step: (
+            source.load_item_detail(
+                item,
+                include_logs=include_logs,
+                log_tail_lines=log_tail_lines,
+                metrics_limit=metrics_limit,
+                metrics_min_step=metrics_min_step,
+            )
+        ),
+    )
+
+    async with app.run_test(size=(140, 44)) as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        app._active_section_key = "evaluations"
+        app._render_active_section()
+        await pilot.pause()
+
+        hosted_item = next(
+            item for item in app._visible_items if item.raw.get("source") == "hosted"
+        )
+        app._show_item(hosted_item)
+        app.action_load_detail()
+
+        for _ in range(20):
+            await pilot.pause()
+            if isinstance(app.screen, HostedEvalSamplesScreen) and app.screen.query(RolloutViewer):
+                break
+
+        assert isinstance(app.screen, HostedEvalSamplesScreen)
+        viewer = app.screen.query_one(RolloutViewer)
+        assert viewer.records[0]["reward"] == 1.0
 
 
 def test_training_progress_counts_step_zero_as_completed() -> None:

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -1015,6 +1015,27 @@ def test_lab_view_initial_snapshot_hydrates_cached_platform_rows(
     assert training.refreshed_at
 
 
+def test_eval_tui_initial_snapshot_hydrates_cached_platform_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = make_source()
+
+    source.load_evaluations(LabLoadOptions(limit=10, workspace=workspace))
+    snapshot = source.load_evaluations_initial(LabLoadOptions(limit=10, workspace=workspace))
+
+    assert [section.key for section in snapshot.sections] == ["evaluations"]
+    evaluations = snapshot.section("evaluations")
+    assert evaluations is not None
+    assert evaluations.items[0].title == "eval-1"
+    assert evaluations.status == "1 cached"
+    assert evaluations.row_data_origin == "disk"
+    assert evaluations.refreshed_at
+
+
 def test_lab_view_row_cache_never_shrinks_on_smaller_refresh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -1426,6 +1426,49 @@ async def test_prime_lab_app_opens_hosted_eval_samples_screen(tmp_path: Path) ->
         assert viewer.records[0]["reward"] == 1.0
 
 
+@pytest.mark.asyncio
+async def test_prime_lab_app_ignores_evaluation_placeholders(tmp_path: Path) -> None:
+    placeholder = LabItem(
+        key="evaluations:error",
+        section="evaluations",
+        title="Unavailable",
+        raw={"error": "boom"},
+    )
+    snapshot = LabSnapshot(
+        workspace=tmp_path,
+        base_url="https://api.test",
+        frontend_url="https://app.test",
+        authenticated=True,
+        team="team",
+        sections=(
+            LabSection(
+                key="evaluations",
+                title="Evaluations",
+                description="Evaluation runs.",
+                items=(placeholder,),
+            ),
+        ),
+    )
+    detail_calls = []
+    app = PrimeLabView(
+        lambda: snapshot,
+        lambda item, include_logs, log_tail_lines, metrics_limit, metrics_min_step: (
+            detail_calls.append(item) or item
+        ),
+        initial_section_key="evaluations",
+        show_launch_screen=False,
+    )
+
+    async with app.run_test(size=(100, 32)) as pilot:
+        await pilot.pause()
+        app._show_item(placeholder)
+        app._load_selected_detail(include_logs=False)
+        await pilot.pause()
+
+        assert not isinstance(app.screen, HostedEvalSamplesScreen)
+        assert detail_calls == []
+
+
 def test_training_progress_counts_step_zero_as_completed() -> None:
     summary = training_progress_summary(
         {"max_steps": 10, "status": "RUNNING"},

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -154,7 +154,7 @@ from prime_lab_app.eval_screen import (
     RolloutCopyScreen,
     RolloutViewer,
 )
-from prime_lab_app.eval_tui import build_eval_tui_app
+from prime_lab_app.eval_view import build_eval_view_app
 from prime_lab_app.evaluation_browser import (
     evaluation_index,
     evaluation_model_selection_details,
@@ -608,7 +608,7 @@ def test_lab_view_evaluation_rows_mark_source_and_keep_status_consistent(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_eval_tui_starts_on_evaluations_and_includes_hosted_runs(tmp_path: Path) -> None:
+async def test_eval_view_starts_on_evaluations_and_includes_hosted_runs(tmp_path: Path) -> None:
     run_dir = tmp_path / "outputs" / "evals" / "gsm8k--openai--gpt-4" / "run-a"
     run_dir.mkdir(parents=True)
     (run_dir / "metadata.json").write_text(
@@ -617,7 +617,7 @@ async def test_eval_tui_starts_on_evaluations_and_includes_hosted_runs(tmp_path:
     )
     (run_dir / "results.jsonl").write_text('{"reward": 0.75}\n', encoding="utf-8")
 
-    app = build_eval_tui_app(limit=10, workspace=tmp_path, data_source=make_source())
+    app = build_eval_view_app(limit=10, workspace=tmp_path, data_source=make_source())
 
     async with app.run_test(size=(140, 44)) as pilot:
         await pilot.pause()
@@ -1015,7 +1015,7 @@ def test_lab_view_initial_snapshot_hydrates_cached_platform_rows(
     assert training.refreshed_at
 
 
-def test_eval_tui_initial_snapshot_hydrates_cached_platform_rows(
+def test_eval_view_initial_snapshot_hydrates_cached_platform_rows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a Prime-owned `prime eval tui` entrypoint that launches directly into the Lab evaluations view
- load hosted/team and local eval rows through the Lab data source, with a smaller default limit and `--limit/-n` control
- open hosted eval rows into a samples viewer backed by the shared rollout viewer, while preserving local eval rollout/log viewing

## Tests
- `uv run ruff check --fix`
- `uv run pytest packages/prime/tests/test_eval_help.py packages/prime/tests/test_lab_view.py -q`
- `uv run pytest packages/prime/tests/test_cli_startup.py -q`
- `uv run prime eval tui --help`

Companion Verifiers PR retires the old `vf-tui` entrypoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the eval viewing entrypoint and wiring from `verifiers` to Prime’s own Textual viewer, which could affect CLI behavior and interactive UI flows (especially hosted eval detail loading). No auth/billing/data-write paths are modified beyond view-related loading.
> 
> **Overview**
> Adds a new `prime eval view` command that launches a Prime-owned interactive evaluations viewer with a configurable `--limit`, and updates setup/help text to point to the new command.
> 
> Reworks the viewer plumbing to run through `prime_lab_app` (new `eval_view.py` + `run_eval_view` bridge), adds `LabDataSource.load_evaluations*()` for an evaluations-only snapshot, and extends the Textual app to open **hosted** evaluation rows into a new `HostedEvalSamplesScreen` while keeping local evals in `LocalEvalRunScreen`.
> 
> Deprecates `prime eval tui` as a hard-error alias that instructs users to switch, and centralizes the shared `DetailLoader` type into `prime_lab_app/detail_loader.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36c8b8f83701d09c7ade1dc185339d89c513172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->