### PR TITLE
fix setup commands

### DIFF
--- a/packages/prime/src/prime_cli/lab_setup.py
+++ b/packages/prime/src/prime_cli/lab_setup.py
@@ -1410,7 +1410,7 @@ def _post_setup_call_to_action(options: LabSetupOptions) -> Panel:
         "[bold green]$[/bold green]", "prime eval run my-env -m openai/gpt-5.4-nano -n 5"
     )
     command_table.add_row("[bold green]$[/bold green]", "prime eval view")
-    command_table.add_row("[bold green]$[/bold green]", "prime rl run configs/rl/qwen-3-5.toml")
+    command_table.add_row("[bold green]$[/bold green]", "prime train configs/rl/qwen.toml")
     command_table.add_row(
         "[bold green]$[/bold green]", "prime gepa run my-env -m openai/gpt-5.4-nano"
     )

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -348,7 +348,7 @@ def test_lab_setup_service_emits_post_setup_call_to_action(
     assert "I want to train a model for <my task domain>" in output
     assert "prime env init my-env" in output
     assert "prime eval run my-env -m openai/gpt-5.4-nano -n 5" in output
-    assert "prime rl run configs/rl/qwen-3-5.toml" in output
+    assert "prime train configs/rl/qwen.toml" in output
     assert "prime gepa run my-env -m openai/gpt-5.4-nano" in output
 
 

--- a/packages/prime/tests/test_lab_setup.py
+++ b/packages/prime/tests/test_lab_setup.py
@@ -348,7 +348,7 @@ def test_lab_setup_service_emits_post_setup_call_to_action(
     assert "I want to train a model for <my task domain>" in output
     assert "prime env init my-env" in output
     assert "prime eval run my-env -m openai/gpt-5.4-nano -n 5" in output
-    assert "prime train configs/rl/qwen.toml" in output
+    assert "prime train configs/rl/" in output
     assert "prime gepa run my-env -m openai/gpt-5.4-nano" in output
 
 


### PR DESCRIPTION
`prime lab setup` post setup instructions include telling user to `prime rl run configs/rl/qwen-3-5.toml` but `prime rl` is deprecated and `configs/rl/qwen-3-5.toml` doesnt exist.  

updated command to correct `prime train configs/rl/qwen.toml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and test-only changes to setup guidance; no runtime training or CLI behavior changes.
> 
> **Overview**
> **`prime lab setup`** post-setup “get started” command table now points users at **`prime train configs/rl/qwen.toml`** instead of the deprecated **`prime rl run`** flow and a non-existent **`qwen-3-5.toml`** path.
> 
> The post-setup call-to-action test was updated to assert **`prime train configs/rl/`** appears in the rendered output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe07a558ee6c77602e9e1605b69d33d3d1b1955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->