### PR TITLE
Remove deprecated Hosted Training val config surface

### DIFF
--- a/packages/prime/src/prime_cli/api/rl.py
+++ b/packages/prime/src/prime_cli/api/rl.py
@@ -192,7 +192,6 @@ class RLClient:
         secrets: Optional[Dict[str, str]] = None,
         team_id: Optional[str] = None,
         eval_config: Optional[Dict[str, Any]] = None,
-        val_config: Optional[Dict[str, Any]] = None,
         buffer_config: Optional[Dict[str, Any]] = None,
         learning_rate: Optional[float] = None,
         lora_alpha: Optional[int] = None,
@@ -265,9 +264,6 @@ class RLClient:
 
             if eval_config:
                 payload["eval"] = eval_config
-
-            if val_config:
-                payload["val"] = val_config
 
             if buffer_config:
                 payload["buffer"] = buffer_config

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -258,12 +258,6 @@ id = "{env_value}"
 # num_examples = 30
 # rollouts_per_example = 4
 
-# Optional: validation during training
-# [val]
-# num_examples = 64
-# rollouts_per_example = 1
-# interval = 5
-
 # Optional: buffer configuration for difficulty filtering
 # [buffer]
 # easy_threshold = 1.0
@@ -407,24 +401,6 @@ class EvalConfig(BaseModel):
         if self.eval_base_model is not None:
             result["eval_base_model"] = self.eval_base_model
         return result
