### PR TITLE
Revert "vm sandbox opt-out"

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -144,7 +144,6 @@ request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
     start_command="python app.py",
-    vm=False,  # string start commands are container-only
     cpu_cores=2,
     memory_gb=4,
     disk_size_gb=20,

--- a/examples/sandbox_async_demo.py
+++ b/examples/sandbox_async_demo.py
@@ -22,7 +22,6 @@ async def main() -> None:
                     name="async-demo-python-1",
                     docker_image="python:3.11-slim",
                     start_command="tail -f /dev/null",
-                    vm=False,  # string start commands are container-only
                     cpu_cores=1,
                     memory_gb=1,
                     timeout_minutes=120,
@@ -31,7 +30,6 @@ async def main() -> None:
                     name="async-demo-node-2",
                     docker_image="node:20-slim",
                     start_command="tail -f /dev/null",
-                    vm=False,  # string start commands are container-only
                     cpu_cores=1,
                     memory_gb=1,
                     timeout_minutes=120,

--- a/examples/sandbox_async_high_volume_demo.py
+++ b/examples/sandbox_async_high_volume_demo.py
@@ -94,7 +94,6 @@ async def main() -> None:
                         name=f"sandbox-{i}",
                         docker_image="python:3.11-slim",
                         start_command="tail -f /dev/null",
-                        vm=False,  # string start commands are container-only
                         cpu_cores=1,
                         memory_gb=1,
                         timeout_minutes=10,

--- a/examples/sandbox_demo.py
+++ b/examples/sandbox_demo.py
@@ -28,7 +28,6 @@ def main() -> None:
             name="demo-sandbox",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",  # Keep container running indefinitely
-            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=120,  # 2 hours to avoid timeout during demo

--- a/examples/sandbox_file_handling_stress_test.py
+++ b/examples/sandbox_file_handling_stress_test.py
@@ -419,7 +419,6 @@ async def main(mode: str = "both") -> None:
             name="file-upload-stress-test",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",
-            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             disk_size_gb=20,  # Ensure enough disk space for tests

--- a/examples/sandbox_file_operations.py
+++ b/examples/sandbox_file_operations.py
@@ -31,7 +31,6 @@ async def main() -> None:
             name="file-operations-demo",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",  # Keep container running
-            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             disk_size_gb=10,
@@ -179,7 +178,6 @@ def sync_example() -> None:
             name="sync-file-demo",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",
-            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=15,

--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -53,7 +53,6 @@ def main() -> None:
             name="port-expose-demo",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",
-            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=30,

--- a/examples/sandbox_tailscale.py
+++ b/examples/sandbox_tailscale.py
@@ -22,7 +22,6 @@ def main() -> None:
             name="sandbox-ssh",
             docker_image="ubuntu:22.04",
             start_command="sleep infinity",
