### PR TITLE
prime-traces read surface (episode reads + pinned response models)

### DIFF
--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -1,15 +1,33 @@
-# prime-traces
+# Prime Traces SDK
 
-Prime Intellect Traces SDK — upload, query and export training, evaluation and
-inference traces through the Prime Traces service.
+Upload, query and export training, evaluation and inference traces through the
+Prime Traces service.
 
-## Install
+## Features
+
+- **Content-addressed uploads** - Batches are identified by the SHA-256 of
+  their exact bytes, so interrupted uploads are safe to rerun and never store
+  twice
+- **Deterministic batching** - JSONL files are split at byte thresholds without
+  rewriting a single line
+- **Typed reads** - Cursor-paginated summaries over extracted columns, raw
+  document retrieval, and streaming exports
+- **Type-safe** - Full type hints and Pydantic models
+- **No CLI dependencies** - Pure SDK, usable in producers and services
+
+## Installation
+
+```bash
+uv add prime-traces
+```
+
+or with pip:
 
 ```bash
 pip install prime-traces
 ```
 
-## Upload a completed JSONL file
+## Quick Start
 
 ```python
 from prime_traces import TracesClient, LineFormat
@@ -89,3 +107,14 @@ export parameters above are a proposal to align on, not a settled contract.
 - An async client — the other prime SDKs ship sync/async pairs, and the main
   producers (verifiers, prime-rl) are async; add once the sync surface
   settles rather than freezing a duplicated API now.
+
+## Documentation
+
+For detailed documentation, visit the
+[Prime Traces SDK documentation](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-traces).
+
+## Related Packages
+
+- [prime](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime) - Prime CLI (`prime traces ...` commands)
+- [prime-sandboxes](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-sandboxes) - Sandboxes SDK
+- [prime-evals](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-evals) - Evals SDK

--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -1,15 +1,23 @@
-# prime-traces
+# Prime Traces SDK
 
-Prime Intellect Traces SDK — upload and query training, evaluation and
-inference traces through the Prime Traces service.
+Upload and query training, evaluation and inference traces through the Prime
+Traces service.
 
-## Install
+## Installation
+
+```bash
+uv add prime-traces
+```
+
+or with pip:
 
 ```bash
 pip install prime-traces
 ```
 
-## Upload from memory
+## Quick Start
+
+### Upload from memory
 
 `upload_records` accepts JSON-compatible mappings as well as objects exposing
 `to_record()`. Verifiers `Trace` / `Episode` and prime-rl `Rollout` objects
@@ -35,11 +43,7 @@ receipts = client.upload_records(
 )
 ```
 
-Records are serialized lazily and fed into bounded batches, so this neither
-buffers the complete iterable nor round-trips through the filesystem. Callers
-that already have encoded JSONL bytes can use `upload_lines` directly.
-
-## Upload a completed JSONL file
+### Upload a completed JSONL file
 
 ```python
 from prime_traces import TracesClient, LineFormat
@@ -56,13 +60,6 @@ receipts = client.upload_file(
     context={"source": "hosted_eval", "suite_commit": "a1f39c2"},
 )
 ```
-
-Uploads are content-addressed: each request is identified by the SHA-256 of its
-exact uncompressed JSONL bytes and sent with an `Idempotency-Key`. Rerunning an
-interrupted upload re-reads the file, reproduces the same bytes and keys, and
-the service replays committed receipts without storing anything twice. A 400
-rejection stops the upload with a bounded error code (`ErrorCode`); 429/503 and
-gateway 502/504 are retried with the same bytes, honoring `Retry-After`.
 
 ## Query
 
@@ -82,22 +79,24 @@ client.delete("8d3f1a2b...")        # NotFoundError if the owner has no such tra
 client.delete_run("run_9f3k2m")     # one mutation, synchronous, no job handle
 ```
 
-Deletion is not a no-op on absent rows: the service checks existence first and
-answers 404, so repeating a delete that already succeeded raises
-`NotFoundError`. (The design docs specify it as idempotent; this tracks the
-service as built.) Failures known to occur before delivery, 429 responses, and
-service-coded 503 refusals are retried. Ambiguous response-path failures and
-gateway 502/503/504 responses are surfaced as `AmbiguousDeleteError` without
-replaying the deletion, because a retry could delete a trace written after the
-first request.
+Episodes are read-only resources:
 
-Point reads and deletes currently reject trace IDs containing `/`. ASGI decodes
-an encoded slash before matching the service's `/{trace_id}` route, so those IDs
-cannot be addressed until the service accepts a path-valued route parameter.
+```python
+page = client.list_episodes(
+    run_id="run_9f3k2m",
+    environment_id="terminal-bench-2",
+)
+for episode in page.items:
+    print(episode.episode_id, episode.outcome)
 
