### PR TITLE
release: prime CLI 0.6.8

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- Bump `prime` CLI package version from `0.6.7` to `0.6.8`.

## Release contents
- Includes #669: allow `prime inference models` to list the public model catalog without requiring a local API key.

## Validation
- `python - <<'PY' ...` import check confirmed `prime_cli.__version__ == "0.6.8"`.
- `ruff check packages/prime/src/prime_cli/__init__.py`.

After this merges, `.github/workflows/release-prime.yml` should create tag `v0.6.8` and publish `prime` to PyPI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version-only change; no functional code paths are modified.
> 
> **Overview**
> **Release bump only:** updates `prime_cli.__version__` from `0.6.7` to `0.6.8` in `packages/prime/src/prime_cli/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf19c47819561cd5e5f7a1c978663aab80a0a806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->