### PR TITLE
ENG-3683: Add max inflight rollout config

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -83,6 +83,7 @@ class RLRun(BaseModel):
     buffer_config: Optional[Dict[str, Any]] = Field(None, alias="bufferConfig")
     learning_rate: Optional[float] = Field(None, alias="learningRate")
     lora_alpha: Optional[int] = Field(None, alias="loraAlpha")
+    max_inflight_rollouts: Optional[int] = Field(None, alias="maxInflightRollouts")
     oversampling_factor: Optional[float] = Field(None, alias="oversamplingFactor")
     max_async_level: Optional[int] = Field(None, alias="maxAsyncLevel")
 
@@ -194,6 +195,7 @@ class RLClient:
         buffer_config: Optional[Dict[str, Any]] = None,
         learning_rate: Optional[float] = None,
         lora_alpha: Optional[int] = None,
+        max_inflight_rollouts: Optional[int] = None,
         oversampling_factor: Optional[float] = None,
         max_async_level: Optional[int] = None,
         checkpoints_config: Optional[Dict[str, Any]] = None,
@@ -274,6 +276,9 @@ class RLClient:
 
             if lora_alpha is not None:
                 payload["lora_alpha"] = lora_alpha
+
+            if max_inflight_rollouts is not None:
+                payload["max_inflight_rollouts"] = max_inflight_rollouts
 
             if oversampling_factor is not None:
                 payload["oversampling_factor"] = oversampling_factor

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -615,20 +615,12 @@ class RLConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_max_inflight_rollouts(self) -> "RLConfig":
+        if self.max_inflight_rollouts is not None and self.oversampling_factor is not None:
+            raise ValueError("Only one of max_inflight_rollouts and oversampling_factor can be set")
         if self.max_inflight_rollouts is None:
             return self
         if self.max_inflight_rollouts < self.rollouts_per_example:
             raise ValueError("max_inflight_rollouts must be at least rollouts_per_example")
-        if self.oversampling_factor is None:
-            return self
-        expected = max(
-            self.rollouts_per_example,
-            int(self.batch_size * self.oversampling_factor),
-        )
-        if self.max_inflight_rollouts != expected:
-            raise ValueError(
-                "max_inflight_rollouts conflicts with oversampling_factor * batch_size"
-            )
         return self
 
 

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -222,6 +222,7 @@ max_steps = 100
 # Training
 batch_size = 128
 rollouts_per_example = 8
+# max_inflight_rollouts = 96 # optional hard cap for in-flight rollout capacity
 # learning_rate = 3e-5 # optional; default is 1e-4
 
 # Optional: warm-start from an existing checkpoint
@@ -591,9 +592,10 @@ class RLConfig(BaseModel):
     max_steps: int = 100
     batch_size: int = 128
     rollouts_per_example: int = 8
+    max_inflight_rollouts: int | None = Field(default=None, ge=1)
     learning_rate: float | None = None
     lora_alpha: int | None = None
-    oversampling_factor: float | None = None
+    oversampling_factor: float | None = Field(default=None, gt=0)
     max_async_level: int | None = None
     checkpoint_id: str | None = None  # Warm-start from an existing checkpoint
     cluster_name: str | None = None  # Admin-only: target a specific cluster by name
@@ -610,6 +612,24 @@ class RLConfig(BaseModel):
     run_config: Dict[str, Any] = Field(default_factory=dict)
     env_file: List[str] = Field(default_factory=list)  # deprecated, use env_files
     env_files: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_max_inflight_rollouts(self) -> "RLConfig":
+        if self.max_inflight_rollouts is None:
+            return self
+        if self.max_inflight_rollouts < self.rollouts_per_example:
+            raise ValueError("max_inflight_rollouts must be at least rollouts_per_example")
+        if self.oversampling_factor is None:
+            return self
+        expected = max(
+            self.rollouts_per_example,
+            int(self.batch_size * self.oversampling_factor),
+        )
+        if self.max_inflight_rollouts != expected:
+            raise ValueError(
+                "max_inflight_rollouts conflicts with oversampling_factor * batch_size"
+            )
+        return self
 
 
 def _format_validation_errors(errors: list[Any]) -> list[str]:
@@ -890,6 +910,8 @@ def create_run(
         console.print(f"  Max Steps:           {cfg.max_steps}")
         console.print(f"  Batch Size:          {cfg.batch_size}")
         console.print(f"  Rollouts per Example: {cfg.rollouts_per_example}")
+        if cfg.max_inflight_rollouts is not None:
+            console.print(f"  Max Inflight Rollouts: {cfg.max_inflight_rollouts}")
         if cfg.learning_rate is not None:
             console.print(f"  Learning Rate:       {cfg.learning_rate}")
         if cfg.lora_alpha is not None:
@@ -1086,6 +1108,7 @@ def create_run(
             buffer_config=cfg.buffer.to_api_dict(),
             learning_rate=cfg.learning_rate,
             lora_alpha=cfg.lora_alpha,
+            max_inflight_rollouts=cfg.max_inflight_rollouts,
             oversampling_factor=cfg.oversampling_factor,
             max_async_level=cfg.max_async_level,
             checkpoints_config=cfg.checkpoints.to_api_dict(),

--- a/packages/prime/src/prime_lab_app/training_config.py
+++ b/packages/prime/src/prime_lab_app/training_config.py
@@ -24,6 +24,7 @@ def training_config_toml(raw: dict[str, Any]) -> str:
         "learning_rate",
         "lora_alpha",
         "oversampling_factor",
+        "max_inflight_rollouts",
         "max_async_level",
         "checkpoint_id",
         "cluster_name",

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -1718,6 +1718,7 @@ def test_lab_view_training_sidebar_config_filters_nulls() -> None:
             "name": "wiki-search",
             "base_model": "Qwen/Qwen3.5-2B",
             "max_steps": 200,
+            "max_inflight_rollouts": 96,
             "learning_rate": None,
             "environments": [
                 {
@@ -1731,6 +1732,7 @@ def test_lab_view_training_sidebar_config_filters_nulls() -> None:
 
     assert 'model = "Qwen/Qwen3.5-2B"' in config
     assert "max_steps = 200" in config
+    assert "max_inflight_rollouts = 96" in config
     assert "\n[[env]]" in config
     assert "learning_rate" not in config
     assert "args" not in config

--- a/packages/prime/tests/test_rl_api.py
+++ b/packages/prime/tests/test_rl_api.py
@@ -8,6 +8,7 @@ from prime_cli.api.rl import RLClient
 class FakeAPIClient:
     def __init__(self) -> None:
         self.requests: list[tuple[str, dict[str, Any] | None]] = []
+        self.posts: list[tuple[str, dict[str, Any] | None]] = []
 
     def get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         self.requests.append((endpoint, params))
@@ -24,6 +25,24 @@ class FakeAPIClient:
             },
             "step": 160,
             "unexpected": "raw response detail",
+        }
+
+    def post(self, endpoint: str, json: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.posts.append((endpoint, json))
+        return {
+            "run": {
+                "id": "run-1",
+                "userId": "user-1",
+                "status": "QUEUED",
+                "rolloutsPerExample": json["rollouts_per_example"] if json else 8,
+                "seqLen": 2048,
+                "maxSteps": json["max_steps"] if json else 100,
+                "batchSize": json["batch_size"] if json else 128,
+                "baseModel": json["model"]["name"] if json else "model",
+                "maxInflightRollouts": json.get("max_inflight_rollouts") if json else None,
+                "createdAt": "2026-05-17T00:00:00Z",
+                "updatedAt": "2026-05-17T00:00:00Z",
+            }
         }
 
 
@@ -47,3 +66,18 @@ def test_get_distributions_preserves_chart_histogram_data() -> None:
         ],
         "step": 160,
     }
+
+
+def test_create_run_sends_max_inflight_rollouts() -> None:
+    api_client = FakeAPIClient()
+    client = RLClient(api_client)  # type: ignore[arg-type]
+
+    run = client.create_run(
+        model_name="Qwen/Qwen3.5-0.8B",
+        environments=[{"id": "reverse-text"}],
+        max_inflight_rollouts=96,
+    )
+
+    assert api_client.posts[0][0] == "/rft/runs"
+    assert api_client.posts[0][1]["max_inflight_rollouts"] == 96
+    assert run.max_inflight_rollouts == 96

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -111,6 +111,69 @@ def test_load_config_accepts_sampling_enable_thinking(tmp_path: Path) -> None:
     assert cfg.sampling.reasoning_effort is None
 
 
+def test_load_config_accepts_max_inflight_rollouts(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\nmax_inflight_rollouts = 96\n')
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.max_inflight_rollouts == 96
+
+
+def test_load_config_accepts_fractional_oversampling_factor(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\noversampling_factor = 0.375\n')
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.oversampling_factor == 0.375
+
+
+def test_load_config_accepts_matching_max_inflight_and_oversampling(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n'
+        "batch_size = 256\n"
+        "rollouts_per_example = 8\n"
+        "oversampling_factor = 0.377\n"
+        "max_inflight_rollouts = 96\n"
+    )
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.max_inflight_rollouts == 96
+
+
+def test_load_config_rejects_conflicting_max_inflight_and_oversampling(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n'
+        "batch_size = 256\n"
+        "rollouts_per_example = 8\n"
+        "oversampling_factor = 0.375\n"
+        "max_inflight_rollouts = 95\n"
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_max_inflight_below_rollouts_per_example(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\nrollouts_per_example = 8\nmax_inflight_rollouts = 4\n')
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
+def test_load_config_rejects_nonpositive_oversampling_factor(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text('model = "dummy"\noversampling_factor = 0\n')
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
+
+
 def test_load_config_rejects_both_reasoning_controls(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -129,7 +129,7 @@ def test_load_config_accepts_fractional_oversampling_factor(tmp_path: Path) -> N
     assert cfg.oversampling_factor == 0.375
 
 
-def test_load_config_accepts_matching_max_inflight_and_oversampling(tmp_path: Path) -> None:
+def test_load_config_rejects_max_inflight_and_oversampling(tmp_path: Path) -> None:
     config_path = tmp_path / "rl.toml"
     config_path.write_text(
         'model = "dummy"\n'
@@ -137,21 +137,6 @@ def test_load_config_accepts_matching_max_inflight_and_oversampling(tmp_path: Pa
         "rollouts_per_example = 8\n"
         "oversampling_factor = 0.377\n"
         "max_inflight_rollouts = 96\n"
-    )
-
-    cfg = load_config(str(config_path))
-
-    assert cfg.max_inflight_rollouts == 96
-
-
-def test_load_config_rejects_conflicting_max_inflight_and_oversampling(tmp_path: Path) -> None:
-    config_path = tmp_path / "rl.toml"
-    config_path.write_text(
-        'model = "dummy"\n'
-        "batch_size = 256\n"
-        "rollouts_per_example = 8\n"
-        "oversampling_factor = 0.375\n"
-        "max_inflight_rollouts = 95\n"
     )
 
     with pytest.raises(typer.Exit):


### PR DESCRIPTION
## Summary

Adds `max_inflight_rollouts` to the Prime CLI training config so TOML configs can pass an explicit in-flight rollout cap through run creation.

## Changes

- Adds `max_inflight_rollouts` to RL config parsing, launch summary, and API payloads.
- Keeps legacy `oversampling_factor` support, including fractional values.
- Rejects configs that set both `max_inflight_rollouts` and `oversampling_factor`; use the explicit cap for new configs.
- Preserves `max_inflight_rollouts` in Prime Lab's generated training-config TOML so reruns keep the explicit cap.
- Adds focused config/API/Lab export tests.

## Related PRs

- Prime-RL support: https://github.com/PrimeIntellect-ai/prime-rl/pull/2533
- Platform support: https://github.com/PrimeIntellect-ai/platform/pull/2310

## Validation

- `uv run --with ruff ruff check packages/prime/src/prime_lab_app/training_config.py packages/prime/tests/test_lab_view.py packages/prime/src/prime_cli/api/rl.py packages/prime/src/prime_cli/commands/rl.py packages/prime/tests/test_rl_api.py packages/prime/tests/test_rl_config.py`
- `uv run --with pytest pytest packages/prime/tests/test_rl_config.py packages/prime/tests/test_rl_api.py packages/prime/tests/test_lab_view.py -q`