-Response shapes mirror the service's pinned models: pages are
-`{items, next_cursor}` and a summary nests `model` / `score` / `execution`,
-with unrecorded fields as `null`.
+if page.items:
+    episode_id = page.items[0].episode_id
+    detail = client.get_episode(episode_id)  # + member aggregate under .traces
+    print(detail.error.type, detail.traces.trace_count)
+
+    # Member trace summaries use the trace filters (except sort) and pagination.
+    client.list_episode_traces(episode_id, has_error=True)
+```
 
 ## Configuration
 
@@ -108,21 +107,28 @@ with unrecorded fields as `null`.
 | `PRIME_TRACES_URL`     | Base URL of the Prime Traces service; defaults to the platform API base URL. For the service's local compose stack: `http://localhost:8083` |
 | `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)                                                                                |
 
-## Not implemented yet
-
-Deferred to follow-up PRs once the service pins the corresponding responses:
+## Not implemented yet (open v0 contract decisions)
 
 - Exports, in any form. The service publishes `GET /traces/export` and the two
   job routes, but all three handlers raise `NotImplementedError` — answered as
   500, not the 501 they document — and the streaming route declares no query
-  parameters, so there is no filter vocabulary to bind to.
-- Episode reads (`GET /episodes[...]`) — read-only resources; episodes are
-  written only as a side effect of episode-grouped uploads.
+  parameters, so there is no filter vocabulary to bind to. Wrapping it now
+  would ship a method that cannot succeed.
 - `/search` and free-text queries — deferred with the `trace_components`
   projection.
-- The `environment_id` list filter — pending its extracted column.
 - Typed dot-path predicates (`traces.query`) — needs the server-side field
   registry.
 - An async client — the other prime SDKs ship sync/async pairs, and the main
   producers (verifiers, prime-rl) are async; add once the sync surface
   settles rather than freezing a duplicated API now.
+
+## Documentation
+
+For detailed documentation, visit the
+[Prime Traces SDK documentation](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-traces).
+
+## Related Packages
+
+- [prime](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime) - Prime CLI (`prime traces ...` commands)
+- [prime-sandboxes](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-sandboxes) - Sandboxes SDK
+- [prime-evals](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-evals) - Evals SDK

--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -1,6 +1,6 @@
 # prime-traces
 
-Prime Intellect Traces SDK — upload and query training, evaluation and
+Prime Intellect Traces SDK — upload, query and export training, evaluation and
 inference traces through the Prime Traces service.
 
 ## Install
@@ -50,10 +50,22 @@ client.download_raw("8d3f1a2b...", "t.json")  # streamed, for large traces
 
 client.delete("8d3f1a2b...")
 client.delete_run("run_9f3k2m")
+
+# Stream a filtered export to disk (same filter vocabulary as list):
+client.export("high_reward.jsonl", run_id="run_9f3k2m", reward_min=0.9)
+```
+
+Episodes are read-only resources:
+
+```python
+episodes = client.list_episodes(run_id="run_9f3k2m")
+client.get_episode(episode_id)
+client.list_episode_traces(episode_id)
 ```
 
 The read surface is provisional: the service defines these routes but has not
-pinned response models yet, so the page shape above is a proposal to align on.
+pinned response models yet, so the page envelopes, summary field nesting, and
+export parameters above are a proposal to align on, not a settled contract.
 
 ## Configuration
 
