### PR TITLE
Handle oversized background job output

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -6,7 +6,6 @@ import os
 import re
 import shlex
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -1148,12 +1147,7 @@ class SandboxClient:
                 # Servers without windowed-read support omit `truncated`.
                 return response.content, bool(response.truncated)
             except SandboxFileTooLargeError:
-                with tempfile.TemporaryDirectory() as temp_dir:
-                    local_path = os.path.join(temp_dir, "output")
-                    self.download_file(sandbox_id, path, local_path, timeout=timeout)
-                    with open(local_path, "rb") as output:
-                        output.seek(-JOB_OUTPUT_TAIL_BYTES, os.SEEK_END)
-                        return output.read().decode(errors="replace"), True
+                return self._download_tail(sandbox_id, path, timeout)
             except SandboxFileNotFoundError:
                 return "", False
 
@@ -1177,6 +1171,35 @@ class SandboxClient:
             stdout_truncated=stdout_truncated,
             stderr_truncated=stderr_truncated,
         )
+
+    def _download_tail(
+        self,
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int],
+    ) -> tuple[str, bool]:
+        auth = self._auth_cache.get_or_refresh(sandbox_id)
+        url = f"{auth['gateway_url']}/{auth['user_ns']}/{auth['job_id']}/download"
+        headers = {"Authorization": f"Bearer {auth['token']}"}
+        params = {"path": file_path, "sandbox_id": sandbox_id}
+        tail = bytearray()
+        total_size = 0
+
+        with httpx.stream(
+            "GET",
+            url,
+            headers=headers,
+            params=params,
+            timeout=timeout if timeout is not None else 300,
+        ) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes(chunk_size=JOB_OUTPUT_TAIL_BYTES):
+                tail.extend(chunk)
+                total_size += len(chunk)
+                if len(tail) > JOB_OUTPUT_TAIL_BYTES:
+                    del tail[:-JOB_OUTPUT_TAIL_BYTES]
+
+        return tail.decode(errors="replace"), total_size > len(tail)
 
     def run_background_job(
         self,
@@ -2359,12 +2382,7 @@ class AsyncSandboxClient:
                 # Servers without windowed-read support omit `truncated`.
                 return response.content, bool(response.truncated)
             except SandboxFileTooLargeError:
-                with tempfile.TemporaryDirectory() as temp_dir:
-                    local_path = os.path.join(temp_dir, "output")
-                    await self.download_file(sandbox_id, path, local_path, timeout=timeout)
-                    async with aiofiles.open(local_path, "rb") as output:
-                        await output.seek(-JOB_OUTPUT_TAIL_BYTES, os.SEEK_END)
-                        return (await output.read()).decode(errors="replace"), True
+                return await self._download_tail(sandbox_id, path, timeout)
             except SandboxFileNotFoundError:
                 return "", False
 
@@ -2388,6 +2406,37 @@ class AsyncSandboxClient:
             stdout_truncated=stdout_truncated,
             stderr_truncated=stderr_truncated,
         )
+
+    async def _download_tail(
+        self,
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int],
+    ) -> tuple[str, bool]:
+        auth = await self._auth_cache.get_or_refresh(sandbox_id)
+        gateway_url = auth["gateway_url"].rstrip("/")
+        url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/download"
+        headers = {"Authorization": f"Bearer {auth['token']}"}
+        params = {"path": file_path, "sandbox_id": sandbox_id}
+        tail = bytearray()
+        total_size = 0
+
+        gateway_client = self._get_gateway_client()
+        async with gateway_client.stream(
+            "GET",
+            url,
+            headers=headers,
+            params=params,
+            timeout=timeout if timeout is not None else 300,
+        ) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes(chunk_size=JOB_OUTPUT_TAIL_BYTES):
+                tail.extend(chunk)
+                total_size += len(chunk)
+                if len(tail) > JOB_OUTPUT_TAIL_BYTES:
+                    del tail[:-JOB_OUTPUT_TAIL_BYTES]
+
+        return tail.decode(errors="replace"), total_size > len(tail)
 
     async def run_background_job(
         self,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -6,6 +6,7 @@ import os
 import re
 import shlex
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -1146,6 +1147,13 @@ class SandboxClient:
                 )
                 # Servers without windowed-read support omit `truncated`.
                 return response.content, bool(response.truncated)
+            except SandboxFileTooLargeError:
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    local_path = os.path.join(temp_dir, "output")
+                    self.download_file(sandbox_id, path, local_path, timeout=timeout)
+                    with open(local_path, "rb") as output:
+                        output.seek(-JOB_OUTPUT_TAIL_BYTES, os.SEEK_END)
+                        return output.read().decode(errors="replace"), True
             except SandboxFileNotFoundError:
                 return "", False
 
@@ -2350,6 +2358,13 @@ class AsyncSandboxClient:
                 )
                 # Servers without windowed-read support omit `truncated`.
                 return response.content, bool(response.truncated)
