### PR TITLE
Pass async sandbox limits to backend client

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -85,11 +85,13 @@ class APIClient:
         api_key: Optional[str] = None,
         require_auth: bool = True,
         user_agent: Optional[str] = None,
+        timeout: Optional[httpx.Timeout] = None,
     ):
         self.config = Config()
         self.api_key = api_key or self.config.api_key
         self.require_auth = require_auth
         self.base_url = self.config.base_url
+        timeout = timeout or DEFAULT_TIMEOUT
 
         headers = {"Content-Type": "application/json"}
         if self.api_key:
@@ -99,7 +101,7 @@ class APIClient:
         self.client = httpx.Client(
             headers=headers,
             follow_redirects=True,
-            timeout=DEFAULT_TIMEOUT,
+            timeout=timeout,
         )
 
     def _check_auth_required(self) -> None:
@@ -247,11 +249,14 @@ class AsyncAPIClient:
         require_auth: bool = True,
         user_agent: Optional[str] = None,
         limits: Optional[httpx.Limits] = None,
+        timeout: Optional[httpx.Timeout] = None,
     ):
         self.config = Config()
         self.api_key = api_key or self.config.api_key
         self.require_auth = require_auth
         self.base_url = self.config.base_url
+        limits = limits or DEFAULT_CONNECTION_LIMITS
+        timeout = timeout or DEFAULT_TIMEOUT
 
         headers = {"Content-Type": "application/json"}
         if self.api_key:
@@ -261,8 +266,8 @@ class AsyncAPIClient:
         client_kwargs: Dict[str, Any] = {
             "headers": headers,
             "follow_redirects": True,
-            "limits": limits if limits is not None else DEFAULT_CONNECTION_LIMITS,
-            "timeout": DEFAULT_TIMEOUT,
+            "limits": limits,
+            "timeout": timeout,
         }
 
         self.client = httpx.AsyncClient(**client_kwargs)

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -240,6 +240,7 @@ class AsyncAPIClient:
         api_key: Optional[str] = None,
         require_auth: bool = True,
         user_agent: Optional[str] = None,
+        limits: Optional[httpx.Limits] = None,
     ):
         self.config = Config()
         self.api_key = api_key or self.config.api_key
@@ -251,11 +252,15 @@ class AsyncAPIClient:
             headers["Authorization"] = f"Bearer {self.api_key}"
         headers["User-Agent"] = user_agent if user_agent else _default_user_agent()
 
-        self.client = httpx.AsyncClient(
-            headers=headers,
-            follow_redirects=True,
-            timeout=httpx.Timeout(30.0, connect=10.0),
-        )
+        client_kwargs: Dict[str, Any] = {
+            "headers": headers,
+            "follow_redirects": True,
+            "timeout": httpx.Timeout(30.0, connect=10.0),
+        }
+        if limits is not None:
+            client_kwargs["limits"] = limits
+
+        self.client = httpx.AsyncClient(**client_kwargs)
 
     def _check_auth_required(self) -> None:
         if self.require_auth and not self.api_key:

