### PR TITLE
release: prime CLI 0.6.7

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Bumps prime CLI to 0.6.7.

- Adds `max_retries` field to `EnvConfig` and `EvalEnvConfig` in RL configs (#661)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only change; no functional or behavioral code paths are modified.
> 
> **Overview**
> Bumps the `prime_cli` package version from `0.6.6` to `0.6.7` in `packages/prime/src/prime_cli/__init__.py` for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63f1606604a525e30ddd0fc9ce857c28c8890ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->