### PR TITLE
add prime agent launcher to the cli

### DIFF
--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -31,6 +31,7 @@ Prime is the official CLI and Python SDK for [Prime Intellect](https://primeinte
 **What can you do with Prime?**
 
 - Deploy GPU pods with H100, A100, and other high-performance GPUs
+- Launch Prime Agent, with automatic installation on first use
 - Set up Lab workspaces for verifiers environments, evals, GEPA, and training
 - Discover and launch Hosted Training runs against verifiers environments
 - Create and manage isolated sandbox environments for running code
@@ -81,6 +82,9 @@ Get your API key from the [Prime Intellect Dashboard](https://app.primeintellect
 ### Basic Usage
 
 ```bash
+# Launch Prime Agent (installs automatically on first use)
+prime agent
+
 # Browse environments on the hub
 prime env list
 

--- a/packages/prime/src/prime_cli/commands/agent.py
+++ b/packages/prime/src/prime_cli/commands/agent.py
@@ -1,19 +1,25 @@
 """Prime Agent launcher."""
 
+import hashlib
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 import typer
 
+from .. import __version__
 from ..utils import get_console
 
 PRIME_AGENT_COMMAND = "prime-agent"
-PRIME_AGENT_INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+PRIME_AGENT_INSTALLER_URL = "https://app.primeintellect.ai/prime-agent/install.sh"
+# Update only after reviewing a new installer published at the URL above.
+PRIME_AGENT_INSTALLER_SHA256 = (
+    "38d14a1be73b325652c7ce8342e3bf19335721837192855a7907732caf8e6d04"
+)
 MAX_INSTALLER_BYTES = 1024 * 1024
 
 console = get_console()
@@ -38,8 +44,12 @@ def _find_agent() -> str | None:
 
 
 def _download_installer() -> bytes:
+    request = Request(
+        PRIME_AGENT_INSTALLER_URL,
+        headers={"User-Agent": f"prime-cli/{__version__}"},
+    )
     try:
-        with urlopen(PRIME_AGENT_INSTALLER_URL, timeout=30) as response:
+        with urlopen(request, timeout=30) as response:
             installer = response.read(MAX_INSTALLER_BYTES + 1)
     except (HTTPError, URLError, TimeoutError, OSError) as exc:
         console.print(f"[red]Failed to download the Prime Agent installer:[/red] {exc}")
@@ -47,6 +57,11 @@ def _download_installer() -> bytes:
 
     if len(installer) > MAX_INSTALLER_BYTES:
         console.print("[red]Failed to download Prime Agent:[/red] installer is unexpectedly large.")
+        raise typer.Exit(1)
+
+    actual_sha256 = hashlib.sha256(installer).hexdigest()
+    if actual_sha256 != PRIME_AGENT_INSTALLER_SHA256:
+        console.print("[red]Failed to download Prime Agent:[/red] installer checksum mismatch.")
         raise typer.Exit(1)
 
     if not installer.startswith(b"#!/bin/sh"):
@@ -73,8 +88,8 @@ def _install_agent() -> None:
             suffix=".sh",
             delete=False,
         ) as file:
-            file.write(installer)
             installer_path = Path(file.name)
+            file.write(installer)
 
         result = subprocess.run([shell, str(installer_path)])
     except OSError as exc:
@@ -90,13 +105,10 @@ def _install_agent() -> None:
 
 def _run_agent(executable: str, args: list[str]) -> None:
     try:
-        result = subprocess.run([executable, *args])
+        os.execv(executable, [executable, *args])
     except OSError as exc:
         console.print(f"[red]Failed to launch Prime Agent:[/red] {exc}")
         raise typer.Exit(1) from exc
-
-    if result.returncode != 0:
-        raise typer.Exit(result.returncode)
 
 
 def agent_command(ctx: typer.Context) -> None:

--- a/packages/prime/src/prime_cli/commands/agent.py
+++ b/packages/prime/src/prime_cli/commands/agent.py
@@ -1,0 +1,114 @@
+"""Prime Agent launcher."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+import typer
+
+from ..utils import get_console
+
+PRIME_AGENT_COMMAND = "prime-agent"
+PRIME_AGENT_INSTALLER_URL = "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/install.sh"
+MAX_INSTALLER_BYTES = 1024 * 1024
+
+console = get_console()
+
+
+def _standalone_agent_path() -> Path:
+    data_home = os.environ.get("XDG_DATA_HOME")
+    base_dir = Path(data_home) if data_home else Path.home() / ".local" / "share"
+    return base_dir / "prime-agent-node" / "current" / "bin" / PRIME_AGENT_COMMAND
+
+
+def _find_agent() -> str | None:
+    executable = shutil.which(PRIME_AGENT_COMMAND)
+    if executable is not None:
+        return executable
+
+    standalone_path = _standalone_agent_path()
+    if standalone_path.is_file():
+        return str(standalone_path)
+
+    return None
+
+
+def _download_installer() -> bytes:
+    try:
+        with urlopen(PRIME_AGENT_INSTALLER_URL, timeout=30) as response:
+            installer = response.read(MAX_INSTALLER_BYTES + 1)
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        console.print(f"[red]Failed to download the Prime Agent installer:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    if len(installer) > MAX_INSTALLER_BYTES:
+        console.print("[red]Failed to download Prime Agent:[/red] installer is unexpectedly large.")
+        raise typer.Exit(1)
+
+    if not installer.startswith(b"#!/bin/sh"):
+        console.print("[red]Failed to download Prime Agent:[/red] invalid installer response.")
+        raise typer.Exit(1)
+
+    return installer
+
+
+def _install_agent() -> None:
+    shell = shutil.which("sh")
+    if shell is None:
+        console.print("[red]Prime Agent is not installed and `sh` is unavailable.[/red]")
+        console.print(f"[dim]Install it from {PRIME_AGENT_INSTALLER_URL} and try again.[/dim]")
+        raise typer.Exit(1)
+
+    console.print("[dim]Prime Agent is not installed. Downloading the installer...[/dim]")
+    installer = _download_installer()
+    installer_path: Path | None = None
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            prefix="prime-agent-install-",
+            suffix=".sh",
+            delete=False,
+        ) as file:
+            file.write(installer)
+            installer_path = Path(file.name)
+
+        result = subprocess.run([shell, str(installer_path)])
+    except OSError as exc:
+        console.print(f"[red]Failed to run the Prime Agent installer:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    finally:
+        if installer_path is not None:
+            installer_path.unlink(missing_ok=True)
+
+    if result.returncode != 0:
+        raise typer.Exit(result.returncode)
+
+
+def _run_agent(executable: str, args: list[str]) -> None:
+    try:
+        result = subprocess.run([executable, *args])
+    except OSError as exc:
+        console.print(f"[red]Failed to launch Prime Agent:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    if result.returncode != 0:
+        raise typer.Exit(result.returncode)
+
+
+def agent_command(ctx: typer.Context) -> None:
+    """Launch Prime Agent, installing it if needed."""
+    executable = _find_agent()
+    if executable is None:
+        _install_agent()
+        executable = _find_agent()
+
+    if executable is None:
+        console.print("[red]Prime Agent was installed, but its command could not be found.[/red]")
+        console.print("[dim]Restart your shell and run `prime agent` again.[/dim]")
+        raise typer.Exit(1)
+
+    _run_agent(executable, list(ctx.args))

--- a/packages/prime/src/prime_cli/main.py
+++ b/packages/prime/src/prime_cli/main.py
@@ -4,6 +4,7 @@ from typing import Optional
 import typer
 
 from . import __version__
+from .commands.agent import agent_command
 from .commands.availability import app as availability_app
 from .commands.config import app as config_app
 from .commands.deployments import app as deployments_app
@@ -43,6 +44,15 @@ app = PlainTyper(
 
 # Lab commands
 app.add_typer(lab_app, name="lab", rich_help_panel="Lab")
+app.command(
+    "agent",
+    rich_help_panel="Lab",
+    add_help_option=False,
+    context_settings={
+        "allow_extra_args": True,
+        "ignore_unknown_options": True,
+    },
+)(agent_command)
 app.add_typer(env_app, name="env", rich_help_panel="Lab")
 app.command("fork", rich_help_panel="Lab", epilog=FORK_JSON_HELP)(fork_command)
 app.add_typer(evals_app, name="eval", rich_help_panel="Lab")

--- a/packages/prime/tests/test_agent.py
+++ b/packages/prime/tests/test_agent.py
@@ -1,7 +1,10 @@
+import hashlib
 from pathlib import Path
 from typing import Any
+from urllib.request import Request
 
 import pytest
+from prime_cli import __version__
 from prime_cli.main import app
 from typer.testing import CliRunner
 
@@ -13,6 +16,18 @@ TEST_ENV = {
     "PRIME_DISABLE_VERSION_CHECK": "1",
 }
 
+FAKE_INSTALLER = b"#!/bin/sh\nexit 0\n"
+
+
+def trust_fake_installer(
+    monkeypatch: pytest.MonkeyPatch,
+    installer: bytes = FAKE_INSTALLER,
+) -> None:
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.PRIME_AGENT_INSTALLER_SHA256",
+        hashlib.sha256(installer).hexdigest(),
+    )
+
 
 class FakeResponse:
     def __enter__(self) -> "FakeResponse":
@@ -22,24 +37,23 @@ class FakeResponse:
         return None
 
     def read(self, _size: int) -> bytes:
-        return b"#!/bin/sh\nexit 0\n"
+        return FAKE_INSTALLER
 
 
 def test_agent_runs_installed_binary_with_passthrough_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[list[str]] = []
+    calls: list[tuple[str, list[str]]] = []
 
     monkeypatch.setattr(
         "prime_cli.commands.agent.shutil.which",
         lambda command: "/usr/local/bin/prime-agent" if command == "prime-agent" else None,
     )
 
-    def fake_run(command: list[str]) -> Any:
-        calls.append(command)
-        return type("Result", (), {"returncode": 0})()
+    def fake_execv(executable: str, args: list[str]) -> None:
+        calls.append((executable, args))
 
-    monkeypatch.setattr("prime_cli.commands.agent.subprocess.run", fake_run)
+    monkeypatch.setattr("prime_cli.commands.agent.os.execv", fake_execv)
 
     result = runner.invoke(
         app,
@@ -49,20 +63,25 @@ def test_agent_runs_installed_binary_with_passthrough_args(
 
     assert result.exit_code == 0, result.output
     assert calls == [
-        [
+        (
             "/usr/local/bin/prime-agent",
-            "--model",
-            "openai/gpt-5",
-            "review this",
-            "--help",
-        ]
+            [
+                "/usr/local/bin/prime-agent",
+                "--model",
+                "openai/gpt-5",
+                "review this",
+                "--help",
+            ],
+        )
     ]
 
 
 def test_agent_installs_then_runs_binary(monkeypatch: pytest.MonkeyPatch) -> None:
     agent_lookups = iter([None, "/new/bin/prime-agent"])
-    calls: list[list[str]] = []
+    installer_calls: list[list[str]] = []
+    exec_calls: list[tuple[str, list[str]]] = []
     installer_paths: list[Path] = []
+    download_requests: list[tuple[str, str | None, int]] = []
 
     def fake_which(command: str) -> str | None:
         if command == "prime-agent":
@@ -72,45 +91,49 @@ def test_agent_installs_then_runs_binary(monkeypatch: pytest.MonkeyPatch) -> Non
         return None
 
     def fake_run(command: list[str]) -> Any:
-        calls.append(command)
+        installer_calls.append(command)
         if command[0] == "/bin/sh":
             installer_path = Path(command[1])
             installer_paths.append(installer_path)
-            assert installer_path.read_bytes() == b"#!/bin/sh\nexit 0\n"
+            assert installer_path.read_bytes() == FAKE_INSTALLER
         return type("Result", (), {"returncode": 0})()
 
+    trust_fake_installer(monkeypatch)
     monkeypatch.setattr("prime_cli.commands.agent.shutil.which", fake_which)
-    monkeypatch.setattr(
-        "prime_cli.commands.agent.urlopen",
-        lambda *_args, **_kwargs: FakeResponse(),
-    )
+
+    def fake_urlopen(request: Request, timeout: int) -> FakeResponse:
+        download_requests.append(
+            (request.full_url, request.get_header("User-agent"), timeout)
+        )
+        return FakeResponse()
+
+    monkeypatch.setattr("prime_cli.commands.agent.urlopen", fake_urlopen)
     monkeypatch.setattr("prime_cli.commands.agent.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.os.execv",
+        lambda executable, args: exec_calls.append((executable, args)),
+    )
 
     result = runner.invoke(app, ["agent", "agents"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
     assert "Downloading the installer" in result.output
-    assert calls[0][0] == "/bin/sh"
-    assert calls[1] == ["/new/bin/prime-agent", "agents"]
+    assert installer_calls[0][0] == "/bin/sh"
+    assert exec_calls == [
+        ("/new/bin/prime-agent", ["/new/bin/prime-agent", "agents"])
+    ]
+    assert download_requests == [
+        (
+            "https://app.primeintellect.ai/prime-agent/install.sh",
+            f"prime-cli/{__version__}",
+            30,
+        )
+    ]
     assert installer_paths and not installer_paths[0].exists()
 
 
-def test_agent_propagates_agent_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "prime_cli.commands.agent.shutil.which",
-        lambda command: "/usr/local/bin/prime-agent" if command == "prime-agent" else None,
-    )
-    monkeypatch.setattr(
-        "prime_cli.commands.agent.subprocess.run",
-        lambda _command: type("Result", (), {"returncode": 17})(),
-    )
-
-    result = runner.invoke(app, ["agent", "doctor"], env=TEST_ENV)
-
-    assert result.exit_code == 17, result.output
-
-
 def test_agent_propagates_installer_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    trust_fake_installer(monkeypatch)
     monkeypatch.setattr(
         "prime_cli.commands.agent.shutil.which",
         lambda command: "/bin/sh" if command == "sh" else None,
@@ -136,26 +159,47 @@ def test_agent_finds_standalone_node_install(
     standalone_agent = tmp_path / "prime-agent-node" / "current" / "bin" / "prime-agent"
     standalone_agent.parent.mkdir(parents=True)
     standalone_agent.touch()
-    calls: list[list[str]] = []
+    calls: list[tuple[str, list[str]]] = []
 
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     monkeypatch.setattr("prime_cli.commands.agent.shutil.which", lambda _command: None)
     monkeypatch.setattr(
-        "prime_cli.commands.agent.subprocess.run",
-        lambda command: calls.append(command) or type("Result", (), {"returncode": 0})(),
+        "prime_cli.commands.agent.os.execv",
+        lambda executable, args: calls.append((executable, args)),
     )
 
     result = runner.invoke(app, ["agent", "doctor"], env=TEST_ENV)
 
     assert result.exit_code == 0, result.output
-    assert calls == [[str(standalone_agent), "doctor"]]
+    assert calls == [
+        (str(standalone_agent), [str(standalone_agent), "doctor"])
+    ]
+
+
+def test_agent_rejects_installer_checksum_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.shutil.which",
+        lambda command: "/bin/sh" if command == "sh" else None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    result = runner.invoke(app, ["agent"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "installer checksum mismatch" in result.output
 
 
 def test_agent_reports_invalid_installer(monkeypatch: pytest.MonkeyPatch) -> None:
+    invalid_installer = b"not a shell script"
+
     class InvalidResponse(FakeResponse):
         def read(self, _size: int) -> bytes:
-            return b"not a shell script"
+            return invalid_installer
 
+    trust_fake_installer(monkeypatch, invalid_installer)
     monkeypatch.setattr(
         "prime_cli.commands.agent.shutil.which",
         lambda command: "/bin/sh" if command == "sh" else None,
@@ -168,3 +212,43 @@ def test_agent_reports_invalid_installer(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert result.exit_code == 1, result.output
     assert "invalid installer response" in result.output
+
+
+def test_agent_cleans_up_temp_file_when_write_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    installer_path = tmp_path / "prime-agent-install.sh"
+
+    class FailingTempFile:
+        name = str(installer_path)
+
+        def __enter__(self) -> "FailingTempFile":
+            installer_path.touch()
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            return None
+
+        def write(self, _installer: bytes) -> None:
+            raise OSError("disk full")
+
+    trust_fake_installer(monkeypatch)
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.shutil.which",
+        lambda command: "/bin/sh" if command == "sh" else None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.tempfile.NamedTemporaryFile",
+        lambda **_kwargs: FailingTempFile(),
+    )
+
+    result = runner.invoke(app, ["agent"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "disk full" in result.output
+    assert not installer_path.exists()

--- a/packages/prime/tests/test_agent.py
+++ b/packages/prime/tests/test_agent.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+from prime_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+TEST_ENV = {
+    "COLUMNS": "200",
+    "LINES": "50",
+    "PRIME_DISABLE_VERSION_CHECK": "1",
+}
+
+
+class FakeResponse:
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def read(self, _size: int) -> bytes:
+        return b"#!/bin/sh\nexit 0\n"
+
+
+def test_agent_runs_installed_binary_with_passthrough_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.shutil.which",
+        lambda command: "/usr/local/bin/prime-agent" if command == "prime-agent" else None,
+    )
+
+    def fake_run(command: list[str]) -> Any:
+        calls.append(command)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr("prime_cli.commands.agent.subprocess.run", fake_run)
+
+    result = runner.invoke(
+        app,
+        ["agent", "--model", "openai/gpt-5", "review this", "--help"],
+        env=TEST_ENV,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        [
+            "/usr/local/bin/prime-agent",
+            "--model",
+            "openai/gpt-5",
+            "review this",
+            "--help",
+        ]
+    ]
+
+
+def test_agent_installs_then_runs_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    agent_lookups = iter([None, "/new/bin/prime-agent"])
+    calls: list[list[str]] = []
+    installer_paths: list[Path] = []
+
+    def fake_which(command: str) -> str | None:
+        if command == "prime-agent":
+            return next(agent_lookups)
+        if command == "sh":
+            return "/bin/sh"
+        return None
+
+    def fake_run(command: list[str]) -> Any:
+        calls.append(command)
+        if command[0] == "/bin/sh":
+            installer_path = Path(command[1])
+            installer_paths.append(installer_path)
+            assert installer_path.read_bytes() == b"#!/bin/sh\nexit 0\n"
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr("prime_cli.commands.agent.shutil.which", fake_which)
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+    monkeypatch.setattr("prime_cli.commands.agent.subprocess.run", fake_run)
+
+    result = runner.invoke(app, ["agent", "agents"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert "Downloading the installer" in result.output
+    assert calls[0][0] == "/bin/sh"
+    assert calls[1] == ["/new/bin/prime-agent", "agents"]
+    assert installer_paths and not installer_paths[0].exists()
+
+
+def test_agent_propagates_agent_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.shutil.which",
+        lambda command: "/usr/local/bin/prime-agent" if command == "prime-agent" else None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.subprocess.run",
+        lambda _command: type("Result", (), {"returncode": 17})(),
+    )
+
+    result = runner.invoke(app, ["agent", "doctor"], env=TEST_ENV)
+
+    assert result.exit_code == 17, result.output
+
+
+def test_agent_propagates_installer_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.shutil.which",
+        lambda command: "/bin/sh" if command == "sh" else None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.subprocess.run",
+        lambda _command: type("Result", (), {"returncode": 23})(),
+    )
+
+    result = runner.invoke(app, ["agent"], env=TEST_ENV)
+
+    assert result.exit_code == 23, result.output
+
+
+def test_agent_finds_standalone_node_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    standalone_agent = tmp_path / "prime-agent-node" / "current" / "bin" / "prime-agent"
+    standalone_agent.parent.mkdir(parents=True)
+    standalone_agent.touch()
+    calls: list[list[str]] = []
+
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr("prime_cli.commands.agent.shutil.which", lambda _command: None)
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.subprocess.run",
+        lambda command: calls.append(command) or type("Result", (), {"returncode": 0})(),
+    )
+
+    result = runner.invoke(app, ["agent", "doctor"], env=TEST_ENV)
+
+    assert result.exit_code == 0, result.output
+    assert calls == [[str(standalone_agent), "doctor"]]
+
+
+def test_agent_reports_invalid_installer(monkeypatch: pytest.MonkeyPatch) -> None:
+    class InvalidResponse(FakeResponse):
+        def read(self, _size: int) -> bytes:
+            return b"not a shell script"
+
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.shutil.which",
+        lambda command: "/bin/sh" if command == "sh" else None,
+    )
+    monkeypatch.setattr(
+        "prime_cli.commands.agent.urlopen", lambda *_args, **_kwargs: InvalidResponse()
+    )
+
+    result = runner.invoke(app, ["agent"], env=TEST_ENV)
+
+    assert result.exit_code == 1, result.output
+    assert "invalid installer response" in result.output


### PR DESCRIPTION
- prime agent now forwards commands and arguments to an existing prime agent installation.
- missing installations use the verified stable installer and launch immediately after setup.
- added documentation and coverage for passthrough, installation, cleanup, and exit codes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> First-use flow downloads and executes a remote shell installer; risk is reduced by pinned SHA-256, size and shebang checks, but supply-chain or installer updates still need manual hash bumps.
> 
> **Overview**
> Adds **`prime agent`** to the Prime CLI as a Lab command that **replaces the current process** with the `prime-agent` binary and **forwards all trailing arguments** unchanged (Typer is configured with `allow_extra_args` / `ignore_unknown_options`).
> 
> If `prime-agent` is missing, the CLI **downloads a pinned installer** from `app.primeintellect.ai`, verifies **SHA-256**, enforces a **1MB cap** and **`#!/bin/sh`**, runs it via `sh`, then locates the binary on `PATH` or under **`~/.local/share/prime-agent-node/current/bin`** (or `XDG_DATA_HOME`). README documents first-use install.
> 
> Tests cover passthrough, install-then-run, standalone path discovery, checksum/invalid installer failures, installer exit codes, and temp-file cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52367160b4d358d0d414c0cec703b098d1411187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->