### PR TITLE
ENG-3681: Prefer chat CLI after deployment

### DIFF
--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -38,8 +38,8 @@ def _print_inference_usage(base_model: str, adapter_id: str) -> None:
     console.print("\n[bold]Once deployed, you can run inference with:[/bold]")
     console.print(f'[dim]prime inference chat "{model_id}" "Hello" --max-tokens 100[/dim]')
     console.print(
-        "[dim]The CLI uses credentials saved by 'prime login'. For raw HTTP clients, "
-        f"create an API key at {API_KEYS_DOCS_URL}, export it, then run cURL:[/dim]"
+        "[dim]For scripts or API clients, create a Platform API key at "
+        f"{API_KEYS_DOCS_URL}, export it, then run cURL:[/dim]"
     )
     console.print(
         f"""

--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -31,6 +31,20 @@ LIST_DEPLOYMENTS_JSON_HELP = json_output_help(
 )
 
 
+def _adapter_inference_model_id(base_model: str, adapter_id: str) -> str:
+    return f"{base_model}:{adapter_id}"
+
+
+def _print_inference_usage(base_model: str, adapter_id: str) -> None:
+    model_id = _adapter_inference_model_id(base_model, adapter_id)
+    console.print("\n[bold]Once deployed, you can run inference with:[/bold]")
+    console.print(f'[dim]prime inference chat "{model_id}" "Hello" --max-tokens 100[/dim]')
+    console.print(
+        "[dim]The CLI uses credentials saved by 'prime login'. "
+        "For raw HTTP clients, export PRIME_API_KEY to a Platform API key first.[/dim]"
+    )
+
+
 @app.command(name="list", epilog=LIST_DEPLOYMENTS_JSON_HELP)
 def list_deployments(
     team: Optional[str] = typer.Option(None, "--team", "-t", help="Filter by team ID"),
@@ -222,18 +236,7 @@ def create_deployment(
         console.print("\n[dim]The model is being deployed. This may take a few minutes.[/dim]")
         console.print("[dim]Use 'prime deployments list' to check deployment status.[/dim]")
 
-        console.print("\n[bold]Once deployed, you can run inference with:[/bold]")
-        console.print(
-            f"""
-[dim]curl -X POST https://api.pinference.ai/api/v1/chat/completions \\
-  -H "Content-Type: application/json" \\
-  -H "Authorization: Bearer $PRIME_API_KEY" \\
-  -d '{{
-    "model": "{model.base_model}:{model.id}",
-    "messages": [{{"role": "user", "content": "Hello"}}],
-    "max_tokens": 100
-  }}'[/dim]"""
-        )
+        _print_inference_usage(model.base_model, model.id)
 
     except APIError as e:
         console.print(f"[red]Error:[/red] {e}")

--- a/packages/prime/src/prime_cli/commands/deployments.py
+++ b/packages/prime/src/prime_cli/commands/deployments.py
@@ -30,18 +30,29 @@ LIST_DEPLOYMENTS_JSON_HELP = json_output_help(
     ".per_page = number",
 )
 
-
-def _adapter_inference_model_id(base_model: str, adapter_id: str) -> str:
-    return f"{base_model}:{adapter_id}"
+API_KEYS_DOCS_URL = "https://docs.primeintellect.ai/api-reference/api-keys"
 
 
 def _print_inference_usage(base_model: str, adapter_id: str) -> None:
-    model_id = _adapter_inference_model_id(base_model, adapter_id)
+    model_id = f"{base_model}:{adapter_id}"
     console.print("\n[bold]Once deployed, you can run inference with:[/bold]")
     console.print(f'[dim]prime inference chat "{model_id}" "Hello" --max-tokens 100[/dim]')
     console.print(
-        "[dim]The CLI uses credentials saved by 'prime login'. "
-        "For raw HTTP clients, export PRIME_API_KEY to a Platform API key first.[/dim]"
+        "[dim]The CLI uses credentials saved by 'prime login'. For raw HTTP clients, "
+        f"create an API key at {API_KEYS_DOCS_URL}, export it, then run cURL:[/dim]"
+    )
+    console.print(
+        f"""
+[dim]export PRIME_API_KEY=<insert_key_here>
+
+curl -X POST https://api.pinference.ai/api/v1/chat/completions \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer $PRIME_API_KEY" \\
+  -d '{{
+    "model": "{model_id}",
+    "messages": [{{"role": "user", "content": "Hello"}}],
+    "max_tokens": 100
+  }}'[/dim]"""
     )
 
 

--- a/packages/prime/tests/test_deployments.py
+++ b/packages/prime/tests/test_deployments.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-def test_deployments_create_prints_login_aware_chat_command(monkeypatch) -> None:
+def test_deployments_create_prints_chat_and_api_key_commands(monkeypatch) -> None:
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
     monkeypatch.setenv("COLUMNS", "200")
