### PR TITLE
fix(prime-sandboxes): isolate live-process RPCs on dedicated transports

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/process.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/process.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import Literal
+from typing import Any, Literal
 
 from connectrpc.client import ConnectClient
 from connectrpc.errors import ConnectError
@@ -67,11 +67,13 @@ class AsyncSandboxProcess:
         stream: AsyncIterator[Message],
         write_stdin: _WriteStdin,
         send_signal: _SendSignal,
+        transport: Any = None,
     ) -> None:
         self.stdout = _AsyncProcessStream()
         self.stderr = _AsyncProcessStream()
         self._stream_client = stream_client
         self._stream = stream
+        self._transport = transport
         self._write_stdin = write_stdin
         self._send_process_signal = send_signal
         self._remote_exited = False
@@ -96,8 +98,9 @@ class AsyncSandboxProcess:
         stream: AsyncIterator[Message],
         write_stdin: _WriteStdin,
         send_signal: _SendSignal,
+        transport: Any = None,
     ) -> "AsyncSandboxProcess":
-        process = cls(stream_client, stream, write_stdin, send_signal)
+        process = cls(stream_client, stream, write_stdin, send_signal, transport)
         try:
             await asyncio.shield(process._started)
         except asyncio.CancelledError:
@@ -196,6 +199,12 @@ class AsyncSandboxProcess:
                     APIError("Process closed before its exit status was observed")
                 )
             await self._stream_client.close()
+            # Dropping the dedicated transport tears down this process's
+            # connection outright, so its gateway stream slot is released
+            # even when the stream itself is wedged.
+            if self._transport is not None:
+                with contextlib.suppress(Exception):
+                    await self._transport.aclose()
             self._closed = True
 
     async def _wait_for_exit_event(self) -> bool:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -15,13 +15,13 @@ from typing import Any, Dict, List, Literal, NoReturn, Optional, TypeVar
 
 import aiofiles
 import httpx
-from pyqwest import Client as PyqwestClient
-from pyqwest import HTTPTransport
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import MethodInfo
 from google.protobuf.message import Message
+from pyqwest import Client as PyqwestClient
+from pyqwest import HTTPTransport
 from tenacity import (
     retry,
     retry_if_exception,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1,6 +1,7 @@
 """Sandbox client implementations."""
 
 import asyncio
+import contextlib
 import json
 import os
 import re
@@ -14,6 +15,8 @@ from typing import Any, Dict, List, Literal, NoReturn, Optional, TypeVar
 
 import aiofiles
 import httpx
+from pyqwest import Client as PyqwestClient
+from pyqwest import HTTPTransport
 from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -1999,7 +2002,21 @@ class AsyncSandboxClient:
         gateway_url = auth["gateway_url"].rstrip("/")
         base_url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}"
         headers = {"Authorization": f"Bearer {auth['token']}"}
-        rpc_client = ConnectClient(base_url)
+        # One dedicated HTTP connection per live process. The shared default
+        # transport multiplexes every RPC in the process onto one HTTP/2
+        # connection, and the gateway caps a connection at 100 concurrent
+        # streams. Each live process pins one stream for its whole lifetime,
+        # so accumulated processes starve stdin/signal RPCs into their
+        # deadline (deadline_exceeded) and queue new process streams for
+        # minutes. A private transport keeps a process competing only with
+        # itself; AsyncSandboxProcess releases it on close.
+        try:
+            # pyqwest >= 0.7 leaves system CA trust off for bare transports.
+            transport = HTTPTransport(tls_include_system_certs=True)
+        except TypeError:  # pyqwest 0.6.x trusts system CAs by default
+            transport = HTTPTransport()
+        http_client = PyqwestClient(transport=transport)
+        rpc_client = ConnectClient(base_url, http_client=http_client)
         request = build_command_session_start_request(
             command,
             working_dir,
@@ -2020,6 +2037,7 @@ class AsyncSandboxClient:
                 COMMAND_SESSION_SEND_INPUT_RPC_METHOD,
                 _PROCESS_INPUT_TIMEOUT_MS,
                 "stdin",
+                http_client=http_client,
             )
 
         async def send_signal(pid: int, signal: Literal["terminate", "kill"]) -> None:
@@ -2029,14 +2047,21 @@ class AsyncSandboxClient:
                 COMMAND_SESSION_SEND_SIGNAL_RPC_METHOD,
                 _PROCESS_SIGNAL_TIMEOUT_MS,
                 "signal",
+                http_client=http_client,
             )
 
-        return await AsyncSandboxProcess._create(
-            rpc_client,
-            stream,
-            write_stdin,
-            send_signal,
-        )
+        try:
+            return await AsyncSandboxProcess._create(
+                rpc_client,
+                stream,
+                write_stdin,
+                send_signal,
+                transport=transport,
+            )
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await transport.aclose()
+            raise
 
     async def _execute_process_control_rpc(
         self,
@@ -2045,6 +2070,7 @@ class AsyncSandboxClient:
         method: MethodInfo[_RequestMessage, _ResponseMessage],
         timeout_ms: int,
         operation: str,
+        http_client: Optional[PyqwestClient] = None,
     ) -> None:
         """Run one live-process control RPC with current sandbox auth."""
         reauthed = False
@@ -2053,7 +2079,7 @@ class AsyncSandboxClient:
             gateway_url = auth["gateway_url"].rstrip("/")
             base_url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}"
             headers = {"Authorization": f"Bearer {auth['token']}"}
-            rpc_client = ConnectClient(base_url)
+            rpc_client = ConnectClient(base_url, http_client=http_client)
             try:
                 await rpc_client.execute_unary(
                     request=request,

--- a/packages/prime-sandboxes/tests/test_command_transport_selection.py
+++ b/packages/prime-sandboxes/tests/test_command_transport_selection.py
@@ -154,7 +154,7 @@ async def test_async_open_process_streams_vm_command_session(monkeypatch):
     terminated = asyncio.Event()
 
     class _FakeConnectClient:
-        def __init__(self, address: str):
+        def __init__(self, address: str, *, http_client=None):
             self.address = address
 
         def execute_server_stream(self, **kwargs):


### PR DESCRIPTION
## Problem

`open_process` used pyqwest’s shared HTTP/2 transport. Each live process pins one stream, and the gateway allows 100 streams per connection. At the limit, stdin, signal, and new-process RPCs time out even though the sandbox is healthy.

## Change

- Give each live process its own HTTP transport.
- Send that process’s stdin and signal RPCs over the same transport.
- Close the transport from `AsyncSandboxProcess.aclose()` and on startup failure.
- Support the TLS defaults of both pyqwest 0.6 and 0.7.

## Verification

- Unpatched: the 101st process hangs; with 100 streams pinned, 107/107 control RPCs timed out.
- Patched: 120/120 processes opened and accepted stdin writes.
- Three 60-process open/close cycles returned to the baseline connection count with no leak.
- Command-transport tests: 9 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-process connection lifecycle and increases concurrent gateway connections per client; behavior is localized to VM `open_process` but affects production long-lived agent sessions at scale.
> 
> **Overview**
> Fixes **HTTP/2 stream exhaustion** when many VM **live processes** (`open_process`) stay open: the shared pyqwest transport used one connection per gateway host (100 concurrent streams cap), so each long-lived process stream could block stdin/signal RPCs and new opens.
> 
> **`open_process`** now allocates a **private `HTTPTransport` + `PyqwestClient`** per process, routes stdin/signal through **`_execute_process_control_rpc(..., http_client=...)`**, and closes the transport if startup fails. **`AsyncSandboxProcess`** holds that transport and **`aclose()`** tears it down so wedged streams still release gateway slots. TLS uses **`tls_include_system_certs=True`** on pyqwest ≥ 0.7 with a **0.6.x fallback**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c61073163bcf9b342b342bcc5cf7c14cc10d579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
