### PR TITLE
fix: declare pytest-asyncio in prime dev extra

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -53,9 +53,10 @@ prime = "prime_cli.main:run"
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "pytest-asyncio>=1.3.0",
     "ruff>=0.13.1",
     "ty>=0.0.0a6",
-    "types-toml>=0.10.0"
+    "types-toml>=0.10.0",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1367,6 +1367,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-toml" },
@@ -1383,6 +1384,7 @@ requires-dist = [
     { name = "prime-tunnel", editable = "packages/prime-tunnel" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "rich", specifier = ">=13.3.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only change to the dev extra; no runtime or production install impact.
> 
> **Overview**
> Adds **`pytest-asyncio>=1.3.0`** to the `prime` package’s **`dev`** optional dependencies in `packages/prime/pyproject.toml`, with matching updates in **`uv.lock`**.
> 
> This aligns dev installs with existing async tests (e.g. `@pytest.mark.asyncio` in `test_lab_view.py`) so `pip install -e ".[dev]"` / `uv sync` with dev extras reliably includes the asyncio pytest plugin. Also fixes a trailing-comma style tweak on the `types-toml` line in the dev dependency list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e2e5976e420080151b7d194561c15ac8a0044d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->