@@ -51,7 +51,8 @@ def test_deployments_create_prints_login_aware_chat_command(monkeypatch) -> None
     assert "prime inference chat" in output
     assert '"meta-llama/Llama-3.1-8B-Instruct:adapter-123"' in output
     assert '"Hello" --max-tokens 100' in output
-    assert "prime login" in output
+    assert "For scripts or API clients" in output
+    assert "prime login" not in output
     assert "https://docs.primeintellect.ai/api-reference/api-keys" in output
     assert "export PRIME_API_KEY=<insert_key_here>" in output
     assert "PRIME_API_KEY" in output

--- a/packages/prime/tests/test_deployments.py
+++ b/packages/prime/tests/test_deployments.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from typing import Any
+
+from prime_cli.main import app
+from prime_cli.utils import strip_ansi
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_deployments_create_prints_login_aware_chat_command(monkeypatch) -> None:
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setattr("prime_cli.main.check_for_update", lambda: (False, None))
+
+    model = SimpleNamespace(
+        id="adapter-123",
+        display_name="Adapter",
+        base_model="meta-llama/Llama-3.1-8B-Instruct",
+        status="READY",
+        deployment_status="NOT_DEPLOYED",
+    )
+    updated_model = SimpleNamespace(deployment_status="DEPLOYING")
+
+    class DummyDeploymentsClient:
+        def __init__(self, api_client: Any) -> None:
+            self.api_client = api_client
+
+        def get_adapter(self, model_id: str) -> Any:
+            assert model_id == "adapter-123"
+            return model
+
+        def get_deployable_models(self) -> list[str]:
+            return [model.base_model]
+
+        def deploy_adapter(self, model_id: str) -> Any:
+            assert model_id == "adapter-123"
+            return updated_model
+
+    monkeypatch.setattr("prime_cli.commands.deployments.APIClient", lambda: object())
+    monkeypatch.setattr(
+        "prime_cli.commands.deployments.DeploymentsClient",
+        DummyDeploymentsClient,
+    )
+
+    result = runner.invoke(app, ["deployments", "create", "adapter-123", "--yes"])
+    output = strip_ansi(result.output)
+
+    assert result.exit_code == 0, result.output
+    assert "prime inference chat" in output
+    assert '"meta-llama/Llama-3.1-8B-Instruct:adapter-123"' in output
+    assert '"Hello" --max-tokens 100' in output
+    assert "prime login" in output
+    assert "PRIME_API_KEY" in output
+    assert "curl -X POST" not in output

--- a/packages/prime/tests/test_deployments.py
+++ b/packages/prime/tests/test_deployments.py
@@ -52,5 +52,7 @@ def test_deployments_create_prints_login_aware_chat_command(monkeypatch) -> None
     assert '"meta-llama/Llama-3.1-8B-Instruct:adapter-123"' in output
     assert '"Hello" --max-tokens 100' in output
     assert "prime login" in output
+    assert "https://docs.primeintellect.ai/api-reference/api-keys" in output
+    assert "export PRIME_API_KEY=<insert_key_here>" in output
     assert "PRIME_API_KEY" in output
-    assert "curl -X POST" not in output
+    assert "curl -X POST" in output


### PR DESCRIPTION
## Summary
- Replace the post-deploy raw cURL example with `prime inference chat` as the first command to try.
- Keep cURL as the scripts/API-client path with explicit `PRIME_API_KEY` export guidance.
- Remove the `prime login` helper sentence from post-deploy usage output.

## Related
- Platform companion PR: https://github.com/PrimeIntellect-ai/platform/pull/2308
- Linear: https://linear.app/primeintellect/issue/ENG-3681/pi-inference-make-deployment-usage-copy-prefer-prime-cli-auth

## Validation
- `uv run --python 3.12 ruff format packages/prime/src/prime_cli/commands/deployments.py packages/prime/tests/test_deployments.py`
- `uv run --python 3.12 ruff check packages/prime/src/prime_cli/commands/deployments.py packages/prime/tests/test_deployments.py`
- `uv run --python 3.12 pytest packages/prime/tests/test_deployments.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI post-deploy guidance text plus a new test, with no changes to deployment API calls or state handling.
> 
> **Overview**
> After `prime deployments create`, the CLI now prints a `prime inference chat` example (using the deployed `base_model:adapter_id`) and adds explicit guidance + docs link for creating/exporting a Platform `PRIME_API_KEY` when using raw HTTP clients (including an updated cURL snippet).
> 
> The post-deploy messaging is refactored into `_print_inference_usage`, and a new `test_deployments.py` verifies the updated success output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba350ab7c00cc56039e3fb25f65d7fbb12f0d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->