-
-
-class ValConfig(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    num_examples: int | None = None
-    rollouts_per_example: int | None = None
-    interval: int | None = None
-
-    def to_api_dict(self) -> Dict[str, Any] | None:
-        result: Dict[str, Any] = {}
-        if self.num_examples is not None:
-            result["num_examples"] = self.num_examples
-        if self.rollouts_per_example is not None:
-            result["rollouts_per_example"] = self.rollouts_per_example
-        if self.interval is not None:
-            result["interval"] = self.interval
-        return result if result else None
 
 
 class BufferConfig(BaseModel):
@@ -602,7 +578,6 @@ class RLConfig(BaseModel):
     env: List[EnvConfig] = Field(default_factory=list)
     sampling: SamplingConfig = Field(default_factory=SamplingConfig)
     eval: EvalConfig = Field(default_factory=EvalConfig)
-    val: ValConfig = Field(default_factory=ValConfig)
     buffer: BufferConfig = Field(default_factory=BufferConfig)
     wandb: WandbConfig = Field(default_factory=WandbConfig)
     checkpoints: CheckpointsConfig = Field(default_factory=CheckpointsConfig)
@@ -964,13 +939,6 @@ def create_run(
             if cfg.eval.interval:
                 console.print(f"  Interval:     {cfg.eval.interval}")
 
-        # Validation
-        if cfg.val.num_examples is not None:
-            console.print("\n[cyan]Validation[/cyan]")
-            console.print(f"  Num Examples: {cfg.val.num_examples}")
-            if cfg.val.interval:
-                console.print(f"  Interval:     {cfg.val.interval}")
-
         # Infrastructure
         if cfg.infrastructure.compute_size:
             console.print("\n[cyan]Infrastructure[/cyan]")
@@ -1096,7 +1064,6 @@ def create_run(
             secrets=secrets if secrets else None,
             team_id=app_config.team_id,
             eval_config=cfg.eval.to_api_dict(),
-            val_config=cfg.val.to_api_dict(),
             buffer_config=cfg.buffer.to_api_dict(),
             learning_rate=cfg.learning_rate,
             lora_alpha=cfg.lora_alpha,

--- a/packages/prime/src/prime_lab_app/training_config.py
+++ b/packages/prime/src/prime_lab_app/training_config.py
@@ -46,8 +46,6 @@ def training_config_toml(raw: dict[str, Any]) -> str:
 
     if isinstance(raw.get("eval_config"), dict):
         config["eval"] = _rl_eval_config(raw["eval_config"])
-    if isinstance(raw.get("val_config"), dict):
-        config["val"] = raw["val_config"]
     if isinstance(raw.get("buffer_config"), dict):
         config["buffer"] = raw["buffer_config"]
 
@@ -76,12 +74,7 @@ def normalize_rl_config(config: dict[str, Any]) -> dict[str, Any]:
             updated["eval"] = _rl_eval_config(eval_config)
     else:
         updated.pop("eval_config", None)
-    if "val_config" in updated and "val" not in updated:
-        val_config = updated.pop("val_config")
-        if isinstance(val_config, dict):
-            updated["val"] = val_config
-    else:
-        updated.pop("val_config", None)
+    updated.pop("val_config", None)
     if "buffer_config" in updated and "buffer" not in updated:
         buffer_config = updated.pop("buffer_config")
         if isinstance(buffer_config, dict):

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -1760,6 +1760,37 @@ def test_lab_view_training_config_uses_sampling_for_max_tokens() -> None:
     HostedRLConfig.model_validate(parsed)
 
 
+def test_lab_view_training_config_drops_deprecated_val_config() -> None:
+    config = _training_config_toml(
+        {
+            "base_model": "Qwen/Qwen3.5-2B",
+            "environments": ["primeintellect/alphabet-sort"],
+            "val_config": {"interval": 5},
+        }
+    )
+
+    parsed = toml.loads(config)
+    assert "val" not in parsed
+    HostedRLConfig.model_validate(parsed)
+
+
+def test_config_builder_preserves_deprecated_val_for_schema_error() -> None:
+    config = {
+        "model": "Qwen/Qwen3.5-2B",
+        "env": [{"id": "primeintellect/alphabet-sort"}],
+        "val": {"interval": 5},
+    }
+    values = {
+        "config-model": "Qwen/Qwen3.5-2B",
+        "config-envs": "primeintellect/alphabet-sort",
+    }
+
+    build = build_config_from_fields(config, "rl", lambda field_id: values.get(field_id, ""))
+
+    assert "[val]" in build.toml_text
+    assert build.errors == ("val: Extra inputs are not permitted",)
+
+
 def test_lab_config_factory_renders_shared_eval_and_rl_templates() -> None:
     eval_toml = format_lab_config(
         evaluation_config(env_id="primeintellect/wordle", num_examples=-1, max_tokens=None)

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -55,6 +55,8 @@ def test_generate_rl_config_template_keeps_default_surface_minimal() -> None:
 
     assert 'model = "Qwen/Qwen3.5-0.8B"' in template
     assert "# learning_rate = 3e-5 # optional; default is 1e-4" in template
+    assert "# [val]" not in template
+    assert "validation during training" not in template.lower()
 
     hidden_fields = [
         "oversampling_factor",
@@ -89,6 +91,18 @@ def test_flatten_config_schema_preserves_optional_array_item_types() -> None:
     }
 
     assert rows["buffer.env_ratios"] == "list[number]"
+
+
+def test_load_config_rejects_deprecated_val_section(tmp_path: Path) -> None:
+    config_path = tmp_path / "rl.toml"
+    config_path.write_text(
+        'model = "dummy"\n'
+        "[val]\n"
+        "interval = 5\n"
+    )
+
+    with pytest.raises(typer.Exit):
+        load_config(str(config_path))
 
 
 def test_load_config_accepts_sampling_reasoning_effort(tmp_path: Path) -> None:

--- a/packages/prime/tests/test_train_cli.py
+++ b/packages/prime/tests/test_train_cli.py
@@ -65,6 +65,15 @@ def test_train_init_defaults_to_rl_toml() -> None:
         assert Path("rl.toml").exists()
 
 
+def test_train_configs_omits_deprecated_val_section() -> None:
+    result = runner.invoke(app, ["train", "configs", "--output", "json"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    sections = {item["section"] for item in data["configs"]}
+    assert "val" not in sections
+
+
 def test_train_request_submits_model_request(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- remove the deprecated Hosted Training `[val]` block from `prime train init`
- stop exposing `val` in `prime train configs` and let schema validation reject old `[val]` configs
- stop CLI-created runs from sending a `val` payload and avoid regenerating `[val]` from legacy run metadata

## Context
I had Codex do this sweep after Prime support told me `[val]` is deprecated and `[eval]` should be used instead.

`prime-rl` removed `orchestrator.val` in PrimeIntellect-ai/prime-rl#2193 and recommends registering validation-style checks as eval environments. This aligns the Prime CLI config surface with `[eval]` / `[[eval.env]]`.

## Tests
- `uv run --package prime pytest packages/prime/tests/test_rl_config.py packages/prime/tests/test_train_cli.py packages/prime/tests/test_rl_api.py -q`
- `uv run --package prime pytest packages/prime/tests/test_lab_view.py -q -k 'training_config or config_builder_preserves_deprecated_val or train_configs or shared_eval'`
- `uv run --package prime ruff check packages/prime/src/prime_cli/commands/rl.py packages/prime/src/prime_cli/api/rl.py packages/prime/src/prime_lab_app/training_config.py packages/prime/tests/test_rl_config.py packages/prime/tests/test_train_cli.py packages/prime/tests/test_lab_view.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-surface removal with tests; run reads may still expose legacy `valConfig` on `RLRun`, but new runs no longer send `val`.
> 
> **Overview**
> Removes the deprecated Hosted Training **`[val]`** block from the user-facing config path so validation-style checks align with **`[eval]`** / **`[[eval.env]]`**.
> 
> **CLI & API:** Drops `ValConfig`, the `val` field on `RLConfig`, template comments, run-summary output, and `val_config` on `RLClient.create_run` (no `val` key in create payloads). **`RLConfig`** with `extra="forbid"` now rejects TOML that still contains `[val]`.
> 
> **Lab:** `training_config` no longer maps legacy `val_config` into exported TOML; rerun copies omit `[val]` even when old run metadata had it.
> 
> **Tests** lock in: init template and `prime train configs` omit `val`, `load_config` fails on `[val]`, lab export strips `val_config`, and the config builder still surfaces `[val]` only to produce a clear schema error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d273ea7262f9f74a42cc0d0bbb6f4b6740ff12d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->