-            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=120,

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -18,7 +18,6 @@ uv pip install prime-sandboxes
 ```
 
 Or with pip:
-
 ```bash
 pip install prime-sandboxes
 ```
@@ -32,8 +31,7 @@ from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest, Star
 client = APIClient(api_key="your-api-key")
 sandbox_client = SandboxClient(client)
 
-# Create a sandbox. Leaving `vm` unset uses the platform default runtime:
-# VM-backed sandboxes (public beta).
+# Create a sandbox
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
@@ -53,15 +51,6 @@ vm = sandbox_client.create(CreateSandboxRequest(
         executable="/worker",
         args=["--platform", "linux/amd64"],
     ),
-))
-
-# Opt out to a container sandbox explicitly with `vm=False` (containers
-# support string start commands, SSH, and port exposure).
-container = sandbox_client.create(CreateSandboxRequest(
-    name="container-workload",
-    docker_image="python:3.11-slim",
-    vm=False,
-    start_command="python -m http.server 8080",
 ))
 
 # Wait for it to be ready

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -202,7 +202,7 @@ class CreateSandboxRequest(BaseModel):
     disk_size_gb: float = 5.0
     gpu_count: int = 0
     gpu_type: Optional[str] = None
-    vm: Optional[bool] = None
+    vm: bool = False
     network_allowlist: Optional[List[str]] = None
     network_denylist: Optional[List[str]] = None
     timeout_minutes: int = 60
@@ -221,53 +221,32 @@ class CreateSandboxRequest(BaseModel):
     def validate_gpu_fields(self) -> "CreateSandboxRequest":
         if self.gpu_count > 0 and not self.gpu_type:
             raise ValueError("gpu_type is required when gpu_count is greater than 0")
-        if self.gpu_count > 0 and self.vm is False:
-            raise ValueError("gpu_count is not supported with vm=False")
+        if self.gpu_count > 0 and not self.vm:
+            raise ValueError("gpu_count is only supported when vm is true")
         if self.gpu_count == 0 and self.gpu_type is not None:
             raise ValueError("gpu_type requires gpu_count greater than 0")
         return self
 
     @model_validator(mode="after")
     def validate_guaranteed(self) -> "CreateSandboxRequest":
-        if self.guaranteed and self.vm is not False:
-            raise ValueError(
-                "guaranteed is not supported for VM sandboxes; pass vm=False "
-                "to create a container sandbox"
-            )
-        return self
-
-    @model_validator(mode="after")
-    def validate_registry_credentials(self) -> "CreateSandboxRequest":
-        if self.registry_credentials_id and self.vm is not False:
-            raise ValueError(
-                "registry_credentials_id is only supported for container "
-                "sandboxes; pass vm=False to create a container sandbox"
-            )
+        if self.guaranteed and self.vm:
+            raise ValueError("guaranteed is not supported for VM sandboxes")
         return self
 
     @model_validator(mode="after")
     def validate_vm_start_command(self) -> "CreateSandboxRequest":
-        if self.vm is False:
+        if self.vm and "start_command" not in self.model_fields_set:
+            self.start_command = None
             return self
-        if "start_command" not in self.model_fields_set:
-            if self.vm is True:
-                self.start_command = None
-            return self
-        if isinstance(self.start_command, str):
-            if self.vm is True:
-                raise ValueError(
-                    "VM sandboxes require start_command as StartCommand(executable=..., args=[...])"
-                )
+        if self.vm and isinstance(self.start_command, str):
             raise ValueError(
-                "String start_command values are container-only. Pass vm=False "
-                "to create a container sandbox, or use "
-                "StartCommand(executable=..., args=[...]) for VM sandboxes."
+                "VM sandboxes require start_command as StartCommand(executable=..., args=[...])"
             )
         return self
 
     @model_validator(mode="after")
     def validate_network_lists(self) -> "CreateSandboxRequest":
-        if self.vm is False and (
+        if not self.vm and (
             self.network_allowlist is not None or self.network_denylist is not None
         ):
             raise ValueError(
@@ -281,11 +260,6 @@ class CreateSandboxRequest(BaseModel):
     def validate_idle_timeout(self) -> "CreateSandboxRequest":
         if self.idle_timeout_minutes is None:
             return self
-        if self.vm is not False:
-            raise ValueError(
-                "idle_timeout_minutes is only supported for container "
-                "sandboxes; pass vm=False to create a container sandbox"
-            )
         if self.idle_timeout_minutes < 1:
             raise ValueError("idle_timeout_minutes must be >= 1")
         if self.timeout_minutes > 0 and self.idle_timeout_minutes > self.timeout_minutes:

--- a/packages/prime-sandboxes/tests/test_egress_policy.py
+++ b/packages/prime-sandboxes/tests/test_egress_policy.py
@@ -44,22 +44,11 @@ class TestCreateSandboxRequestNetworkLists:
         assert "network_access" not in type(request).model_fields
         assert "network_access" not in request.model_dump()
 
-    def test_lists_rejected_with_container_opt_out(self):
+    def test_lists_require_vm(self):
         with pytest.raises(ValidationError, match="only supported for"):
             CreateSandboxRequest(
-                name="t",
-                docker_image="img",
-                vm=False,
-                network_allowlist=["api.example.com"],
+                name="t", docker_image="img", network_allowlist=["api.example.com"]
             )
-
-    def test_lists_accepted_with_unset_vm(self):
-        # Unset vm defers to the platform default runtime (VM), so egress
-        # lists are accepted without an explicit vm=True.
-        request = CreateSandboxRequest(
-            name="t", docker_image="img", network_allowlist=["api.example.com"]
-        )
-        assert request.network_allowlist == ["api.example.com"]
 
     def test_vm_allowlist_accepted(self):
         request = CreateSandboxRequest(

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -25,75 +25,11 @@ def test_create_sandbox_request_defaults():
     assert request.disk_size_gb == 5
     assert request.gpu_count == 0
     assert request.gpu_type is None
-    # Unset vm defers the runtime choice to the server (platform default: VM).
-    assert request.vm is None
+    assert request.vm is False
     assert request.timeout_minutes == 60
     assert request.region is None
     assert request.labels == []
     assert request.start_command == "tail -f /dev/null"
-
-
-def test_unset_vm_is_omitted_from_payload():
-    """Unset vm must be excluded from the API payload so the server default applies."""
-    request = CreateSandboxRequest(
-        name="test-sandbox",
-        docker_image="python:3.11-slim",
-    )
-
-    assert "vm" not in request.model_dump(exclude_none=True)
-
-
-def test_unset_vm_still_serializes_default_start_command():
-    """With vm unset, the container keep-alive default stays on the wire.
-
-    This is deliberate, not a leak: the server is contractually committed to
-    dropping legacy string start commands on the VM path (ingress #3817
-    compat), so a VM-resolved sandbox behaves as if no start command was set.
-    Meanwhile a container-resolved sandbox (SANDBOX_DEFAULT_VM=false rollback,
-    or an older ingress where omitted vm still means container) needs this
-    default — without it the container runs the bare image ENTRYPOINT and
-    typically exits immediately. Do not clear this default for unset vm.
-    """
-    request = CreateSandboxRequest(
-        name="test-sandbox",
-        docker_image="python:3.11-slim",
-    )
-
-    payload = request.model_dump(exclude_none=True)
-    assert payload["start_command"] == "tail -f /dev/null"
-    assert "vm" not in payload
-
-
-def test_explicit_vm_false_is_serialized():
-    """The explicit container opt-out must survive exclude_none serialization."""
-    request = CreateSandboxRequest(
-        name="test-sandbox",
-        docker_image="python:3.11-slim",
-        vm=False,
-    )
-
-    assert request.model_dump(exclude_none=True)["vm"] is False
-
-
-def test_unset_vm_rejects_explicit_string_start_command():
-    """Explicit string start commands are container-only; require vm=False."""
-    with pytest.raises(ValidationError, match="container-only"):
-        CreateSandboxRequest(
-            name="test-sandbox",
-            docker_image="python:3.11-slim",
-            start_command="sleep infinity",
-        )
-
-
-def test_container_opt_out_keeps_explicit_string_start_command():
-    request = CreateSandboxRequest(
-        name="test-sandbox",
-        docker_image="python:3.11-slim",
-        vm=False,
-        start_command="sleep infinity",
-    )
-
-    assert request.start_command == "sleep infinity"
 
 
 def test_vm_start_command_preserves_argv():
@@ -170,29 +106,15 @@ def test_create_sandbox_request_accepts_gpu_type_for_gpu_count():
     assert request.vm is True
 
 
-def test_create_sandbox_request_rejects_gpu_with_container_opt_out():
-    """GPUs conflict with an explicit container opt-out (vm=False)"""
+def test_create_sandbox_request_requires_vm_for_gpu_count():
+    """Test vm is required when gpu_count > 0"""
     with pytest.raises(ValidationError):
         CreateSandboxRequest(
             name="gpu-sandbox",
             docker_image="python:3.11-slim",
             gpu_count=1,
             gpu_type="H100_80GB",
-            vm=False,
         )
-
-
-def test_create_sandbox_request_allows_gpu_with_unset_vm():
-    """Unset vm defers to the platform default (VM), which supports GPUs"""
-    request = CreateSandboxRequest(
-        name="gpu-sandbox",
-        docker_image="python:3.11-slim",
-        gpu_count=1,
-        gpu_type="H100_80GB",
-    )
-
-    assert request.vm is None
-    assert request.gpu_count == 1
 
 
 def test_create_sandbox_request_rejects_gpu_type_without_gpu_count():
@@ -220,76 +142,6 @@ def test_create_sandbox_request_gpu_type_none_matches_default():
 
     assert request_default.gpu_type is None
     assert request_none.gpu_type is None
-
-
-def test_guaranteed_requires_container_opt_out():
-    """guaranteed is container-only; unset vm resolves to VM on the server"""
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="guaranteed-sandbox",
-            docker_image="python:3.11-slim",
-            guaranteed=True,
-        )
-
-    request = CreateSandboxRequest(
-        name="guaranteed-sandbox",
-        docker_image="python:3.11-slim",
-        guaranteed=True,
-        vm=False,
-    )
-    assert request.guaranteed is True
-
-
-def test_registry_credentials_require_container_opt_out():
-    """registry_credentials_id is container-only; unset vm resolves to VM on the server"""
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="private-image-sandbox",
-            docker_image="registry.example.com/private:latest",
-            registry_credentials_id="cred-123",
-        )
-
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="private-image-sandbox",
-            docker_image="registry.example.com/private:latest",
-            registry_credentials_id="cred-123",
-            vm=True,
-        )
-
-    request = CreateSandboxRequest(
-        name="private-image-sandbox",
-        docker_image="registry.example.com/private:latest",
-        registry_credentials_id="cred-123",
-        vm=False,
-    )
-    assert request.registry_credentials_id == "cred-123"
-
-
-def test_idle_timeout_requires_container_opt_out():
-    """idle_timeout_minutes is container-only; unset vm resolves to VM on the server"""
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="idle-sandbox",
-            docker_image="python:3.11-slim",
-            idle_timeout_minutes=10,
-        )
-
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="idle-sandbox",
-            docker_image="python:3.11-slim",
-            idle_timeout_minutes=10,
-            vm=True,
-        )
-
-    request = CreateSandboxRequest(
-        name="idle-sandbox",
-        docker_image="python:3.11-slim",
-        idle_timeout_minutes=10,
-        vm=False,
-    )
-    assert request.idle_timeout_minutes == 10
 
 
 def test_sandbox_status_enum():

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -183,17 +183,17 @@ prime pods terminate <pod-id>
 Isolated environments for running code remotely:
 
 ```bash
