### PR TITLE
feature: forward arbitrary secrets on full-FT run dispatch

### DIFF
--- a/packages/prime/src/prime_cli/api/training.py
+++ b/packages/prime/src/prime_cli/api/training.py
@@ -146,6 +146,7 @@ def build_payload_from_toml(
     wandb_api_key: Optional[str] = None,
     hf_token: Optional[str] = None,
     gpu_type: Optional[str] = None,
+    secrets: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Build the /v1/training/runs payload from a prime-rl-style TOML dict.
 
@@ -157,7 +158,11 @@ def build_payload_from_toml(
     behaviour as `uv run rl @ rl.toml`.
 
     What stays out of `config`:
-      - secrets (wandb / hf): materialised into a per-run k8s Secret,
+      - secrets (wandb / hf, plus any caller-supplied env vars):
+        materialised into a per-run k8s Secret. WANDB_API_KEY and
+        HF_TOKEN keep their dedicated fields; everything else rides
+        along in `secrets` and the chart projects it onto the pods as
+        `secretKeyRef` env entries,
       - run name: lives on the platform's RFTRun row, not the TOML,
       - team_id: links the RFTRun to a team for billing/access scoping,
       - image_tag: chart-level (which prime-rl image to pull),
@@ -180,4 +185,9 @@ def build_payload_from_toml(
         payload["hfToken"] = hf_token
     if gpu_type:
         payload["gpuType"] = gpu_type
+    # Omit the key entirely when there's nothing to send — the backend
+    # treats absent and empty as the same thing, and an empty map would
+    # otherwise trip its "arbitrary secrets" path for no reason.
+    if secrets:
+        payload["secrets"] = secrets
     return payload

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -975,27 +975,15 @@ def _dispatch_full_finetune_run(
         raise typer.Exit(1)
     secrets = secrets or {}
 
-    # The full-FT backend schema only knows about WANDB_API_KEY and
-    # HF_TOKEN (see platform CreateDedicatedRunRequestBase). Silently
-    # dropping anything else here would launch the run without the
-    # credentials the orchestrator's env needs — the LoRA path forwards
-    # the whole map via env-server pods, but full-FT runs the env inline
-    # in the orchestrator and has no comparable surface today. Reject
-    # loudly instead so the user knows up-front rather than discovering
-    # via a runtime auth error inside a $$$ hosted pod.
-    supported_secret_keys = {"WANDB_API_KEY", "HF_TOKEN"}
-    unsupported = sorted(k for k in secrets if k not in supported_secret_keys)
-    if unsupported:
-        console.print(
-            "[red]Error:[/red] full-FT runs only forward "
-            f"{', '.join(sorted(supported_secret_keys))} today; got "
-            f"unsupported secret(s): {', '.join(unsupported)}."
-        )
-        console.print(
-            "[dim]Drop these from --env-var/--env-file, or wait for "
-            "generic secret forwarding on the dedicated training endpoint.[/dim]"
-        )
-        raise typer.Exit(1)
+    # WANDB_API_KEY and HF_TOKEN keep their dedicated request fields, so
+    # strip them from the freeform map — the backend 422s on reserved
+    # keys rather than letting the same credential arrive by two routes.
+    # Everything else goes over as `secrets` and the chart projects it
+    # onto trainer / inference / orchestrator / env pods. Platform-owned
+    # names (PRIME_API_KEY and friends) are deliberately *not* filtered
+    # here: the backend rejects them by name, which tells the user their
+    # secret was refused instead of silently dropping it.
+    extra_secrets = {k: v for k, v in secrets.items() if k not in ("WANDB_API_KEY", "HF_TOKEN")}
 
     # `image_tag` is chart-level — it picks which prime-rl container build
     # the run pulls. Two ways to set it: `--image-tag` (CLI flag, useful
@@ -1058,6 +1046,7 @@ def _dispatch_full_finetune_run(
         wandb_api_key=secrets.get("WANDB_API_KEY"),
         hf_token=secrets.get("HF_TOKEN"),
         gpu_type=resolved_gpu_type,
+        secrets=extra_secrets,
     )
 
     # `--output json` is a formatting switch: still dispatch the run,

--- a/packages/prime/tests/test_training_payload_secrets.py
+++ b/packages/prime/tests/test_training_payload_secrets.py
@@ -1,0 +1,43 @@
+from prime_cli.api.training import build_payload_from_toml
+
+
+def test_secrets_map_rides_on_the_payload() -> None:
+    payload = build_payload_from_toml(
+        {"trainer": {}},
+        secrets={"OPENAI_API_KEY": "sk-abc", "JUDGE_API_KEY": "j-xyz"},
+    )
+
+    assert payload["secrets"] == {"OPENAI_API_KEY": "sk-abc", "JUDGE_API_KEY": "j-xyz"}
+
+
+def test_secrets_key_omitted_when_empty() -> None:
+    # The backend treats absent and empty the same way, so don't send a
+    # key at all rather than an empty object.
+    assert "secrets" not in build_payload_from_toml({"trainer": {}}, secrets={})
+    assert "secrets" not in build_payload_from_toml({"trainer": {}}, secrets=None)
+    assert "secrets" not in build_payload_from_toml({"trainer": {}})
+
+
+def test_reserved_credentials_keep_their_dedicated_fields() -> None:
+    # WANDB_API_KEY / HF_TOKEN travel as wandbApiKey / hfToken. The
+    # backend 422s on either name inside `secrets`, so the two must not
+    # arrive by both routes.
+    payload = build_payload_from_toml(
+        {"trainer": {}},
+        wandb_api_key="w-1",
+        hf_token="h-1",
+        secrets={"OPENAI_API_KEY": "sk-abc"},
+    )
+
+    assert payload["wandbApiKey"] == "w-1"
+    assert payload["hfToken"] == "h-1"
+    assert payload["secrets"] == {"OPENAI_API_KEY": "sk-abc"}
+
+
+def test_secrets_stay_out_of_the_config_blob() -> None:
+    # `config` is shipped verbatim to the pods as TOML; credentials must
+    # only reach them via the per-run k8s Secret.
+    cfg = {"trainer": {"model": {"name": "Qwen/Qwen3-4B"}}}
+    payload = build_payload_from_toml(cfg, secrets={"OPENAI_API_KEY": "sk-abc"})
+
+    assert "sk-abc" not in str(payload["config"])


### PR DESCRIPTION
Platform [#3596](https://github.com/PrimeIntellect-ai/platform/pull/3596) adds an optional `secrets` map to `POST /api/v1/training/runs`, which the fft chart projects onto the trainer / inference / orchestrator / env pods — but the CLI is the last hop and had no way to send the field, so it rejected anything beyond `WANDB_API_KEY` / `HF_TOKEN` up front.

- Drop the `supported_secret_keys` guard in the full-FT dispatch path
- Add a `secrets` parameter to `build_payload_from_toml`, emitted only when non-empty (backend treats absent and empty the same)
- Forward the collected `--env-var` / `--env-file` map minus `WANDB_API_KEY` and `HF_TOKEN`, which keep their dedicated fields and are reserved server-side
- Platform-owned names (`PRIME_API_KEY` and friends) are deliberately not filtered client-side — the backend rejects them by name, so the user hears about it instead of the secret being silently dropped
- LoRA path is untouched; it already forwards the whole map by a different route

**Do not merge before platform #3596 is in.** The endpoint returns 400 on any non-empty `secrets` until that PR lands alongside the fft chart update. Merging this early just converts a clear CLI-side error into a confusing server-side 400.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential forwarding for hosted training runs, a security-sensitive path, though it mainly wires through an existing platform API and keeps reserved keys on dedicated fields.
> 
> **Overview**
> Full-FT hosted training can now forward **arbitrary secrets** from `--env-var` / `--env-file`, matching the platform's new `secrets` field on `POST /v1/training/runs`.
> 
> Removes the CLI guard that rejected anything beyond `WANDB_API_KEY` / `HF_TOKEN`. Those two still use their dedicated payload fields; everything else is sent as `secrets` (omitted when empty). Platform-owned names are left for the backend to reject explicitly rather than silently dropped.
> 
> Adds unit coverage for payload construction around the new map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313185b8e6fb339bb8e2df8811de1f6f174ae7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->