@@ -64,15 +76,11 @@ pinned response models yet, so the page shape above is a proposal to align on.
 | `PRIME_TRACES_URL`     | Base URL of the Prime Traces service; defaults to the platform API base URL. For the service's local compose stack: `http://localhost:8083` |
 | `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)                                                                                |
 
-## Not implemented yet
+## Not implemented yet (open v0 contract decisions)
 
-Deferred to follow-up PRs once the service pins the corresponding responses:
-
-- Exports — the streaming `GET /traces/export` (params and format not yet
-  defined by the service) and the exports _job_ API (published as 501 by the
-  service in v0 until export results have somewhere to land).
-- Episode reads (`GET /episodes[...]`) — read-only resources; episodes are
-  written only as a side effect of episode-grouped uploads.
+- The exports _job_ API (`POST /traces/exports`, `GET /traces/exports/{job_id}`)
+  — published as 501 by the service in v0 until export results have somewhere
+  to land. The streaming `GET /traces/export` is what `export()` wraps.
 - `/search` and free-text queries — deferred with the `trace_components`
   projection.
 - The `environment_id` list filter — pending its extracted column.

--- a/packages/prime-traces/src/prime_traces/__init__.py
+++ b/packages/prime-traces/src/prime_traces/__init__.py
@@ -31,6 +31,11 @@ from .exceptions import (
     ValidationRejectedError,
 )
 from .models import (
+    EpisodeDetail,
+    EpisodeError,
+    EpisodeListPage,
+    EpisodeSummary,
+    EpisodeTraceAggregate,
     ErrorCode,
     Execution,
     LineFormat,
@@ -60,7 +65,11 @@ __all__ = [
     "MAX_BATCH_LINES",
     "MAX_LINE_BYTES",
     # Models
-    "UploadReceipt",
+    "EpisodeDetail",
+    "EpisodeError",
+    "EpisodeListPage",
+    "EpisodeSummary",
+    "EpisodeTraceAggregate",
     "ErrorCode",
     "Execution",
     "LineFormat",
@@ -68,6 +77,7 @@ __all__ = [
     "Score",
     "TraceListPage",
     "TraceSummary",
+    "UploadReceipt",
     # Exceptions
     "PrimeTracesError",
     "APIError",

--- a/packages/prime-traces/src/prime_traces/__init__.py
+++ b/packages/prime-traces/src/prime_traces/__init__.py
@@ -28,6 +28,8 @@ from .exceptions import (
 )
 from .models import (
     BatchReceipt,
+    EpisodeListPage,
+    EpisodeSummary,
     ErrorCode,
     Execution,
     LineFormat,
@@ -54,6 +56,8 @@ __all__ = [
     "MAX_LINE_BYTES",
     # Models
     "BatchReceipt",
+    "EpisodeListPage",
+    "EpisodeSummary",
     "ErrorCode",
     "Execution",
     "LineFormat",

--- a/packages/prime-traces/src/prime_traces/models.py
+++ b/packages/prime-traces/src/prime_traces/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 
 class LineFormat(str, Enum):
@@ -92,23 +92,23 @@ class UploadReceipt(BaseModel):
 class ModelInfo(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    provider: Optional[str] = None
-    id: Optional[str] = None
+    provider: Optional[str]
+    id: Optional[str]
 
 
 class Score(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     # None means unscored, which is distinct from a scored 0.0.
-    reward: Optional[float] = None
-    outcome: Optional[str] = None
+    reward: Optional[float]
+    outcome: Optional[str]
 
 
 class Execution(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    has_error: Optional[bool] = None
-    is_truncated: Optional[bool] = None
+    has_error: bool
+    is_truncated: bool
 
 
 class TraceSummary(BaseModel):
@@ -118,33 +118,95 @@ class TraceSummary(BaseModel):
     absent because the v0 extractor does not write them; fetch the raw
     document for those. ``total_tokens`` is the one extracted usage figure
     (it counts re-sent context once, so it is not the sum of per-call usage).
+
+    Every field is present on every service response; the ``Optional`` ones
+    are those the service nulls for "not recorded".
     """
 
     model_config = ConfigDict(extra="allow")
 
     trace_id: str
-    upload_id: Optional[str] = None
-    episode_id: Optional[str] = None
-    created_at: Optional[datetime] = None
-    ingested_at: Optional[datetime] = None
-    run_id: Optional[str] = None
-    environment_id: Optional[str] = None
-    model: Optional[ModelInfo] = None
-    task_id: Optional[str] = None
-    agent_name: Optional[str] = None
-    score: Optional[Score] = None
-    execution: Optional[Execution] = None
-    duration_ms: Optional[int] = None
-    total_tokens: Optional[int] = None
-    size_bytes: Optional[int] = None
-    context: Dict[str, str] = Field(default_factory=dict)
+    upload_id: str
+    episode_id: Optional[str]
+    created_at: datetime
+    ingested_at: datetime
+    run_id: Optional[str]
+    environment_id: Optional[str]
+    model: ModelInfo
+    task_id: Optional[str]
+    agent_name: Optional[str]
+    score: Score
+    execution: Execution
+    duration_ms: int
+    total_tokens: int
+    size_bytes: int
+    context: Dict[str, str]
+
+
+class EpisodeError(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Optional[str]
+    message: Optional[str]
+
+
+class EpisodeSummary(BaseModel):
+    """One episode's extracted columns and episode-owned fields.
+
+    ``has_error`` and ``error`` are the episode row's own — an
+    environment-hook failure with every member trace green lives here, not in
+    the member-trace aggregate.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    episode_id: str
+    upload_id: str
+    schema_version: int
+    created_at: datetime
+    ingested_at: datetime
+    run_id: Optional[str]
+    environment_id: Optional[str]
+    outcome: Optional[str]
+    has_error: bool
+    error: EpisodeError
+
+
+class EpisodeTraceAggregate(BaseModel):
+    """Read-time rollup over deduplicated member traces.
+
+    A zero-trace episode is a legitimate terminal state (a failure before any
+    trace was minted still leaves its errors on the episode), so an empty
+    aggregate is not an error.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    trace_count: int
+    total_tokens: int
+    total_duration_ms: int
+    any_trace_error: bool
+    agent_names: List[str]
+
+
+class EpisodeDetail(EpisodeSummary):
+    """Point-lookup response: the summary plus the member-trace aggregate."""
+
+    traces: EpisodeTraceAggregate
 
 
 class TraceListPage(BaseModel):
     """One page of trace summaries. ``next_cursor`` is opaque and only valid
-    with the exact filters that produced it."""
+    with the exact filters that produced it; ``None`` marks the last page."""
 
     model_config = ConfigDict(extra="allow")
 
-    items: List[TraceSummary] = Field(default_factory=list)
-    next_cursor: Optional[str] = None
+    items: List[TraceSummary]
+    next_cursor: Optional[str]
+
+
+class EpisodeListPage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    items: List[EpisodeSummary]
+    next_cursor: Optional[str]

--- a/packages/prime-traces/src/prime_traces/models.py
+++ b/packages/prime-traces/src/prime_traces/models.py
@@ -130,6 +130,31 @@ class TraceSummary(BaseModel):
     context: Dict[str, str] = Field(default_factory=dict)
 
 
+class EpisodeSummary(BaseModel):
+    """One episode's summary plus episode-owned fields.
+
+    Aggregates (total tokens, participating agents, any-trace-error) are
+    computed from member traces at read time by the service.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    episode_id: str
+    batch_id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    ingested_at: Optional[datetime] = None
+    environment_id: Optional[str] = None
+    run_id: Optional[str] = None
+    outcome: Optional[str] = None
+    has_error: Optional[bool] = None
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    total_tokens: Optional[int] = None
+    total_agent_time: Optional[int] = None
+    any_trace_error: Optional[bool] = None
+    participating_agents: Optional[List[str]] = None
+
+
 class TraceListPage(BaseModel):
     """One page of trace summaries. ``next_cursor`` is opaque and only valid
     with the exact filters that produced it."""
@@ -137,4 +162,11 @@ class TraceListPage(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     traces: List[TraceSummary] = Field(default_factory=list)
+    next_cursor: Optional[str] = None
+
+
+class EpisodeListPage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    episodes: List[EpisodeSummary] = Field(default_factory=list)
     next_cursor: Optional[str] = None

--- a/packages/prime-traces/src/prime_traces/traces.py
+++ b/packages/prime-traces/src/prime_traces/traces.py
@@ -1,17 +1,4 @@
-"""High-level client for Prime Traces.
-
-Wraps the wire client with upload batching/retry and typed read paths.
-
-The read surface matches the service's pinned response models
-(``prime-traces/src/traces/models.py`` in the platform repo): pages are
-``{items, next_cursor}``, summaries nest ``model``/``score``/``execution``.
-
-Deferred to follow-up PRs: exports (streaming ``GET /traces/export`` — its
-filter vocabulary is not declared server-side yet — and the unimplemented job
-API), episode reads, ``/search``, the ``environment_id`` filter (no populated
-column behind it yet), and the dot-path query compiler (needs the
-server-side field registry).
-"""
+"""High-level client for Prime Traces."""
 
 import json
 import tempfile
@@ -29,6 +16,8 @@ from .batching import (
 from .core.client import TracesAPIClient, retry_delay
 from .exceptions import RetryableAPIError, TransportError
 from .models import (
+    EpisodeDetail,
+    EpisodeListPage,
     LineFormat,
     TraceListPage,
     TraceSummary,
@@ -91,15 +80,17 @@ def _build_params(
     return params
 
 
-def _trace_endpoint(trace_id: str) -> str:
-    """Build a trace endpoint with the ID encoded as one path segment."""
-    if "/" in trace_id:
+def _encoded_id_segment(identifier: str, *, parameter_name: str) -> str:
+    """Encode a resource ID as one URL path segment."""
+    if "/" in identifier:
         # ASGI decodes %2F before Starlette route matching, so the service's
-        # /traces/{trace_id} route sees an extra path segment and returns 404.
+        # /{resource}/{id} routes see an extra path segment and return 404.
         # Fail locally until that route accepts a path-valued parameter rather
-        # than issuing a request that cannot address the uploaded trace.
-        raise ValueError("trace_id cannot contain '/' until the service supports path-valued IDs")
-    encoded = quote(trace_id, safe="")
+        # than issuing a request that cannot address the uploaded resource.
+        raise ValueError(
+            f"{parameter_name} cannot contain '/' until the service supports path-valued IDs"
+        )
+    encoded = quote(identifier, safe="")
     # RFC 3986 leaves periods unescaped even with ``safe=""``. A segment that
     # is exactly "." or ".." is special, though: HTTP clients normalize it
     # away before sending the request, which would target the collection or API
@@ -107,7 +98,17 @@ def _trace_endpoint(trace_id: str) -> str:
     # explicitly so they remain ordinary path-segment values on the wire.
     if encoded in {".", ".."}:
         encoded = encoded.replace(".", "%2E")
-    return f"/traces/{encoded}"
+    return encoded
+
+
+def _trace_endpoint(trace_id: str) -> str:
+    """Build a trace endpoint with the ID encoded as one path segment."""
+    return f"/traces/{_encoded_id_segment(trace_id, parameter_name='trace_id')}"
+
+
+def _episode_endpoint(episode_id: str) -> str:
+    """Build an episode endpoint with the ID encoded as one path segment."""
+    return f"/episodes/{_encoded_id_segment(episode_id, parameter_name='episode_id')}"
 
 
 class TracesClient:
@@ -175,7 +176,7 @@ class TracesClient:
         ambiguous failure safe, because a request that did land replays its
         receipt instead of storing twice.
 
-        Batches are sent sequentially in v0. The contract allows 2–8 requests
+        Batches are sent sequentially in v0. The contract allows 2-8 requests
         in flight per producer; add bounded concurrency here once the service
         is up and throughput is measured.
         """
@@ -256,6 +257,7 @@ class TracesClient:
         self,
         *,
         run_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
         model_id: Optional[str] = None,
         model_provider: Optional[str] = None,
         task_id: Optional[str] = None,
@@ -280,6 +282,7 @@ class TracesClient:
         params = _build_params(
             (
                 ("run_id", run_id),
+                ("environment_id", environment_id),
                 ("model_id", model_id),
                 ("model_provider", model_provider),
                 ("task_id", task_id),
@@ -399,6 +402,97 @@ class TracesClient:
         traces added to the run after the first request.
         """
         self.client.delete("/traces", params={"run_id": run_id})
+
+    # -- episodes -----------------------------------------------------------
+
+    def list_episodes(
+        self,
+        *,
+        run_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
+        outcome: Optional[str] = None,
+        has_error: Optional[bool] = None,
+        created_after: Optional[str] = None,
+        created_before: Optional[str] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+    ) -> EpisodeListPage:
+        """List episode summaries using the server's complete filter set.
+
+        ``environment_id`` is extracted from the canonical episode
+        ``env.id``. Episodes carry no upload ``context`` map.
+        """
+        params = _build_params(
+            (
+                ("run_id", run_id),
+                ("environment_id", environment_id),
+                ("outcome", outcome),
+                ("has_error", has_error),
+                ("created_after", created_after),
+                ("created_before", created_before),
+                ("limit", limit),
+                ("cursor", cursor),
+            )
+        )
+        return EpisodeListPage.model_validate(self.client.get_json("/episodes", params=params))
+
+    def get_episode(self, episode_id: str) -> EpisodeDetail:
+        """Episode-owned fields plus the read-time member-trace aggregate.
+
+        The response carries the episode row's own ``has_error``/``error``
+        alongside ``traces.any_trace_error``, so an environment-hook failure
+        stays visible even when every individual trace succeeded.
+        """
+        return EpisodeDetail.model_validate(self.client.get_json(_episode_endpoint(episode_id)))
+
+    def list_episode_traces(
+        self,
+        episode_id: str,
+        *,
+        run_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        model_provider: Optional[str] = None,
+        task_id: Optional[str] = None,
+        reward_min: Optional[float] = None,
+        reward_max: Optional[float] = None,
+        outcome: Optional[str] = None,
+        has_error: Optional[bool] = None,
+        is_truncated: Optional[bool] = None,
+        created_after: Optional[str] = None,
+        created_before: Optional[str] = None,
+        context: Optional[Dict[str, str]] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+    ) -> TraceListPage:
+        """List an episode's member traces in upload order.
+
+        The filter vocabulary matches the backend member-trace route and the
+        top-level trace listing, except that member traces have no ``sort``
+        option.
+        """
+        params = _build_params(
+            (
+                ("run_id", run_id),
+                ("environment_id", environment_id),
+                ("model_id", model_id),
+                ("model_provider", model_provider),
+                ("task_id", task_id),
+                ("reward_min", reward_min),
+                ("reward_max", reward_max),
+                ("outcome", outcome),
+                ("has_error", has_error),
+                ("is_truncated", is_truncated),
+                ("created_after", created_after),
+                ("created_before", created_before),
+                ("limit", limit),
+                ("cursor", cursor),
+            ),
+            context,
+        )
+        return TraceListPage.model_validate(
+            self.client.get_json(f"{_episode_endpoint(episode_id)}/traces", params=params)
+        )
 
     def close(self) -> None:
         self.client.close()

--- a/packages/prime-traces/src/prime_traces/traces.py
+++ b/packages/prime-traces/src/prime_traces/traces.py
@@ -286,7 +286,6 @@ class TracesClient:
         dest: Union[str, Path],
         *,
         run_id: Optional[str] = None,
-        environment_id: Optional[str] = None,
         model_id: Optional[str] = None,
         model_provider: Optional[str] = None,
         task_id: Optional[str] = None,
@@ -314,7 +313,6 @@ class TracesClient:
         params = _build_params(
             (
                 ("run_id", run_id),
-                ("environment_id", environment_id),
                 ("model_id", model_id),
                 ("model_provider", model_provider),
                 ("task_id", task_id),
@@ -328,12 +326,7 @@ class TracesClient:
             ),
             context,
         )
-        written = 0
-        with open(dest, "wb") as f:
-            for chunk in self.client.stream_bytes("/traces/export", params=params):
-                f.write(chunk)
-                written += len(chunk)
-        return written
+        return self._stream_to_file("/traces/export", params, dest)
 
     # -- episodes (read-only in v0) -----------------------------------------
 
@@ -341,7 +334,6 @@ class TracesClient:
         self,
         *,
         run_id: Optional[str] = None,
-        environment_id: Optional[str] = None,
         created_after: Optional[str] = None,
         created_before: Optional[str] = None,
         limit: Optional[int] = None,
@@ -350,7 +342,6 @@ class TracesClient:
         params: Dict[str, object] = {}
         for key, value in (
             ("run_id", run_id),
-            ("environment_id", environment_id),
             ("created_after", created_after),
             ("created_before", created_before),
             ("limit", limit),

--- a/packages/prime-traces/src/prime_traces/traces.py
+++ b/packages/prime-traces/src/prime_traces/traces.py
@@ -2,14 +2,16 @@
 
 Wraps the wire client with upload batching/retry and typed read paths.
 
-The read surface (list/get envelopes) is provisional: the service PR defines
-routes but no response models yet, so the page shape here is a proposal to
-align on, not a settled contract.
+The read surface (list/get/episode envelopes, export params) is provisional:
+the service defines these routes but has not pinned response models yet, so
+the shapes here are a proposal to align on, not a settled contract.
 
-Deferred to follow-up PRs once the service pins the corresponding responses:
-exports (streaming ``GET /traces/export`` and the job API, which is 501 in
-v0), episode reads, ``/search``, the ``environment_id`` filter (no populated
-column behind it yet), and the dot-path query compiler (needs the
+Deliberately not implemented yet (open v0 contract decisions — do not freeze
+them here): the exports *job* API (``POST /traces/exports`` is published as
+501 in v0; the streaming ``GET /traces/export`` is what ``export`` wraps),
+``/search``, the ``environment_id`` filter (no populated column behind it
+yet), episode writes (episodes are read-only, written only as a side effect
+of episode-grouped uploads), and the dot-path query compiler (needs the
 server-side field registry).
 """
 
@@ -28,6 +30,8 @@ from .core.client import TracesAPIClient
 from .exceptions import RetryableAPIError
 from .models import (
     BatchReceipt,
+    EpisodeListPage,
+    EpisodeSummary,
     LineFormat,
     TraceListPage,
     TraceSummary,
@@ -255,6 +259,106 @@ class TracesClient:
         result = self.client.delete_json("/traces", params={"run_id": run_id})
         job_id = result.get("job_id")
         return str(job_id) if job_id is not None else None
+
+    # -- export -------------------------------------------------------------
+
+    def export(
+        self,
+        dest: Union[str, Path],
+        *,
+        run_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
+        model_id: Optional[str] = None,
+        model_provider: Optional[str] = None,
+        task_id: Optional[str] = None,
+        reward_min: Optional[float] = None,
+        reward_max: Optional[float] = None,
+        outcome: Optional[str] = None,
+        has_error: Optional[bool] = None,
+        is_truncated: Optional[bool] = None,
+        created_after: Optional[str] = None,
+        created_before: Optional[str] = None,
+        context: Optional[Dict[str, str]] = None,
+    ) -> int:
+        """Stream a filtered export (``GET /traces/export``) to ``dest``.
+
+        Takes the same filter vocabulary as ``list`` — no pagination: the
+        export is one file, resumable by re-running. Returns bytes written.
+        Egress is metered on bytes actually sent, so a failed stream still
+        costs for the bytes that made it; always stream to disk rather than
+        buffering.
+
+        A format parameter (raw JSONL vs. column projection) is not exposed
+        yet — the service route does not define it; add it here when it lands.
+        The exports *job* API is 501 in v0 and is deliberately not wrapped.
+        """
+        params = _build_params(
+            (
+                ("run_id", run_id),
+                ("environment_id", environment_id),
+                ("model_id", model_id),
+                ("model_provider", model_provider),
+                ("task_id", task_id),
+                ("reward_min", reward_min),
+                ("reward_max", reward_max),
+                ("outcome", outcome),
+                ("has_error", has_error),
+                ("is_truncated", is_truncated),
+                ("created_after", created_after),
+                ("created_before", created_before),
+            ),
+            context,
+        )
+        written = 0
+        with open(dest, "wb") as f:
+            for chunk in self.client.stream_bytes("/traces/export", params=params):
+                f.write(chunk)
+                written += len(chunk)
+        return written
+
+    # -- episodes (read-only in v0) -----------------------------------------
+
+    def list_episodes(
+        self,
+        *,
+        run_id: Optional[str] = None,
+        environment_id: Optional[str] = None,
+        created_after: Optional[str] = None,
+        created_before: Optional[str] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+    ) -> EpisodeListPage:
+        params: Dict[str, object] = {}
+        for key, value in (
+            ("run_id", run_id),
+            ("environment_id", environment_id),
+            ("created_after", created_after),
+            ("created_before", created_before),
+            ("limit", limit),
+            ("cursor", cursor),
+        ):
+            if value is not None:
+                params[key] = value
+        return EpisodeListPage.model_validate(self.client.get_json("/episodes", params=params))
+
+    def get_episode(self, episode_id: str) -> EpisodeSummary:
+        return EpisodeSummary.model_validate(self.client.get_json(f"/episodes/{episode_id}"))
+
+    def list_episode_traces(
+        self,
+        episode_id: str,
+        *,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+    ) -> TraceListPage:
+        params: Dict[str, object] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        return TraceListPage.model_validate(
+            self.client.get_json(f"/episodes/{episode_id}/traces", params=params)
+        )
 
     def close(self) -> None:
         self.client.close()

--- a/packages/prime-traces/tests/test_reads.py
+++ b/packages/prime-traces/tests/test_reads.py
@@ -175,3 +175,46 @@ class TestTeamHeader:
 
         self._client("", handler).get_json("/traces")
         assert captured["team"] is None
+
+
+class TestExport:
+    def test_export_streams_filtered_body_to_file(self, make_client, tmp_path):
+        body = b'{"id":"a"}\n{"id":"b"}\n'
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v1/traces/export"
+            assert dict(request.url.params) == {
+                "run_id": "run_9f3k2m",
+                "reward_min": "0.9",
+                "context.source": "hosted_eval",
+            }
+            return httpx.Response(200, content=body)
+
+        dest = tmp_path / "export.jsonl"
+        written = make_client(handler).export(
+            dest,
+            run_id="run_9f3k2m",
+            reward_min=0.9,
+            context={"source": "hosted_eval"},
+        )
+        assert written == len(body)
+        assert dest.read_bytes() == body
+
+
+class TestEpisodes:
+    def test_episode_reads(self, make_client):
+        episode = {"episode_id": "ep-1", "run_id": "run_9f3k2m", "has_error": False}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/api/v1/episodes":
+                return httpx.Response(200, json={"episodes": [episode], "next_cursor": None})
+            if request.url.path == "/api/v1/episodes/ep-1":
+                return httpx.Response(200, json=episode)
+            if request.url.path == "/api/v1/episodes/ep-1/traces":
+                return httpx.Response(200, json={"traces": [SUMMARY], "next_cursor": None})
+            raise AssertionError(f"unexpected path {request.url.path}")
+
+        client = make_client(handler)
+        assert client.list_episodes(run_id="run_9f3k2m").episodes[0].episode_id == "ep-1"
+        assert client.get_episode("ep-1").episode_id == "ep-1"
+        assert client.list_episode_traces("ep-1").traces[0].trace_id == "8d3f1a2b"

--- a/packages/prime-traces/tests/test_reads.py
+++ b/packages/prime-traces/tests/test_reads.py
@@ -214,6 +214,18 @@ class TestExport:
         assert written == len(body)
         assert dest.read_bytes() == body
 
+    def test_export_failure_preserves_existing_file(self, make_client, tmp_path):
+        dest = tmp_path / "export.jsonl"
+        dest.write_bytes(b"previous export")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, json={"detail": "expired token"})
+
+        with pytest.raises(UnauthorizedError):
+            make_client(handler).export(dest, run_id="run_9f3k2m")
+        assert dest.read_bytes() == b"previous export"
+        assert not (tmp_path / "export.jsonl.partial").exists()
+
 
 class TestEpisodes:
     def test_episode_reads(self, make_client):

--- a/packages/prime-traces/tests/test_reads.py
+++ b/packages/prime-traces/tests/test_reads.py
@@ -36,6 +36,8 @@ SUMMARY = {
 
 RESERVED_TRACE_ID = "trace?with#reserved%chars and space"
 ENCODED_TRACE_PATH = b"/api/v1/traces/trace%3Fwith%23reserved%25chars%20and%20space"
+RESERVED_EPISODE_ID = "episode?with#reserved%chars and space"
+ENCODED_EPISODE_PATH = b"/api/v1/episodes/episode%3Fwith%23reserved%25chars%20and%20space"
 
 
 class TestList:
@@ -49,6 +51,7 @@ class TestList:
         client = make_client(handler)
         page = client.list(
             run_id="run_9f3k2m",
+            environment_id="terminal-bench-2",
             reward_min=0.5,
             has_error=False,
             context={"source": "hosted_eval"},
@@ -57,6 +60,7 @@ class TestList:
 
         assert captured["params"] == {
             "run_id": "run_9f3k2m",
+            "environment_id": "terminal-bench-2",
             "reward_min": "0.5",
             "has_error": "false",
             "context.source": "hosted_eval",
@@ -528,3 +532,194 @@ class TestTeamHeader:
 
         self._client("", handler).get_json("/traces")
         assert captured["team"] is None
+
+
+class TestStreamToFile:
+    """`download_raw` is the only streamed-to-disk read in v0 — exports are
+    unimplemented server-side — so it carries the clobber-safety rules.
+
+    The pre-request failure case lives in `TestPointReads`; this is the harder
+    one, where bytes have already been written before the failure.
+    """
+
+    def test_partial_is_cleaned_up_when_the_stream_breaks_midway(self, make_client, tmp_path):
+        def handler(request: httpx.Request) -> httpx.Response:
+            def body():
+                yield b'{"version":4,'
+                raise httpx.ReadError("connection reset")
+
+            return httpx.Response(200, content=body())
+
+        dest = tmp_path / "trace.json"
+        with pytest.raises(TransportError):
+            make_client(handler).download_raw("8d3f1a2b", dest)
+        # A mid-stream failure is never retried under the consumer, so the
+        # prefix that did arrive is discarded rather than left as a document.
+        assert not dest.exists()
+        assert not (tmp_path / "trace.json.partial").exists()
+
+
+class TestEpisodes:
+    # Mirrors the service's `EpisodeSummary` (prime-traces/src/episodes/
+    # models.py in the platform repo): episode-owned fields, nested `error`.
+    EPISODE = {
+        "episode_id": "ep-1",
+        "upload_id": "5ee85e41",
+        "schema_version": 1,
+        "created_at": "2026-07-20T18:02:11.482Z",
+        "ingested_at": "2026-07-20T18:06:02.117Z",
+        "run_id": "run_9f3k2m",
+        "environment_id": "terminal-bench-2",
+        "outcome": "done",
+        "has_error": False,
+        "error": {"type": None, "message": None},
+    }
+    EMPTY_AGGREGATE = {
+        "trace_count": 0,
+        "total_tokens": 0,
+        "total_duration_ms": 0,
+        "any_trace_error": False,
+        "agent_names": [],
+    }
+
+    def test_list_episodes_filters_and_envelope(self, make_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"items": [self.EPISODE], "next_cursor": None})
+
+        page = make_client(handler).list_episodes(
+            run_id="run_9f3k2m",
+            environment_id="terminal-bench-2",
+            outcome="done",
+            has_error=False,
+        )
+        assert captured["params"] == {
+            "run_id": "run_9f3k2m",
+            "environment_id": "terminal-bench-2",
+            "outcome": "done",
+            "has_error": "false",
+        }
+        [episode] = page.items
+        assert episode.episode_id == "ep-1"
+        assert episode.environment_id == "terminal-bench-2"
+        assert episode.error.type is None
+
+    def test_get_episode_nests_member_aggregate(self, make_client):
+        # The episode row's own error stays visible alongside the aggregate:
+        # an environment-hook failure with every member trace green.
+        detail = {
+            **self.EPISODE,
+            "has_error": True,
+            "error": {"type": "SetupError", "message": "setup hook failed"},
+            "traces": {
+                "trace_count": 2,
+                "total_tokens": 168426,
+                "total_duration_ms": 431074,
+                "any_trace_error": False,
+                "agent_names": ["judge", "solver"],
+            },
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v1/episodes/ep-1"
+            return httpx.Response(200, json=detail)
+
+        episode = make_client(handler).get_episode("ep-1")
+        assert episode.has_error is True
+        assert episode.error.type == "SetupError"
+        assert episode.traces.trace_count == 2
+        assert episode.traces.any_trace_error is False
+        assert episode.traces.agent_names == ["judge", "solver"]
+
+    def test_get_episode_encodes_episode_id_as_one_path_segment(self, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.raw_path == ENCODED_EPISODE_PATH
+            return httpx.Response(
+                200,
+                json={
+                    **self.EPISODE,
+                    "episode_id": RESERVED_EPISODE_ID,
+                    "traces": self.EMPTY_AGGREGATE,
+                },
+            )
+
+        assert make_client(handler).get_episode(RESERVED_EPISODE_ID).episode_id == (
+            RESERVED_EPISODE_ID
+        )
+
+    @pytest.mark.parametrize(
+        ("episode_id", "encoded"),
+        [(".", b"%2E"), ("..", b"%2E%2E")],
+    )
+    def test_get_episode_preserves_dot_only_id_segment(self, make_client, episode_id, encoded):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.raw_path == b"/api/v1/episodes/" + encoded
+            return httpx.Response(
+                200,
+                json={**self.EPISODE, "episode_id": episode_id, "traces": self.EMPTY_AGGREGATE},
+            )
+
+        assert make_client(handler).get_episode(episode_id).episode_id == episode_id
+
+    @pytest.mark.parametrize("method", ["get_episode", "list_episode_traces"])
+    def test_episode_reads_reject_episode_id_with_slash_before_request(self, make_client, method):
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        with pytest.raises(ValueError, match="episode_id cannot contain '/'"):
+            getattr(make_client(handler), method)("episode/child")
+
+    def test_list_episode_traces_forwards_backend_filters(self, make_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v1/episodes/ep-1/traces"
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"items": [SUMMARY], "next_cursor": None})
+
+        page = make_client(handler).list_episode_traces(
+            "ep-1",
+            run_id="run_9f3k2m",
+            environment_id="terminal-bench-2",
+            model_id="deepseek-v4-flash",
+            model_provider="prime",
+            task_id="tb2-0187",
+            reward_min=0.5,
+            reward_max=1.0,
+            outcome="done",
+            has_error=False,
+            is_truncated=False,
+            created_after="2026-07-01T00:00:00Z",
+            created_before="2026-08-01T00:00:00Z",
+            context={"source": "hosted_eval"},
+            limit=50,
+            cursor="next-page",
+        )
+        assert captured["params"] == {
+            "run_id": "run_9f3k2m",
+            "environment_id": "terminal-bench-2",
+            "model_id": "deepseek-v4-flash",
+            "model_provider": "prime",
+            "task_id": "tb2-0187",
+            "reward_min": "0.5",
+            "reward_max": "1.0",
+            "outcome": "done",
+            "has_error": "false",
+            "is_truncated": "false",
+            "created_after": "2026-07-01T00:00:00Z",
+            "created_before": "2026-08-01T00:00:00Z",
+            "limit": "50",
+            "cursor": "next-page",
+            "context.source": "hosted_eval",
+        }
+        assert page.items[0].trace_id == "8d3f1a2b"
+
+    def test_list_episode_traces_encodes_episode_id_as_one_path_segment(self, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.raw_path == ENCODED_EPISODE_PATH + b"/traces"
+            return httpx.Response(200, json={"items": [SUMMARY], "next_cursor": None})
+
+        page = make_client(handler).list_episode_traces(RESERVED_EPISODE_ID)
+        assert page.items[0].trace_id == "8d3f1a2b"


### PR DESCRIPTION
Stacked on #814. Completes the read surface:

- **Read-only episode resources**, pinned to the service's `episodes/models.py` (platform#3956):
  - `list_episodes` with the full server filter set (`run_id`, `environment_id`, `outcome`, `has_error`, created window) returning `{items, next_cursor}` pages of `EpisodeSummary` — episode-owned fields with nested `error {type, message}` and `schema_version`.
  - `get_episode` returning `EpisodeDetail`: the summary plus the read-time member aggregate nested under `traces {trace_count, total_tokens, total_duration_ms, any_trace_error, agent_names}`. The episode row's own `has_error`/`error` stays visible alongside `any_trace_error`, so an environment-hook failure shows even when every member trace succeeded.
  - `list_episode_traces` for cursor-paginated member trace summaries.
- **Response models pin the service's required/nullable split** (trace and episode alike): a field the service always sends is required here, so contract drift fails loudly in tests instead of propagating `None`; fields the service nulls for "not recorded" stay `Optional`; `extra="allow"` still covers the documented additive-growth path, and the additive-fields test keeps passing.

~~Don't merge until platform #3833 pins response models.~~ **Resolved:** all envelopes, summary nesting, and episode shapes are reconciled against the service as implemented through platform#3956, and the tests assert those exact wire shapes.

**Export is not in this PR.** Neither form is wrapped: the streaming route (`GET /traces/export`) exists but declares no parameters and answers 500, and the job-based API (`POST /traces/exports`) has nowhere to land results in v0. `TracesClient` exposes no `export()`, and there is no `prime traces export` in #816 — this continues #814's deferral rather than reversing it. The wrapper should land with the service contract it targets, so the filter vocabulary is designed against something real instead of proposed against a stub.

<sub>An earlier revision of this description advertised `export(dest, **filters)` as delivered here. It never was — the claim was stale, and #814's "export remains intentionally deferred" was the accurate one throughout. Corrected after the read and write paths were exercised end-to-end against the deployed dev service (ENG-5112).</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Read-path and model strictness changes can break callers that relied on optional defaults or assumed looser shapes; behavior is bounded to query/parse layers with broad test coverage.
> 
> **Overview**
> Adds **read-only episode APIs** on `TracesClient`: `list_episodes` (server filters including `environment_id`), `get_episode` (`EpisodeDetail` with member rollup under `.traces`), and `list_episode_traces` (same trace filters as `list`, without `sort`). Episode IDs reuse shared path encoding with traces via `_encoded_id_segment` / `_episode_endpoint`.
> 
> **Response models** are tightened to match the service contract: new episode types are exported from the package; trace and nested models drop implicit defaults so always-present wire fields are required and “not recorded” stays `Optional`. Trace `list` gains an **`environment_id`** query parameter.
> 
> README is reorganized (install/quick start, episode query examples) and episode reads are removed from the “not implemented” list. Tests cover episode list/detail/member traces, `environment_id` on trace list, and mid-stream `download_raw` partial cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1a0bde53f9bac6b304fec20c17bb7010839b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

