### PR TITLE
fix(sandboxes): retry transient timeout when launching a background job

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -93,6 +93,13 @@ _LIVE_PROCESS_TIMEOUT_MS = 24 * 60 * 60 * 1000
 _PROCESS_INPUT_TIMEOUT_MS = 30_000
 _PROCESS_SIGNAL_TIMEOUT_MS = 10_000
 
+# A background-job launch is fire-and-forget and returns immediately, so a timeout on it is a
+# transport blip, not a slow command; retry it. (A dead sandbox raises SandboxNotRunningError
+# rather than CommandTimeoutError, so this only retries genuine transport failures.)
+_BG_LAUNCH_TIMEOUT = 30
+_BG_LAUNCH_ATTEMPTS = 3
+_BG_LAUNCH_BACKOFF = 0.5
+
 _RequestMessage = TypeVar("_RequestMessage", bound=Message)
 _ResponseMessage = TypeVar("_ResponseMessage", bound=Message)
 
@@ -1114,7 +1121,14 @@ class SandboxClient:
 
         # Outer nohup redirects to /dev/null since output goes to log files inside sh -c
         bg_cmd = f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
-        self.execute_command(sandbox_id, bg_cmd, timeout=30, user=user)
+        for attempt in range(_BG_LAUNCH_ATTEMPTS):
+            try:
+                self.execute_command(sandbox_id, bg_cmd, timeout=_BG_LAUNCH_TIMEOUT, user=user)
+                break
+            except CommandTimeoutError:
+                if attempt == _BG_LAUNCH_ATTEMPTS - 1:
+                    raise
+                time.sleep(_BG_LAUNCH_BACKOFF * 2**attempt)
 
         return BackgroundJob(
             job_id=job_id,
@@ -2330,7 +2344,14 @@ class AsyncSandboxClient:
 
         # Outer nohup redirects to /dev/null since output goes to log files inside sh -c
         bg_cmd = f"nohup sh -c {quoted_sh_command} < /dev/null > /dev/null 2>&1 &"
-        await self.execute_command(sandbox_id, bg_cmd, timeout=30, user=user)
+        for attempt in range(_BG_LAUNCH_ATTEMPTS):
+            try:
+                await self.execute_command(sandbox_id, bg_cmd, timeout=_BG_LAUNCH_TIMEOUT, user=user)
+                break
+            except CommandTimeoutError:
+                if attempt == _BG_LAUNCH_ATTEMPTS - 1:
+                    raise
+                await asyncio.sleep(_BG_LAUNCH_BACKOFF * 2**attempt)
 
         return BackgroundJob(
             job_id=job_id,

--- a/packages/prime-sandboxes/tests/test_background_job_launch_retry.py
+++ b/packages/prime-sandboxes/tests/test_background_job_launch_retry.py
@@ -1,0 +1,90 @@
+"""start_background_job retries a transient timeout on the fire-and-forget launch."""
+
+from typing import Any, cast
+
+import pytest
+
+from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.exceptions import CommandTimeoutError
+from prime_sandboxes.models import CommandResponse
+from prime_sandboxes.sandbox import (
+    AsyncSandboxClient,
+    SandboxClient,
+    _BG_LAUNCH_ATTEMPTS,
+)
+
+_OK = CommandResponse(stdout="", stderr="", exit_code=0)
+
+
+def _timeout():
+    return CommandTimeoutError("sb", "nohup ...", 30)
+
+
+async def _no_sleep(_):
+    return None
+
+
+class TestSyncLaunchRetry:
+    def test_retries_and_succeeds(self, monkeypatch):
+        monkeypatch.setattr("prime_sandboxes.sandbox.time.sleep", lambda _: None)
+        client = SandboxClient(APIClient(api_key="test-key"))
+        calls = {"n": 0}
+
+        def execute(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] < _BG_LAUNCH_ATTEMPTS:
+                raise _timeout()
+            return _OK
+
+        cast(Any, client).execute_command = execute
+        job = client.start_background_job("sb", "rm -rf x")
+        assert calls["n"] == _BG_LAUNCH_ATTEMPTS
+        assert job.job_id
+
+    def test_gives_up_after_max_attempts(self, monkeypatch):
+        monkeypatch.setattr("prime_sandboxes.sandbox.time.sleep", lambda _: None)
+        client = SandboxClient(APIClient(api_key="test-key"))
+        calls = {"n": 0}
+
+        def execute(*_a, **_k):
+            calls["n"] += 1
+            raise _timeout()
+
+        cast(Any, client).execute_command = execute
+        with pytest.raises(CommandTimeoutError):
+            client.start_background_job("sb", "rm -rf x")
+        assert calls["n"] == _BG_LAUNCH_ATTEMPTS
+
+
+class TestAsyncLaunchRetry:
+    @pytest.mark.asyncio
+    async def test_retries_and_succeeds(self, monkeypatch):
+        monkeypatch.setattr("prime_sandboxes.sandbox.asyncio.sleep", _no_sleep)
+        client = AsyncSandboxClient(APIClient(api_key="test-key"))
+        calls = {"n": 0}
+
+        async def execute(*_a, **_k):
+            calls["n"] += 1
+            if calls["n"] < _BG_LAUNCH_ATTEMPTS:
+                raise _timeout()
+            return _OK
+
+        cast(Any, client).execute_command = execute
+        job = await client.start_background_job("sb", "rm -rf x")
+        assert calls["n"] == _BG_LAUNCH_ATTEMPTS
+        assert job.job_id
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts(self, monkeypatch):
+        monkeypatch.setattr("prime_sandboxes.sandbox.asyncio.sleep", _no_sleep)
+        client = AsyncSandboxClient(APIClient(api_key="test-key"))
+        calls = {"n": 0}
+
+        async def execute(*_a, **_k):
+            calls["n"] += 1
+            raise _timeout()
+
+        cast(Any, client).execute_command = execute
+        with pytest.raises(CommandTimeoutError):
+            await client.start_background_job("sb", "rm -rf x")
+        assert calls["n"] == _BG_LAUNCH_ATTEMPTS


### PR DESCRIPTION
Builds on #831 (live-process transport isolation), now merged into `main` — together they harden VM-sandbox exec reliability under a flaky link.

`start_background_job` submits a fire-and-forget `nohup ... &` through `execute_command` with a 30s timeout and no retry. For a VM sandbox that exec runs over a Connect-RPC whose deadline covers connection setup, so a flaky client↔sandbox link can time out the launch even though the job would have started fine. The `CommandTimeoutError` then propagates as a fatal error and takes down the caller's work (we hit this running agentic rollouts on VM sandboxes from a remote host — setup `uv sync` and per-rollout `rm -rf` cleanup both go through this path).

Since the launch returns immediately, a timeout on it is always a transport blip, so retry it (3 attempts, 0.5s→1s backoff) in both the sync and async clients. A genuinely dead sandbox raises `SandboxNotRunningError` rather than `CommandTimeoutError`, so only transport failures retry; re-issuing the identical command reuses the same job id and log files.

Tests: added unit coverage for retry-then-succeed and exhaust-then-raise (sync + async); existing prime-sandboxes unit suites still pass.