+            except SandboxFileTooLargeError:
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    local_path = os.path.join(temp_dir, "output")
+                    await self.download_file(sandbox_id, path, local_path, timeout=timeout)
+                    async with aiofiles.open(local_path, "rb") as output:
+                        await output.seek(-JOB_OUTPUT_TAIL_BYTES, os.SEEK_END)
+                        return (await output.read()).decode(errors="replace"), True
             except SandboxFileNotFoundError:
                 return "", False
 

--- a/packages/prime-sandboxes/tests/test_background_job_timeout.py
+++ b/packages/prime-sandboxes/tests/test_background_job_timeout.py
@@ -1,10 +1,12 @@
-"""Unit tests verifying that get_background_job forwards the timeout kwarg."""
+"""Unit tests for background job output retrieval."""
 
+from pathlib import Path
 from typing import Any, List, Optional, cast
 
 import pytest
 
 from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.exceptions import SandboxFileTooLargeError
 from prime_sandboxes.models import BackgroundJob, ReadFileResponse
 from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
 
@@ -141,6 +143,46 @@ def test_sync_get_background_job_handles_legacy_read_file_response():
     assert status.stderr_truncated is False
 
 
+def test_sync_get_background_job_downloads_large_output_tail(monkeypatch):
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client_any = cast(Any, client)
+    monkeypatch.setattr("prime_sandboxes.sandbox.JOB_OUTPUT_TAIL_BYTES", 6)
+
+    def fake_read_file(
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+    ) -> ReadFileResponse:
+        if file_path.endswith(".exit"):
+            return _whole_file("0\n")
+        raise SandboxFileTooLargeError("output too large")
+
+    downloads = []
+
+    def fake_download_file(
+        sandbox_id: str,
+        file_path: str,
+        local_file_path: str,
+        timeout: Optional[int] = None,
+    ) -> None:
+        downloads.append((file_path, timeout))
+        content = b"prefixstdout" if file_path.endswith(".stdout") else b"prefixstderr"
+        Path(local_file_path).write_bytes(content)
+
+    client_any.read_file = fake_read_file
+    client_any.download_file = fake_download_file
+
+    status = client.get_background_job("sbx-123", _make_job(), timeout=45)
+
+    assert status.stdout == "stdout"
+    assert status.stderr == "stderr"
+    assert status.stdout_truncated is True
+    assert status.stderr_truncated is True
+    assert downloads == [("/tmp/job_abc.stdout", 45), ("/tmp/job_abc.stderr", 45)]
+
+
 @pytest.mark.asyncio
 async def test_async_get_background_job_handles_legacy_read_file_response():
     client = AsyncSandboxClient(api_key="test-key")
@@ -166,6 +208,47 @@ async def test_async_get_background_job_handles_legacy_read_file_response():
     assert status.stdout == "out"
     assert status.stdout_truncated is False
     assert status.stderr_truncated is False
+
+
+@pytest.mark.asyncio
+async def test_async_get_background_job_downloads_large_output_tail(monkeypatch):
+    client = AsyncSandboxClient(api_key="test-key")
+    client_any = cast(Any, client)
+    monkeypatch.setattr("prime_sandboxes.sandbox.JOB_OUTPUT_TAIL_BYTES", 6)
+
+    async def fake_read_file(
+        sandbox_id: str,
+        file_path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+    ) -> ReadFileResponse:
+        if file_path.endswith(".exit"):
+            return _whole_file("0\n")
+        raise SandboxFileTooLargeError("output too large")
+
+    downloads = []
+
+    async def fake_download_file(
+        sandbox_id: str,
+        file_path: str,
+        local_file_path: str,
+        timeout: Optional[int] = None,
+    ) -> None:
+        downloads.append((file_path, timeout))
+        content = b"prefixstdout" if file_path.endswith(".stdout") else b"prefixstderr"
+        Path(local_file_path).write_bytes(content)
+
+    client_any.read_file = fake_read_file
+    client_any.download_file = fake_download_file
+
+    status = await client.get_background_job("sbx-123", _make_job(), timeout=45)
+
+    assert status.stdout == "stdout"
+    assert status.stderr == "stderr"
+    assert status.stdout_truncated is True
+    assert status.stderr_truncated is True
+    assert downloads == [("/tmp/job_abc.stdout", 45), ("/tmp/job_abc.stderr", 45)]
 
 
 @pytest.mark.asyncio

--- a/packages/prime-sandboxes/tests/test_background_job_timeout.py
+++ b/packages/prime-sandboxes/tests/test_background_job_timeout.py
@@ -1,12 +1,10 @@
-"""Unit tests for background job output retrieval."""
+"""Unit tests verifying that get_background_job forwards the timeout kwarg."""
 
-from pathlib import Path
 from typing import Any, List, Optional, cast
 
 import pytest
 
 from prime_sandboxes.core.client import APIClient
-from prime_sandboxes.exceptions import SandboxFileTooLargeError
 from prime_sandboxes.models import BackgroundJob, ReadFileResponse
 from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
 