-# Create a sandbox (VM-backed by default, public beta)
+# Create a sandbox
 prime sandbox create python:3.11
 
 # Create a VM sandbox with GPUs
 prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
 
-# Create a one-shot VM workload (arguments after -- are preserved exactly)
-prime sandbox create user-1/vm-image:latest -- /worker --platform linux/amd64
+# Create a CPU-only VM sandbox
+prime sandbox create user-1/vm-image:latest --vm
 
-# Opt out to a container sandbox (supports SSH, port exposure, string start commands)
-prime sandbox create python:3.11 --container
+# Create a one-shot VM workload (arguments after -- are preserved exactly)
+prime sandbox create user-1/vm-image:latest --vm -- /worker --platform linux/amd64
 
 # List sandboxes
 prime sandbox list

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -507,7 +507,7 @@ def get(
 def create(
     docker_image: Optional[str] = typer.Argument(
         None,
-        help="Image to run. For VM sandboxes (the default), provide the VM image reference.",
+        help="Image to run. When using --vm, provide the VM image reference.",
     ),
     command: Optional[List[str]] = typer.Argument(
         None,
@@ -523,7 +523,7 @@ def create(
     start_command: Optional[str] = typer.Option(
         None,
         "--start-command",
-        help="Legacy container-only command string (requires --container)",
+        help="Legacy container-only command string",
     ),
     cpu_cores: float = typer.Option(1.0, help="Number of CPU cores"),
     memory_gb: float = typer.Option(1.0, help="Memory in GB"),
@@ -534,14 +534,10 @@ def create(
         "--gpu-type",
         help="GPU type/model (e.g. H100_80GB, A100_80GB). Required when --gpu-count > 0",
     ),
-    vm: Optional[bool] = typer.Option(
-        None,
-        "--vm/--container",
-        help=(
-            "Sandbox runtime. VM-backed sandboxes are the default (public beta); "
-            "pass --container to opt out to a container sandbox. VMs are "
-            "required when requesting GPUs."
-        ),
+    vm: bool = typer.Option(
+        False,
+        "--vm",
+        help="Create a VM-backed sandbox on the VM sandbox infra. Required when requesting GPUs.",
     ),
     network_allow: Optional[List[str]] = typer.Option(
         None,
@@ -600,8 +596,8 @@ def create(
         "--guaranteed",
         help=(
             "Admin/manager only. Schedule with CPU/memory requests equal to limits "
-            "(Guaranteed QoS), bypassing the default oversubscription. Container "
-            "sandboxes only (requires --container)."
+            "(Guaranteed QoS), bypassing the default oversubscription. Not supported "
+            "with --vm."
         ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -629,13 +625,6 @@ def create(
                 key, value = secret_var.split("=", 1)
                 secrets_vars[key] = value
 
-        # Resolve the sandbox runtime. VM is the platform default (public
-        # beta); explicit --vm/--container flags always win. The resolved
-        # value is sent to the API so the created runtime never depends on
-        # server-side defaults changing underneath a deployed CLI.
-        runtime_defaulted = vm is None
-        use_vm = True if runtime_defaulted else vm
-
         if gpu_count > 0 and not gpu_type:
             console.print(
                 "[red]GPU type is required when requesting GPUs.[/red] "
@@ -643,9 +632,9 @@ def create(
             )
             raise typer.Exit(1)
 
-        if gpu_count > 0 and not use_vm:
+        if gpu_count > 0 and not vm:
             console.print(
-                "[red]GPUs require VM sandboxes.[/red] Drop --container when using --gpu-count."
+                "[red]GPUs require VM sandboxes.[/red] Pass --vm whenever using --gpu-count."
             )
             raise typer.Exit(1)
 
@@ -656,44 +645,18 @@ def create(
             )
             raise typer.Exit(1)
 
-        if guaranteed and use_vm:
-            if runtime_defaulted:
-                console.print(
-                    "[red]--guaranteed is only supported for container sandboxes.[/red] "
-                    "Add --container to opt out of the default VM runtime."
-                )
-            else:
-                console.print(
-                    "[red]--guaranteed is not supported for VM sandboxes.[/red] "
-                    "Drop --vm or drop --guaranteed."
-                )
-            raise typer.Exit(1)
-
-        if registry_credentials_id and use_vm:
-            if runtime_defaulted:
-                console.print(
-                    "[red]--registry-credentials-id is only supported for container "
-                    "sandboxes.[/red] Add --container to opt out of the default VM runtime."
-                )
-            else:
-                console.print(
-                    "[red]--registry-credentials-id is not supported for VM sandboxes.[/red] "
-                    "Drop --vm or drop --registry-credentials-id."
-                )
+        if guaranteed and vm:
+            console.print(
+                "[red]--guaranteed is not supported for VM sandboxes.[/red] "
+                "Drop --vm or drop --guaranteed."
+            )
             raise typer.Exit(1)
 
         if idle_timeout_minutes is not None:
-            if use_vm:
-                console.print(
-                    "[yellow]Warning:[/yellow] --idle-timeout-minutes is not supported "
-                    "for VM sandboxes and will be ignored. Add --container to use "
-                    "idle-based termination."
-                )
-                idle_timeout_minutes = None
-            elif idle_timeout_minutes < 1:
+            if idle_timeout_minutes < 1:
                 console.print("[red]--idle-timeout-minutes must be at least 1.[/red]")
                 raise typer.Exit(1)
-            elif timeout_minutes > 0 and idle_timeout_minutes > timeout_minutes:
+            if timeout_minutes > 0 and idle_timeout_minutes > timeout_minutes:
                 console.print(
                     "[red]--idle-timeout-minutes must be <= --timeout-minutes "
                     f"(got idle={idle_timeout_minutes}, lifetime={timeout_minutes}).[/red]"
@@ -711,7 +674,7 @@ def create(
             if gpu_count > 0 and gpu_type:
                 gpu_slug = "".join(c if c.isalnum() or c == "-" else "-" for c in gpu_type.lower())
                 base_name = f"gpu-{'-'.join(filter(None, gpu_slug.split('-')))}"
-            elif use_vm:
+            elif vm:
                 image_parts = docker_image.split("/")[-1].split(":")[0]
                 image_slug = "".join(
                     c if c.isalnum() or c == "-" else "-" for c in image_parts.lower()
@@ -747,11 +710,8 @@ def create(
                 "[red]Error:[/red] --network-allow and --network-deny are mutually exclusive"
             )
             raise typer.Exit(1)
-        if (network_allow is not None or network_deny is not None) and not use_vm:
-            console.print(
-                "[red]Error:[/red] --network-allow/--network-deny require a VM "
-                "sandbox; drop --container"
-            )
+        if (network_allow is not None or network_deny is not None) and not vm:
+            console.print("[red]Error:[/red] --network-allow/--network-deny require --vm")
             raise typer.Exit(1)
 
         if command and start_command is not None:
@@ -760,18 +720,11 @@ def create(
                 "or --start-command, not both"
             )
             raise typer.Exit(1)
-        if use_vm and start_command is not None:
-            if runtime_defaulted:
-                console.print(
-                    "[red]Error:[/red] --start-command is legacy container-only syntax. "
-                    "Pass an executable after '--' for VM sandboxes (the default), "
-                    "or add --container to create a container sandbox."
-                )
-            else:
-                console.print(
-                    "[red]Error:[/red] --start-command is legacy container-only syntax. "
-                    "For VMs, pass an executable after '--'."
-                )
+        if vm and start_command is not None:
+            console.print(
+                "[red]Error:[/red] --start-command is legacy container-only syntax. "
+                "For VMs, pass an executable after '--'."
+            )
             raise typer.Exit(1)
 
         resolved_start_command: StartCommand | str | None
@@ -782,7 +735,7 @@ def create(
             )
         elif start_command is not None:
             resolved_start_command = start_command
-        elif use_vm:
+        elif vm:
             resolved_start_command = None
         else:
             # Preserve the existing long-running default for container callers.
@@ -797,7 +750,7 @@ def create(
             disk_size_gb=disk_size_gb,
             gpu_count=gpu_count,
             gpu_type=gpu_type,
-            vm=use_vm,
+            vm=vm,
             network_allowlist=network_allow,
             network_denylist=network_deny,
             timeout_minutes=timeout_minutes,
@@ -819,8 +772,7 @@ def create(
         console.print(f"Resources: {cpu_cores} CPU, {memory_gb}GB RAM, {disk_size_gb}GB disk")
         if guaranteed:
             console.print("Scheduling: [green]Guaranteed QoS[/green]")
-        runtime_label = "VM (default)" if runtime_defaulted else ("VM" if use_vm else "Container")
-        console.print(f"Runtime: {runtime_label}")
+        console.print(f"VM: {'Enabled' if vm else 'Disabled'}")
         if gpu_count > 0:
             console.print(f"GPUs: {gpu_type} x{gpu_count}")
         if network_allow is not None:

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -338,7 +338,7 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "Successfully created sandbox sbx-gpu-123" in output
-    assert "Runtime: VM" in output
+    assert "VM: Enabled" in output
     assert "GPUs: H100_80GB x1" in output
     assert "Docker Image: team-1/gpu-runtime:v1" in output
     assert captured["request"].docker_image == "team-1/gpu-runtime:v1"
@@ -428,37 +428,11 @@ def test_sandbox_create_container_keeps_legacy_default(
 
     result = runner.invoke(
         app,
-        ["sandbox", "create", "python:3.12", "--container", "--yes"],
-    )
-
-    assert result.exit_code == 0, result.output
-    assert captured["request"].vm is False
-    assert captured["request"].start_command == "tail -f /dev/null"
-
-
-def test_sandbox_create_defaults_to_vm_runtime(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Without --vm/--container the CLI resolves the runtime to VM."""
-    _configure_cli(monkeypatch)
-    captured: dict[str, Any] = {}
-
-    def mock_create(self: Any, request: Any) -> Any:
-        captured["request"] = request
-        return SimpleNamespace(id="sbx-default-vm")
-
-    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
-
-    result = runner.invoke(
-        app,
         ["sandbox", "create", "python:3.12", "--yes"],
     )
 
-    output = strip_ansi(result.output)
     assert result.exit_code == 0, result.output
-    assert "Runtime: VM (default)" in output
-    assert captured["request"].vm is True
-    assert captured["request"].start_command is None
+    assert captured["request"].start_command == "tail -f /dev/null"
 
 
 def test_sandbox_create_container_keeps_explicit_empty_legacy_command(
@@ -475,37 +449,11 @@ def test_sandbox_create_container_keeps_explicit_empty_legacy_command(
 
     result = runner.invoke(
         app,
-        ["sandbox", "create", "python:3.12", "--container", "--start-command", "", "--yes"],
+        ["sandbox", "create", "python:3.12", "--start-command", "", "--yes"],
     )
 
     assert result.exit_code == 0, result.output
     assert captured["request"].start_command == ""
-
-
-def test_sandbox_create_rejects_start_command_for_default_vm_runtime(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """--start-command without --container must fail with opt-out guidance."""
-    _configure_cli(monkeypatch)
-    called = False
-
-    def mock_create(self: Any, request: Any) -> Any:
-        nonlocal called
-        called = True
-        return SimpleNamespace(id="sbx-should-not-create")
-
-    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
-
-    result = runner.invoke(
-        app,
-        ["sandbox", "create", "python:3.12", "--start-command", "sleep infinity", "--yes"],
-    )
-
-    output = strip_ansi(result.output)
-    assert result.exit_code == 1
-    assert "container-only" in output
-    assert "--container" in output
-    assert called is False
 
 
 def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -535,7 +483,7 @@ def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch
 
     output = strip_ansi(result.output)
     assert result.exit_code == 1
-    assert "Docker image is required." in output
+    assert "GPUs require VM sandboxes." in output
     assert "Successfully created sandbox" not in output
     assert "request" not in captured
 
@@ -631,10 +579,7 @@ def test_sandbox_create_requires_gpu_type(monkeypatch: pytest.MonkeyPatch) -> No
     assert called is False
 
 
-def test_sandbox_create_rejects_gpu_with_container_opt_out(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """GPUs conflict with an explicit --container opt-out."""
+def test_sandbox_create_requires_vm_for_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
 
@@ -653,7 +598,6 @@ def test_sandbox_create_rejects_gpu_with_container_opt_out(
             "sandbox",
             "create",
             "python:3.11-slim",
-            "--container",
             "--gpu-count",
             "1",
             "--gpu-type",
@@ -666,42 +610,6 @@ def test_sandbox_create_rejects_gpu_with_container_opt_out(
     assert result.exit_code == 1
     assert "GPUs require VM sandboxes." in output
     assert called is False
-
-
-def test_sandbox_create_gpu_with_defaulted_vm_runtime(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """GPU requests work without an explicit --vm now that VM is the default."""
-    monkeypatch.setenv("PRIME_API_KEY", "dummy")
-    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
-
-    captured: dict[str, Any] = {}
-
-    def mock_create(self: Any, request: Any) -> Any:
-        captured["request"] = request
-        return SimpleNamespace(id="sbx-gpu-default-vm")
-
-    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
-
-    result = runner.invoke(
-        app,
-        [
-            "sandbox",
-            "create",
-            "python:3.11-slim",
-            "--gpu-count",
-            "1",
-            "--gpu-type",
-            "H100_80GB",
-            "--yes",
-        ],
-    )
-
-    output = strip_ansi(result.output)
-    assert result.exit_code == 0, f"Failed: {result.output}"
-    assert "Successfully created sandbox sbx-gpu-default-vm" in output
-    assert captured["request"].vm is True
-    assert captured["request"].gpu_count == 1
 
 
 def test_sandbox_create_rejects_gpu_type_without_count(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Reverts PrimeIntellect-ai/prime#820

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores prior default-runtime semantics and changes API payloads (explicit vm=false); scripts or CLIs written for VM-as-default may create the wrong sandbox type until updated.
> 
> **Overview**
> Reverts the **VM-by-default / `--container` opt-out** sandbox UX from PR #820. Sandboxes are **container-backed unless `--vm` is set** again.
> 
> **SDK (`CreateSandboxRequest`)**: `vm` goes from optional `None` (omit from API, defer to server) to **`vm: bool = False`**, so creates typically send **`vm: false`**. Validators are simplified: GPUs and egress lists require **`vm=True`**; **`guaranteed`** conflicts with VM only; **`registry_credentials_id`** and VM-only **`idle_timeout_minutes`** guards tied to “must pass `vm=False`” are removed. Examples and README drop explicit `vm=False` and container opt-out docs.
> 
> **CLI**: `--vm/--container` becomes **`--vm` only** (default off). Create summary shows **“VM: Enabled/Disabled”** instead of “Runtime: VM (default)”. GPU without `--vm` fails locally; tests drop default-VM and `--container` cases.
> 
> **Risk**: Callers who relied on **omitted `vm` → server VM default** or **GPU without `--vm`** will get **containers** unless they pass **`--vm` / `vm=True`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e807b3458658f77afd5b51741cbac79badd564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->