### PR TITLE
release: prime-sandboxes 0.2.35

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -70,7 +70,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.34"
+__version__ = "0.2.35"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError


### PR DESCRIPTION
## Summary

- bump `prime-sandboxes` from 0.2.34 to 0.2.35
- publish the VM live process handles added in #819

## Why

The 0.2.34 tag predates `AsyncSandboxClient.open_process`. Verifiers PR #2249 needs that API to keep a harness process alive across turns in Prime VM sandboxes.

Merging this PR triggers the existing `prime-sandboxes` release workflow, which creates `prime-sandboxes-v0.2.35` and publishes the package to PyPI.

## Validation

- `uv run pytest tests/ -v -n auto` with live sandbox files excluded: 156 passed, including the VM `open_process` transport tests
- `uv run ruff check .`
- `uv build` produced the 0.2.35 wheel and sdist

The live sandbox tests require `PRIME_API_KEY`; GitHub CI supplies the repository secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version string change with no runtime or API edits in this PR.
> 
> **Overview**
> **Release-only change:** bumps `prime-sandboxes` from **0.2.34** to **0.2.35** in `__init__.py` so CI can tag and publish to PyPI.
> 
> No new SDK behavior in this diff—the release ships **VM live process** support already merged (e.g. `AsyncSandboxClient.open_process` and `AsyncSandboxProcess`), which **0.2.34** did not include on PyPI. Downstream (e.g. verifiers) can depend on **0.2.35** for long-lived harness processes in Prime VM sandboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6433af126d0e9d99431fad34d313b0d269f8289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->