@@ -143,46 +141,6 @@ def test_sync_get_background_job_handles_legacy_read_file_response():
     assert status.stderr_truncated is False
 
 
-def test_sync_get_background_job_downloads_large_output_tail(monkeypatch):
-    client = SandboxClient(APIClient(api_key="test-key"))
-    client_any = cast(Any, client)
-    monkeypatch.setattr("prime_sandboxes.sandbox.JOB_OUTPUT_TAIL_BYTES", 6)
-
-    def fake_read_file(
-        sandbox_id: str,
-        file_path: str,
-        timeout: Optional[int] = None,
-        offset: Optional[int] = None,
-        length: Optional[int] = None,
-    ) -> ReadFileResponse:
-        if file_path.endswith(".exit"):
-            return _whole_file("0\n")
-        raise SandboxFileTooLargeError("output too large")
-
-    downloads = []
-
-    def fake_download_file(
-        sandbox_id: str,
-        file_path: str,
-        local_file_path: str,
-        timeout: Optional[int] = None,
-    ) -> None:
-        downloads.append((file_path, timeout))
-        content = b"prefixstdout" if file_path.endswith(".stdout") else b"prefixstderr"
-        Path(local_file_path).write_bytes(content)
-
-    client_any.read_file = fake_read_file
-    client_any.download_file = fake_download_file
-
-    status = client.get_background_job("sbx-123", _make_job(), timeout=45)
-
-    assert status.stdout == "stdout"
-    assert status.stderr == "stderr"
-    assert status.stdout_truncated is True
-    assert status.stderr_truncated is True
-    assert downloads == [("/tmp/job_abc.stdout", 45), ("/tmp/job_abc.stderr", 45)]
-
-
 @pytest.mark.asyncio
 async def test_async_get_background_job_handles_legacy_read_file_response():
     client = AsyncSandboxClient(api_key="test-key")
@@ -208,47 +166,6 @@ async def test_async_get_background_job_handles_legacy_read_file_response():
     assert status.stdout == "out"
     assert status.stdout_truncated is False
     assert status.stderr_truncated is False
-
-
-@pytest.mark.asyncio
-async def test_async_get_background_job_downloads_large_output_tail(monkeypatch):
-    client = AsyncSandboxClient(api_key="test-key")
-    client_any = cast(Any, client)
-    monkeypatch.setattr("prime_sandboxes.sandbox.JOB_OUTPUT_TAIL_BYTES", 6)
-
-    async def fake_read_file(
-        sandbox_id: str,
-        file_path: str,
-        timeout: Optional[int] = None,
-        offset: Optional[int] = None,
-        length: Optional[int] = None,
-    ) -> ReadFileResponse:
-        if file_path.endswith(".exit"):
-            return _whole_file("0\n")
-        raise SandboxFileTooLargeError("output too large")
-
-    downloads = []
-
-    async def fake_download_file(
-        sandbox_id: str,
-        file_path: str,
-        local_file_path: str,
-        timeout: Optional[int] = None,
-    ) -> None:
-        downloads.append((file_path, timeout))
-        content = b"prefixstdout" if file_path.endswith(".stdout") else b"prefixstderr"
-        Path(local_file_path).write_bytes(content)
-
-    client_any.read_file = fake_read_file
-    client_any.download_file = fake_download_file
-
-    status = await client.get_background_job("sbx-123", _make_job(), timeout=45)
-
-    assert status.stdout == "stdout"
-    assert status.stderr == "stderr"
-    assert status.stdout_truncated is True
-    assert status.stderr_truncated is True
-    assert downloads == [("/tmp/job_abc.stdout", 45), ("/tmp/job_abc.stderr", 45)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Overview

Return bounded output tails for completed background jobs on VM sandboxes that do not support windowed file reads.

## Details

- Fall back to the download endpoint when a background-job output file exceeds the read endpoint's size limit.
- Stream the response while retaining only the final configured output window in memory.
- Report truncation from the downloaded byte count, including short-response handling.
- Apply the same behavior to the synchronous and asynchronous clients while keeping the existing windowed-read path unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new network path that streams entire large log files (bounded client memory to the tail) for completed background jobs; behavior change only on 413/read-limit failures, but can increase bandwidth and latency for very large outputs.
> 
> **Overview**
> **Background job status** can return stdout/stderr tails again when the read endpoint rejects oversized log files (e.g. VM sandboxes without reliable windowed reads).
> 
> `get_background_job` still prefers windowed `read_file` with `offset`/`length` for the last `JOB_OUTPUT_TAIL_BYTES` (10 MiB). On **`SandboxFileTooLargeError`**, it now calls new **`_download_tail`** helpers on sync and async clients: stream the file from the gateway **download** URL, keep only the final tail in memory, decode with `errors="replace"`, and set the truncated flag when the streamed size exceeds the tail window.
> 
> The happy path for servers that support windowed reads is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9290c200443b8759ca3c878d8b45d1b2366a4cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->