--- a/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/core/client.py
@@ -31,6 +31,12 @@ IDEMPOTENT_RETRYABLE_EXCEPTIONS = POST_RETRYABLE_EXCEPTIONS + (
 IDEMPOTENT_RETRYABLE_STATUSES = frozenset({502, 503, 504})
 IDEMPOTENT_HTTP_METHODS = frozenset({"GET", "HEAD", "PUT", "DELETE", "OPTIONS"})
 
+DEFAULT_CONNECTION_LIMITS = httpx.Limits(
+    max_connections=1000,
+    max_keepalive_connections=100,
+)
+DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
 
 def _is_idempotent_request_retryable_error(exc: BaseException) -> bool:
     if isinstance(exc, IDEMPOTENT_RETRYABLE_EXCEPTIONS):
@@ -93,7 +99,7 @@ class APIClient:
         self.client = httpx.Client(
             headers=headers,
             follow_redirects=True,
-            timeout=httpx.Timeout(30.0, connect=10.0),
+            timeout=DEFAULT_TIMEOUT,
         )
 
     def _check_auth_required(self) -> None:
@@ -255,10 +261,9 @@ class AsyncAPIClient:
         client_kwargs: Dict[str, Any] = {
             "headers": headers,
             "follow_redirects": True,
-            "timeout": httpx.Timeout(30.0, connect=10.0),
+            "limits": limits if limits is not None else DEFAULT_CONNECTION_LIMITS,
+            "timeout": DEFAULT_TIMEOUT,
         }
-        if limits is not None:
-            client_kwargs["limits"] = limits
 
         self.client = httpx.AsyncClient(**client_kwargs)
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1401,14 +1401,21 @@ class AsyncSandboxClient:
             max_connections: Maximum number of concurrent connections (default: 1000)
             max_keepalive_connections: Maximum keep-alive connections (default: 200)
         """
-        self.client = AsyncAPIClient(api_key=api_key, user_agent=_build_user_agent())
+        # Connection pool configuration
+        self._max_connections = max_connections
+        self._max_keepalive_connections = max_keepalive_connections
+        self.client = AsyncAPIClient(
+            api_key=api_key,
+            user_agent=_build_user_agent(),
+            limits=httpx.Limits(
+                max_connections=self._max_connections,
+                max_keepalive_connections=self._max_keepalive_connections,
+            ),
+        )
         self._auth_cache = AsyncSandboxAuthCache(
             self.client.config.config_dir / "sandbox_auth_cache.json",
             self.client,
         )
-        # Connection pool configuration
-        self._max_connections = max_connections
-        self._max_keepalive_connections = max_keepalive_connections
         # Shared httpx client for gateway operations (upload/download/execute)
         # Initialized lazily to allow connection pooling and reuse
         self._gateway_client: Optional[httpx.AsyncClient] = None

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -174,6 +174,23 @@ class AsyncAlwaysFailTransport(httpx.AsyncBaseTransport):
         raise httpx.RemoteProtocolError("Server disconnected")
 
 
+class TestAsyncSandboxClientConnectionLimits:
+    @pytest.mark.asyncio
+    async def test_threads_connection_limits_to_backend_api_client(self):
+        client = AsyncSandboxClient(
+            api_key="test-key",
+            max_connections=321,
+            max_keepalive_connections=123,
+        )
+        try:
+            backend_pool = client.client.client._transport._pool
+
+            assert backend_pool._max_connections == 321
+            assert backend_pool._max_keepalive_connections == 123
+        finally:
+            await client.aclose()
+
+
 class TestSyncAPIClientRetry:
     """Tests for sync APIClient retry behavior."""
 

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -200,6 +200,31 @@ class TestAsyncAPIClientDefaults:
         finally:
             await client.aclose()
 
+    @pytest.mark.asyncio
+    async def test_allows_custom_connection_limits_and_timeout(self):
+        custom_limits = httpx.Limits(max_connections=321, max_keepalive_connections=123)
+        custom_timeout = httpx.Timeout(12.0, connect=4.0)
+        client = AsyncAPIClient(
+            api_key="test-key",
+            limits=custom_limits,
+            timeout=custom_timeout,
+        )
+        try:
+            backend_pool = client.client._transport._pool
+            timeout = client.client.timeout
+
+            assert backend_pool._max_connections == custom_limits.max_connections
+            assert (
+                backend_pool._max_keepalive_connections
+                == custom_limits.max_keepalive_connections
+            )
+            assert timeout.connect == custom_timeout.connect
+            assert timeout.read == custom_timeout.read
+            assert timeout.write == custom_timeout.write
+            assert timeout.pool == custom_timeout.pool
+        finally:
+            await client.aclose()
+
 
 class TestAsyncSandboxClientConnectionLimits:
     @pytest.mark.asyncio

--- a/packages/prime-sandboxes/tests/test_client_retry.py
+++ b/packages/prime-sandboxes/tests/test_client_retry.py
@@ -6,7 +6,13 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
-from prime_sandboxes.core.client import APIClient, APIError, AsyncAPIClient
+from prime_sandboxes.core.client import (
+    DEFAULT_CONNECTION_LIMITS,
+    DEFAULT_TIMEOUT,
+    APIClient,
+    APIError,
+    AsyncAPIClient,
+)
 from prime_sandboxes.models import CreateSandboxRequest
 from prime_sandboxes.sandbox import (
     AsyncSandboxAuthCache,
@@ -172,6 +178,27 @@ class AsyncAlwaysFailTransport(httpx.AsyncBaseTransport):
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.call_count += 1
         raise httpx.RemoteProtocolError("Server disconnected")
+
+
+class TestAsyncAPIClientDefaults:
+    @pytest.mark.asyncio
+    async def test_uses_default_connection_limits_and_timeout(self):
+        client = AsyncAPIClient(api_key="test-key")
+        try:
+            backend_pool = client.client._transport._pool
+            timeout = client.client.timeout
+
+            assert backend_pool._max_connections == DEFAULT_CONNECTION_LIMITS.max_connections
+            assert (
+                backend_pool._max_keepalive_connections
+                == DEFAULT_CONNECTION_LIMITS.max_keepalive_connections
+            )
+            assert timeout.connect == DEFAULT_TIMEOUT.connect
+            assert timeout.read == DEFAULT_TIMEOUT.read
+            assert timeout.write == DEFAULT_TIMEOUT.write
+            assert timeout.pool == DEFAULT_TIMEOUT.pool
+        finally:
+            await client.aclose()
 
 
 class TestAsyncSandboxClientConnectionLimits:


### PR DESCRIPTION
- Sandbox client has been using default httpx limits of 100 max connections, update with new defaults for 1000 max connections and enable user to pass through their own limit configuration 
- Also create a DEFAULT_TIMEOUT constant at top of file for consistency 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK-only HTTP client configuration; behavior change is higher default async pool capacity and explicit limit plumbing, with no auth or API contract changes.
> 
> **Overview**
> **Async sandbox backend calls** now honor the same connection pool sizing as the rest of the async client. `AsyncSandboxClient` passes `max_connections` / `max_keepalive_connections` into the underlying `AsyncAPIClient` via `httpx.Limits`, instead of leaving the Prime API client on httpx’s smaller default pool (~100 connections).
> 
> **Shared HTTP defaults** in `client.py`: `DEFAULT_CONNECTION_LIMITS` (1000 / 100 keep-alive) and `DEFAULT_TIMEOUT` (30s read, 10s connect). `AsyncAPIClient` accepts optional `limits` and `timeout`; sync `APIClient` accepts optional `timeout` and uses the shared default. Tests assert defaults, overrides, and that sandbox constructor limits reach the backend pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eccecb7351c7b68ff77d6dd2d3c5c486e586875f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->