### PR TITLE
ENG-3679: Allow inference models without API key

### DIFF
--- a/packages/prime/src/prime_cli/api/inference.py
+++ b/packages/prime/src/prime_cli/api/inference.py
@@ -42,31 +42,37 @@ class InferenceClient:
         team_id: Optional[str] = None,
         inference_url: Optional[str] = None,
         timeout: Optional[float | httpx.Timeout] = None,
+        require_auth: bool = True,
     ) -> None:
         # Load config
         self.config = Config()
 
         self.api_key = api_key or self.config.api_key
-        if not self.api_key:
-            raise InferenceAPIError(
-                "No API key. Run `prime config set-api-key` or set PRIME_API_KEY."
-            )
-
         self.team_id = team_id if team_id is not None else self.config.team_id
         self.inference_url = (inference_url or self.config.inference_url).rstrip("/")
 
+        if require_auth:
+            self._require_api_key()
+
         headers = {
-            "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
-        if self.team_id:
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        if self.api_key and self.team_id:
             headers["X-Prime-Team-ID"] = self.team_id
 
         self._client = httpx.Client(
             headers=headers,
             timeout=timeout or httpx.Timeout(connect=10.0, read=600.0, write=60.0, pool=60.0),
         )
+
+    def _require_api_key(self) -> None:
+        if not self.api_key:
+            raise InferenceAPIError(
+                "No API key. Run `prime config set-api-key` or set PRIME_API_KEY."
+            )
 
     def list_models(self) -> Dict[str, Any]:
         url = f"{self.inference_url}/models"

--- a/packages/prime/src/prime_cli/commands/inference.py
+++ b/packages/prime/src/prime_cli/commands/inference.py
@@ -47,7 +47,7 @@ def list_models(
     """List available models from Prime Inference (/v1/models)."""
     validate_output_format(output, console)
     try:
-        client = InferenceClient()
+        client = InferenceClient(require_auth=False)
         data = client.list_models()
 
         # Expect OpenAI-style: {"object":"list","data":[{"id":..., ...}, ...]}

--- a/packages/prime/tests/test_inference_models.py
+++ b/packages/prime/tests/test_inference_models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import httpx
+import pytest
+from prime_cli.api.inference import InferenceAPIError, InferenceClient
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+TEST_ENV: Dict[str, str] = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "NO_COLOR": "1",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+}
+
+
+class NoKeyConfig:
+    api_key = ""
+    inference_url = "https://api.pinference.ai/api/v1"
+    team_id = "team-1"
+
+
+def test_inference_client_requires_api_key_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("prime_cli.api.inference.Config", lambda: NoKeyConfig())
+
+    with pytest.raises(InferenceAPIError, match="No API key"):
+        InferenceClient()
+
+
+def test_inference_client_can_list_models_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("prime_cli.api.inference.Config", lambda: NoKeyConfig())
+    created: Dict[str, Any] = {}
+
+    class DummyHTTPClient:
+        def get(self, url: str) -> httpx.Response:
+            created["url"] = url
+            request = httpx.Request("GET", url)
+            return httpx.Response(200, request=request, json={"object": "list", "data": []})
+
+    def fake_http_client(**kwargs: Any) -> DummyHTTPClient:
+        created["headers"] = kwargs["headers"]
+        return DummyHTTPClient()
+
+    monkeypatch.setattr("prime_cli.api.inference.httpx.Client", fake_http_client)
+
+    client = InferenceClient(require_auth=False)
+
+    assert client.list_models() == {"object": "list", "data": []}
+    assert created["url"] == "https://api.pinference.ai/api/v1/models"
+    assert "Authorization" not in created["headers"]
+    assert "X-Prime-Team-ID" not in created["headers"]
+
+
+def test_models_command_uses_optional_auth_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_kwargs: Dict[str, Any] = {}
+
+    class DummyModelsClient:
+        def __init__(self, **kwargs: Any) -> None:
+            seen_kwargs.update(kwargs)
+
+        def list_models(self) -> Dict[str, Any]:
+            return {"object": "list", "data": [{"id": "qwen/qwen3-8b"}]}
+
+    monkeypatch.setattr("prime_cli.commands.inference.InferenceClient", DummyModelsClient)
+
+    result = CliRunner().invoke(
+        app,
+        ["inference", "models", "--output", "json"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen_kwargs["require_auth"] is False
+    assert '"id": "qwen/qwen3-8b"' in result.output


### PR DESCRIPTION
## Summary
- Allow the Prime Inference client to be constructed without an API key for optional-auth calls.
- Use optional auth for `prime inference models`, matching the public `/v1/models` backend behavior.
- Add focused tests covering default auth enforcement, unauthenticated model listing, and CLI wiring.

## Root cause
The platform endpoint now exposes the public base model catalog without auth, but the CLI still raised locally while constructing `InferenceClient()` before it could call `GET /models`.

## Validation
- `ruff check packages/prime/src/prime_cli/api/inference.py packages/prime/src/prime_cli/commands/inference.py packages/prime/tests/test_inference_models.py`
- `pytest packages/prime/tests/test_inference_models.py packages/prime/tests/test_inference_chat.py packages/prime/tests/test_eval_billing.py -q` (`29 passed, 1 warning`)
- `pytest packages/prime/tests -q` (`725 passed, 1 skipped, 3 warnings`)
- Live smoke with empty `HOME` and no `PRIME_API_KEY`: `prime inference models --output json` returned 121 models.
- GitHub CI is green on head `50e1fc2dcf8987137b4ac22303d4c1c926721136`.