### PR TITLE
Revert "Revert "vm sandbox opt-out""

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,15 +258,17 @@ uv run pytest packages/prime/tests
 uv run pytest packages/prime-sandboxes/tests
 ```
 
-All packages (prime-core, prime-sandboxes, prime) are installed in editable mode. Changes to code are immediately reflected.
+All workspace packages (`prime`, `prime-sandboxes`, `prime-evals`, `prime-tunnel`) are installed in editable mode. Changes to code are immediately reflected.
 
 ### Releasing
 
-This monorepo contains two independently versioned packages: `prime` (CLI + full SDK) and `prime-sandboxes` (lightweight SDK).
+This monorepo contains independently versioned packages: `prime` (CLI + full SDK), `prime-sandboxes`, `prime-evals`, and `prime-tunnel` (lightweight SDKs).
 
 Versions are single-sourced from each package's `__init__.py` file:
 - **prime**: `packages/prime/src/prime_cli/__init__.py`
 - **prime-sandboxes**: `packages/prime-sandboxes/src/prime_sandboxes/__init__.py`
+- **prime-evals**: `packages/prime-evals/src/prime_evals/__init__.py`
+- **prime-tunnel**: `packages/prime-tunnel/src/prime_tunnel/__init__.py`
 
 #### To release a new version:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -137,7 +137,8 @@ from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest, Star
 client = APIClient()
 sandbox_client = SandboxClient(client)
 
-# Create sandbox
+# Create sandbox. Leaving `vm` unset uses the platform default runtime:
+# VM-backed sandboxes (public beta).
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
@@ -154,22 +155,25 @@ sandbox = sandbox_client.create(request)
 print(f"Created sandbox: {sandbox.id}")
 ```
 
-VM sandboxes are opt-in with `vm=True`. They take a structured argv start command
-(`StartCommand`) instead of a command string, and support GPUs and network rules:
+VM sandboxes take a structured argv start command (`StartCommand`) instead of a command
+string, and support GPUs and network rules:
 
 ```python
 vm_request = CreateSandboxRequest(
     name="my-vm-sandbox",
     docker_image="user-1/vm-image:latest",
-    vm=True,
+    vm=True,  # redundant with the default, but explicit for VM-only features
     start_command=StartCommand(executable="python", args=["serve.py", "--port", "8000"]),
     gpu_count=1,
-    gpu_type="RTX_PRO_6000",  # required when gpu_count > 0; GPUs require vm=True
+    gpu_type="RTX_PRO_6000",  # required when gpu_count > 0
     network_allowlist=["api.openai.com"],  # mutually exclusive with network_denylist
 )
 
 vm = sandbox_client.create(vm_request)
 ```
+
+Pass `vm=False` for a container sandbox, which is currently the only runtime that supports
+SSH, port exposure, string start commands, idle timeout, and private-registry credentials.
 
 ### CLI Command Reference
 
@@ -180,18 +184,18 @@ prime sandbox list [--team-id TEAM] [--status STATUS] [--label LABEL] [--page N]
 # Create sandbox
 prime sandbox create IMAGE [OPTIONS]
 
-# Create VM sandbox with GPUs (GPUs require --vm, and --gpu-type when --gpu-count > 0)
+# Opt out to a container sandbox (SSH, port exposure, string start commands, idle timeout)
+prime sandbox create python:3.11-slim --container
+
+# Create VM sandbox with GPUs (--gpu-type is required when --gpu-count > 0)
 prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type RTX_PRO_6000
 
-# Create CPU-only VM sandbox
-prime sandbox create user-1/vm-image:latest --vm
-
 # VM start command: each argv token is separate after --, no shell is involved
-prime sandbox create user-1/vm-image:latest --vm -- python serve.py --port 8000
+prime sandbox create user-1/vm-image:latest -- python serve.py --port 8000
 
-# Restrict VM egress (--network-allow/--network-deny are VM only, repeatable, mutually exclusive)
-prime sandbox create user-1/vm-image:latest --vm --network-allow api.openai.com
-prime sandbox create user-1/vm-image:latest --vm --network-deny 0.0.0.0/0
+# Restrict egress (--network-allow/--network-deny are repeatable and mutually exclusive)
+prime sandbox create user-1/vm-image:latest --network-allow api.openai.com
+prime sandbox create user-1/vm-image:latest --network-deny 0.0.0.0/0
 
 # With environment variables and secrets:
 prime sandbox create python:3.11-slim --env KEY=VALUE --secret API_KEY=secret123
@@ -205,7 +209,7 @@ prime sandbox run SANDBOX_ID -- python script.py
 # Get sandbox details
 prime sandbox get SANDBOX_ID [--output json]
 
-# Show or replace VM network rules (VM only)
+# Show or replace network rules (not available on container sandboxes)
 prime sandbox network SANDBOX_ID
 prime sandbox network SANDBOX_ID --allow api.openai.com,10.0.0.0/8
 
@@ -237,7 +241,7 @@ prime images push myapp:v1.0.0 --context ./app --dockerfile ./app/Dockerfile
 # Copy an existing public image into Prime instead of building
 prime images push myubuntu:22.04 --source-image ubuntu:22.04
 
-# Pre-build the VM artifact for an existing image (otherwise the first --vm
+# Pre-build the VM artifact for an existing image (otherwise the first VM
 # sandbox using that image triggers a one-time conversion)
 prime images build-vm myapp:v1.0.0
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -144,6 +144,7 @@ request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
     start_command="python app.py",
+    vm=False,  # string start commands are container-only
     cpu_cores=2,
     memory_gb=4,
     disk_size_gb=20,

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,8 +92,7 @@ uv run python examples/sandbox_file_handling_stress_test.py concurrent
 
 - Creating sandboxes with custom configurations
 - Listing and filtering sandboxes
-- Getting detailed sandbox information
-- Updating sandbox settings
+- Executing commands in a sandbox
 - Retrieving logs
 - Deleting sandboxes
 - Error handling
@@ -132,8 +131,7 @@ This example is useful for:
 ### Creating Sandboxes Programmatically
 
 ```python
-from prime_core import APIClient
-from prime_sandboxes import SandboxClient, CreateSandboxRequest
+from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest, StartCommand
 
 # Initialize client
 client = APIClient()
@@ -143,55 +141,118 @@ sandbox_client = SandboxClient(client)
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
-    start_command="python app.py",
-    vm=False,  # string start commands are container-only
     cpu_cores=2,
     memory_gb=4,
     disk_size_gb=20,
-    gpu_count=0,
-    gpu_type=None,
     timeout_minutes=60,
     environment_vars={"ENV": "production"},
     secrets={"API_KEY": "your-secret-key"},
-    team_id=None  # Use None for personal account
+    team_id=None,  # Use None for personal account
 )
 
 sandbox = sandbox_client.create(request)
 print(f"Created sandbox: {sandbox.id}")
 ```
 
+VM sandboxes are opt-in with `vm=True`. They take a structured argv start command
+(`StartCommand`) instead of a command string, and support GPUs and network rules:
+
+```python
+vm_request = CreateSandboxRequest(
+    name="my-vm-sandbox",
+    docker_image="user-1/vm-image:latest",
+    vm=True,
+    start_command=StartCommand(executable="python", args=["serve.py", "--port", "8000"]),
+    gpu_count=1,
+    gpu_type="RTX_PRO_6000",  # required when gpu_count > 0; GPUs require vm=True
+    network_allowlist=["api.openai.com"],  # mutually exclusive with network_denylist
+)
+
+vm = sandbox_client.create(vm_request)
+```
+
 ### CLI Command Reference
 
 ```bash
 # List sandboxes
-prime sandbox list [--team_id TEAM] [--status STATUS] [--page N] [--per_page N]
+prime sandbox list [--team-id TEAM] [--status STATUS] [--label LABEL] [--page N] [--num N] [--all]
 
 # Create sandbox
 prime sandbox create IMAGE [OPTIONS]
 
-# Create VM sandbox with GPUs
-prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
+# Create VM sandbox with GPUs (GPUs require --vm, and --gpu-type when --gpu-count > 0)
+prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type RTX_PRO_6000
 
 # Create CPU-only VM sandbox
 prime sandbox create user-1/vm-image:latest --vm
 
+# VM start command: each argv token is separate after --, no shell is involved
+prime sandbox create user-1/vm-image:latest --vm -- python serve.py --port 8000
+
+# Restrict VM egress (--network-allow/--network-deny are VM only, repeatable, mutually exclusive)
+prime sandbox create user-1/vm-image:latest --vm --network-allow api.openai.com
+prime sandbox create user-1/vm-image:latest --vm --network-deny 0.0.0.0/0
+
 # With environment variables and secrets:
 prime sandbox create python:3.11-slim --env KEY=VALUE --secret API_KEY=secret123
+
+# Other create options: --name, --cpu-cores, --memory-gb, --disk-size-gb,
+# --timeout-minutes, --idle-timeout-minutes, --team-id, --region, --label, --yes
 
 # Run command in sandbox
 prime sandbox run SANDBOX_ID -- python script.py
 
 # Get sandbox details
-prime sandbox get SANDBOX_ID
+prime sandbox get SANDBOX_ID [--output json]
 
-# Update sandbox
-prime sandbox update SANDBOX_ID [OPTIONS]
+# Show or replace VM network rules (VM only)
+prime sandbox network SANDBOX_ID
+prime sandbox network SANDBOX_ID --allow api.openai.com,10.0.0.0/8
 
-# Delete sandbox
+# Delete sandboxes (by ID, by label, or all)
 prime sandbox delete SANDBOX_ID
+prime sandbox delete --label experiment-1
+prime sandbox delete --all --yes
 
 # Get logs
 prime sandbox logs SANDBOX_ID
+
+# Upload/download files
+prime sandbox upload SANDBOX_ID local_file.py /remote/path/file.py
+prime sandbox download SANDBOX_ID /remote/file.txt ./local/file.txt
+
+# Expose ports and SSH (container sandboxes)
+prime sandbox expose SANDBOX_ID 8000 [--protocol HTTP|TCP]
+prime sandbox list-ports [SANDBOX_ID]
+prime sandbox unexpose SANDBOX_ID EXPOSURE_ID
+prime sandbox ssh SANDBOX_ID
+```
+
+### Image Command Reference
+
+```bash
+# Build and push an image from a Dockerfile (linux/amd64 by default)
+prime images push myapp:v1.0.0 --context ./app --dockerfile ./app/Dockerfile
+
+# Copy an existing public image into Prime instead of building
+prime images push myubuntu:22.04 --source-image ubuntu:22.04
+
+# Pre-build the VM artifact for an existing image (otherwise the first --vm
+# sandbox using that image triggers a one-time conversion)
+prime images build-vm myapp:v1.0.0
+
+# List images
+prime images list [--search TERM] [--page N] [--num N] [--output json]
+
+# Change visibility
+prime images publish myapp:v1.0.0
+prime images unpublish myapp:v1.0.0
+
+# Rename, retag, or move an image
+prime images update myapp:v1 --name myapp-final --tag v2
+
+# Delete an image
+prime images delete myapp:v1.0.0 --yes
 ```
 
 ## Error Handling

--- a/examples/sandbox_async_demo.py
+++ b/examples/sandbox_async_demo.py
@@ -22,6 +22,7 @@ async def main() -> None:
                     name="async-demo-python-1",
                     docker_image="python:3.11-slim",
                     start_command="tail -f /dev/null",
+                    vm=False,  # string start commands are container-only
                     cpu_cores=1,
                     memory_gb=1,
                     timeout_minutes=120,
@@ -30,6 +31,7 @@ async def main() -> None:
                     name="async-demo-node-2",
                     docker_image="node:20-slim",
                     start_command="tail -f /dev/null",
+                    vm=False,  # string start commands are container-only
                     cpu_cores=1,
                     memory_gb=1,
                     timeout_minutes=120,

--- a/examples/sandbox_async_high_volume_demo.py
+++ b/examples/sandbox_async_high_volume_demo.py
@@ -94,6 +94,7 @@ async def main() -> None:
                         name=f"sandbox-{i}",
                         docker_image="python:3.11-slim",
                         start_command="tail -f /dev/null",
+                        vm=False,  # string start commands are container-only
                         cpu_cores=1,
                         memory_gb=1,
                         timeout_minutes=10,

--- a/examples/sandbox_demo.py
+++ b/examples/sandbox_demo.py
@@ -28,6 +28,7 @@ def main() -> None:
             name="demo-sandbox",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",  # Keep container running indefinitely
+            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=120,  # 2 hours to avoid timeout during demo

--- a/examples/sandbox_file_handling_stress_test.py
+++ b/examples/sandbox_file_handling_stress_test.py
@@ -419,6 +419,7 @@ async def main(mode: str = "both") -> None:
             name="file-upload-stress-test",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",
+            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             disk_size_gb=20,  # Ensure enough disk space for tests

--- a/examples/sandbox_file_operations.py
+++ b/examples/sandbox_file_operations.py
@@ -31,6 +31,7 @@ async def main() -> None:
             name="file-operations-demo",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",  # Keep container running
+            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             disk_size_gb=10,
@@ -178,6 +179,7 @@ def sync_example() -> None:
             name="sync-file-demo",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",
+            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=15,

--- a/examples/sandbox_port_expose_demo.py
+++ b/examples/sandbox_port_expose_demo.py
@@ -53,6 +53,7 @@ def main() -> None:
             name="port-expose-demo",
             docker_image="python:3.11-slim",
             start_command="tail -f /dev/null",
+            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=30,

--- a/examples/sandbox_tailscale.py
+++ b/examples/sandbox_tailscale.py
@@ -22,6 +22,7 @@ def main() -> None:
             name="sandbox-ssh",
             docker_image="ubuntu:22.04",
             start_command="sleep infinity",
+            vm=False,  # string start commands are container-only
             cpu_cores=1,
             memory_gb=2,
             timeout_minutes=120,

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -18,6 +18,7 @@ uv pip install prime-sandboxes
 ```
 
 Or with pip:
+
 ```bash
 pip install prime-sandboxes
 ```
@@ -31,7 +32,8 @@ from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest, Star
 client = APIClient(api_key="your-api-key")
 sandbox_client = SandboxClient(client)
 
-# Create a sandbox
+# Create a sandbox. Leaving `vm` unset uses the platform default runtime:
+# VM-backed sandboxes (public beta).
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
@@ -51,6 +53,15 @@ vm = sandbox_client.create(CreateSandboxRequest(
         executable="/worker",
         args=["--platform", "linux/amd64"],
     ),
+))
+
+# Opt out to a container sandbox explicitly with `vm=False` (containers
+# support string start commands, SSH, and port exposure).
+container = sandbox_client.create(CreateSandboxRequest(
+    name="container-workload",
+    docker_image="python:3.11-slim",
+    vm=False,
+    start_command="python -m http.server 8080",
 ))
 
 # Wait for it to be ready

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -198,9 +198,9 @@ for s in sandboxes.sandboxes:
 Use `start_background_job` to run long-running tasks that continue after the API call returns. Poll for completion with `get_background_job`.
 
 ```python
-from prime_sandboxes import SandboxClient, CreateSandboxRequest
+from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest
 
-sandbox_client = SandboxClient()
+sandbox_client = SandboxClient(APIClient())
 
 # Create sandbox with extended timeout
 sandbox = sandbox_client.create(CreateSandboxRequest(

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -202,7 +202,7 @@ class CreateSandboxRequest(BaseModel):
     disk_size_gb: float = 5.0
     gpu_count: int = 0
     gpu_type: Optional[str] = None
-    vm: bool = False
+    vm: Optional[bool] = None
     network_allowlist: Optional[List[str]] = None
     network_denylist: Optional[List[str]] = None
     timeout_minutes: int = 60
@@ -221,32 +221,53 @@ class CreateSandboxRequest(BaseModel):
     def validate_gpu_fields(self) -> "CreateSandboxRequest":
         if self.gpu_count > 0 and not self.gpu_type:
             raise ValueError("gpu_type is required when gpu_count is greater than 0")
-        if self.gpu_count > 0 and not self.vm:
-            raise ValueError("gpu_count is only supported when vm is true")
+        if self.gpu_count > 0 and self.vm is False:
+            raise ValueError("gpu_count is not supported with vm=False")
         if self.gpu_count == 0 and self.gpu_type is not None:
             raise ValueError("gpu_type requires gpu_count greater than 0")
         return self
 
     @model_validator(mode="after")
     def validate_guaranteed(self) -> "CreateSandboxRequest":
-        if self.guaranteed and self.vm:
-            raise ValueError("guaranteed is not supported for VM sandboxes")
+        if self.guaranteed and self.vm is not False:
+            raise ValueError(
+                "guaranteed is not supported for VM sandboxes; pass vm=False "
+                "to create a container sandbox"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_registry_credentials(self) -> "CreateSandboxRequest":
+        if self.registry_credentials_id and self.vm is not False:
+            raise ValueError(
+                "registry_credentials_id is only supported for container "
+                "sandboxes; pass vm=False to create a container sandbox"
+            )
         return self
 
     @model_validator(mode="after")
     def validate_vm_start_command(self) -> "CreateSandboxRequest":
-        if self.vm and "start_command" not in self.model_fields_set:
-            self.start_command = None
+        if self.vm is False:
             return self
-        if self.vm and isinstance(self.start_command, str):
+        if "start_command" not in self.model_fields_set:
+            if self.vm is True:
+                self.start_command = None
+            return self
+        if isinstance(self.start_command, str):
+            if self.vm is True:
+                raise ValueError(
+                    "VM sandboxes require start_command as StartCommand(executable=..., args=[...])"
+                )
             raise ValueError(
-                "VM sandboxes require start_command as StartCommand(executable=..., args=[...])"
+                "String start_command values are container-only. Pass vm=False "
+                "to create a container sandbox, or use "
+                "StartCommand(executable=..., args=[...]) for VM sandboxes."
             )
         return self
 
     @model_validator(mode="after")
     def validate_network_lists(self) -> "CreateSandboxRequest":
-        if not self.vm and (
+        if self.vm is False and (
             self.network_allowlist is not None or self.network_denylist is not None
         ):
             raise ValueError(
@@ -260,6 +281,11 @@ class CreateSandboxRequest(BaseModel):
     def validate_idle_timeout(self) -> "CreateSandboxRequest":
         if self.idle_timeout_minutes is None:
             return self
+        if self.vm is not False:
+            raise ValueError(
+                "idle_timeout_minutes is only supported for container "
+                "sandboxes; pass vm=False to create a container sandbox"
+            )
         if self.idle_timeout_minutes < 1:
             raise ValueError("idle_timeout_minutes must be >= 1")
         if self.timeout_minutes > 0 and self.idle_timeout_minutes > self.timeout_minutes:

--- a/packages/prime-sandboxes/tests/test_egress_policy.py
+++ b/packages/prime-sandboxes/tests/test_egress_policy.py
@@ -44,11 +44,22 @@ class TestCreateSandboxRequestNetworkLists:
         assert "network_access" not in type(request).model_fields
         assert "network_access" not in request.model_dump()
 
-    def test_lists_require_vm(self):
+    def test_lists_rejected_with_container_opt_out(self):
         with pytest.raises(ValidationError, match="only supported for"):
             CreateSandboxRequest(
-                name="t", docker_image="img", network_allowlist=["api.example.com"]
+                name="t",
+                docker_image="img",
+                vm=False,
+                network_allowlist=["api.example.com"],
             )
+
+    def test_lists_accepted_with_unset_vm(self):
+        # Unset vm defers to the platform default runtime (VM), so egress
+        # lists are accepted without an explicit vm=True.
+        request = CreateSandboxRequest(
+            name="t", docker_image="img", network_allowlist=["api.example.com"]
+        )
+        assert request.network_allowlist == ["api.example.com"]
 
     def test_vm_allowlist_accepted(self):
         request = CreateSandboxRequest(

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -25,11 +25,75 @@ def test_create_sandbox_request_defaults():
     assert request.disk_size_gb == 5
     assert request.gpu_count == 0
     assert request.gpu_type is None
-    assert request.vm is False
+    # Unset vm defers the runtime choice to the server (platform default: VM).
+    assert request.vm is None
     assert request.timeout_minutes == 60
     assert request.region is None
     assert request.labels == []
     assert request.start_command == "tail -f /dev/null"
+
+
+def test_unset_vm_is_omitted_from_payload():
+    """Unset vm must be excluded from the API payload so the server default applies."""
+    request = CreateSandboxRequest(
+        name="test-sandbox",
+        docker_image="python:3.11-slim",
+    )
+
+    assert "vm" not in request.model_dump(exclude_none=True)
+
+
+def test_unset_vm_still_serializes_default_start_command():
+    """With vm unset, the container keep-alive default stays on the wire.
+
+    This is deliberate, not a leak: the server is contractually committed to
+    dropping legacy string start commands on the VM path (ingress #3817
+    compat), so a VM-resolved sandbox behaves as if no start command was set.
+    Meanwhile a container-resolved sandbox (SANDBOX_DEFAULT_VM=false rollback,
+    or an older ingress where omitted vm still means container) needs this
+    default — without it the container runs the bare image ENTRYPOINT and
+    typically exits immediately. Do not clear this default for unset vm.
+    """
+    request = CreateSandboxRequest(
+        name="test-sandbox",
+        docker_image="python:3.11-slim",
+    )
+
+    payload = request.model_dump(exclude_none=True)
+    assert payload["start_command"] == "tail -f /dev/null"
+    assert "vm" not in payload
+
+
+def test_explicit_vm_false_is_serialized():
+    """The explicit container opt-out must survive exclude_none serialization."""
+    request = CreateSandboxRequest(
+        name="test-sandbox",
+        docker_image="python:3.11-slim",
+        vm=False,
+    )
+
+    assert request.model_dump(exclude_none=True)["vm"] is False
+
+
+def test_unset_vm_rejects_explicit_string_start_command():
+    """Explicit string start commands are container-only; require vm=False."""
+    with pytest.raises(ValidationError, match="container-only"):
+        CreateSandboxRequest(
+            name="test-sandbox",
+            docker_image="python:3.11-slim",
+            start_command="sleep infinity",
+        )
+
+
+def test_container_opt_out_keeps_explicit_string_start_command():
+    request = CreateSandboxRequest(
+        name="test-sandbox",
+        docker_image="python:3.11-slim",
+        vm=False,
+        start_command="sleep infinity",
+    )
+
+    assert request.start_command == "sleep infinity"
 
 
 def test_vm_start_command_preserves_argv():
@@ -106,15 +170,29 @@ def test_create_sandbox_request_accepts_gpu_type_for_gpu_count():
     assert request.vm is True
 
 
-def test_create_sandbox_request_requires_vm_for_gpu_count():
-    """Test vm is required when gpu_count > 0"""
+def test_create_sandbox_request_rejects_gpu_with_container_opt_out():
+    """GPUs conflict with an explicit container opt-out (vm=False)"""
     with pytest.raises(ValidationError):
         CreateSandboxRequest(
             name="gpu-sandbox",
             docker_image="python:3.11-slim",
             gpu_count=1,
             gpu_type="H100_80GB",
+            vm=False,
         )
+
+
+def test_create_sandbox_request_allows_gpu_with_unset_vm():
+    """Unset vm defers to the platform default (VM), which supports GPUs"""
+    request = CreateSandboxRequest(
+        name="gpu-sandbox",
+        docker_image="python:3.11-slim",
+        gpu_count=1,
+        gpu_type="H100_80GB",
+    )
+
+    assert request.vm is None
+    assert request.gpu_count == 1
 
 
 def test_create_sandbox_request_rejects_gpu_type_without_gpu_count():
@@ -142,6 +220,76 @@ def test_create_sandbox_request_gpu_type_none_matches_default():
 
     assert request_default.gpu_type is None
     assert request_none.gpu_type is None
+
+
+def test_guaranteed_requires_container_opt_out():
+    """guaranteed is container-only; unset vm resolves to VM on the server"""
+    with pytest.raises(ValidationError, match="vm=False"):
+        CreateSandboxRequest(
+            name="guaranteed-sandbox",
+            docker_image="python:3.11-slim",
+            guaranteed=True,
+        )
+
+    request = CreateSandboxRequest(
+        name="guaranteed-sandbox",
+        docker_image="python:3.11-slim",
+        guaranteed=True,
+        vm=False,
+    )
+    assert request.guaranteed is True
+
+
+def test_registry_credentials_require_container_opt_out():
+    """registry_credentials_id is container-only; unset vm resolves to VM on the server"""
+    with pytest.raises(ValidationError, match="vm=False"):
+        CreateSandboxRequest(
+            name="private-image-sandbox",
+            docker_image="registry.example.com/private:latest",
+            registry_credentials_id="cred-123",
+        )
+
+    with pytest.raises(ValidationError, match="vm=False"):
+        CreateSandboxRequest(
+            name="private-image-sandbox",
+            docker_image="registry.example.com/private:latest",
+            registry_credentials_id="cred-123",
+            vm=True,
+        )
+
+    request = CreateSandboxRequest(
+        name="private-image-sandbox",
+        docker_image="registry.example.com/private:latest",
+        registry_credentials_id="cred-123",
+        vm=False,
+    )
+    assert request.registry_credentials_id == "cred-123"
+
+
+def test_idle_timeout_requires_container_opt_out():
+    """idle_timeout_minutes is container-only; unset vm resolves to VM on the server"""
+    with pytest.raises(ValidationError, match="vm=False"):
+        CreateSandboxRequest(
+            name="idle-sandbox",
+            docker_image="python:3.11-slim",
+            idle_timeout_minutes=10,
+        )
+
+    with pytest.raises(ValidationError, match="vm=False"):
+        CreateSandboxRequest(
+            name="idle-sandbox",
+            docker_image="python:3.11-slim",
+            idle_timeout_minutes=10,
+            vm=True,
+        )
+
+    request = CreateSandboxRequest(
+        name="idle-sandbox",
+        docker_image="python:3.11-slim",
+        idle_timeout_minutes=10,
+        vm=False,
+    )
+    assert request.idle_timeout_minutes == 10
 
 
 def test_sandbox_status_enum():

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -183,17 +183,17 @@ prime pods terminate <pod-id>
 Isolated environments for running code remotely:
 
 ```bash
-# Create a sandbox
+# Create a sandbox (VM-backed by default, public beta)
 prime sandbox create python:3.11
 
 # Create a VM sandbox with GPUs
 prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
 
-# Create a CPU-only VM sandbox
-prime sandbox create user-1/vm-image:latest --vm
-
 # Create a one-shot VM workload (arguments after -- are preserved exactly)
-prime sandbox create user-1/vm-image:latest --vm -- /worker --platform linux/amd64
+prime sandbox create user-1/vm-image:latest -- /worker --platform linux/amd64
+
+# Opt out to a container sandbox (supports SSH, port exposure, string start commands)
+prime sandbox create python:3.11 --container
 
 # List sandboxes
 prime sandbox list

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -187,7 +187,7 @@ Isolated environments for running code remotely:
 prime sandbox create python:3.11
 
 # Create a VM sandbox with GPUs
-prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
+prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type RTX_PRO_6000
 
 # Create a one-shot VM workload (arguments after -- are preserved exactly)
 prime sandbox create user-1/vm-image:latest -- /worker --platform linux/amd64

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -532,7 +532,7 @@ def create(
     gpu_type: Optional[str] = typer.Option(
         None,
         "--gpu-type",
-        help="GPU type/model (e.g. H100_80GB, A100_80GB). Required when --gpu-count > 0",
+        help="GPU type/model (e.g. RTX_PRO_6000, H200_141GB). Required when --gpu-count > 0",
     ),
     vm: Optional[bool] = typer.Option(
         None,

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -507,7 +507,7 @@ def get(
 def create(
     docker_image: Optional[str] = typer.Argument(
         None,
-        help="Image to run. When using --vm, provide the VM image reference.",
+        help="Image to run. For VM sandboxes (the default), provide the VM image reference.",
     ),
     command: Optional[List[str]] = typer.Argument(
         None,
@@ -523,7 +523,7 @@ def create(
     start_command: Optional[str] = typer.Option(
         None,
         "--start-command",
-        help="Legacy container-only command string",
+        help="Legacy container-only command string (requires --container)",
     ),
     cpu_cores: float = typer.Option(1.0, help="Number of CPU cores"),
     memory_gb: float = typer.Option(1.0, help="Memory in GB"),
@@ -534,10 +534,14 @@ def create(
         "--gpu-type",
         help="GPU type/model (e.g. H100_80GB, A100_80GB). Required when --gpu-count > 0",
     ),
-    vm: bool = typer.Option(
-        False,
-        "--vm",
-        help="Create a VM-backed sandbox on the VM sandbox infra. Required when requesting GPUs.",
+    vm: Optional[bool] = typer.Option(
+        None,
+        "--vm/--container",
+        help=(
+            "Sandbox runtime. VM-backed sandboxes are the default (public beta); "
+            "pass --container to opt out to a container sandbox. VMs are "
+            "required when requesting GPUs."
+        ),
     ),
     network_allow: Optional[List[str]] = typer.Option(
         None,
@@ -596,8 +600,8 @@ def create(
         "--guaranteed",
         help=(
             "Admin/manager only. Schedule with CPU/memory requests equal to limits "
-            "(Guaranteed QoS), bypassing the default oversubscription. Not supported "
-            "with --vm."
+            "(Guaranteed QoS), bypassing the default oversubscription. Container "
+            "sandboxes only (requires --container)."
         ),
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
@@ -625,6 +629,13 @@ def create(
                 key, value = secret_var.split("=", 1)
                 secrets_vars[key] = value
 
+        # Resolve the sandbox runtime. VM is the platform default (public
+        # beta); explicit --vm/--container flags always win. The resolved
+        # value is sent to the API so the created runtime never depends on
+        # server-side defaults changing underneath a deployed CLI.
+        runtime_defaulted = vm is None
+        use_vm = True if runtime_defaulted else vm
+
         if gpu_count > 0 and not gpu_type:
             console.print(
                 "[red]GPU type is required when requesting GPUs.[/red] "
@@ -632,9 +643,9 @@ def create(
             )
             raise typer.Exit(1)
 
-        if gpu_count > 0 and not vm:
+        if gpu_count > 0 and not use_vm:
             console.print(
-                "[red]GPUs require VM sandboxes.[/red] Pass --vm whenever using --gpu-count."
+                "[red]GPUs require VM sandboxes.[/red] Drop --container when using --gpu-count."
             )
             raise typer.Exit(1)
 
@@ -645,18 +656,44 @@ def create(
             )
             raise typer.Exit(1)
 
-        if guaranteed and vm:
-            console.print(
-                "[red]--guaranteed is not supported for VM sandboxes.[/red] "
-                "Drop --vm or drop --guaranteed."
-            )
+        if guaranteed and use_vm:
+            if runtime_defaulted:
+                console.print(
+                    "[red]--guaranteed is only supported for container sandboxes.[/red] "
+                    "Add --container to opt out of the default VM runtime."
+                )
+            else:
+                console.print(
+                    "[red]--guaranteed is not supported for VM sandboxes.[/red] "
+                    "Drop --vm or drop --guaranteed."
+                )
+            raise typer.Exit(1)
+
+        if registry_credentials_id and use_vm:
+            if runtime_defaulted:
+                console.print(
+                    "[red]--registry-credentials-id is only supported for container "
+                    "sandboxes.[/red] Add --container to opt out of the default VM runtime."
+                )
+            else:
+                console.print(
+                    "[red]--registry-credentials-id is not supported for VM sandboxes.[/red] "
+                    "Drop --vm or drop --registry-credentials-id."
+                )
             raise typer.Exit(1)
 
         if idle_timeout_minutes is not None:
-            if idle_timeout_minutes < 1:
+            if use_vm:
+                console.print(
+                    "[yellow]Warning:[/yellow] --idle-timeout-minutes is not supported "
+                    "for VM sandboxes and will be ignored. Add --container to use "
+                    "idle-based termination."
+                )
+                idle_timeout_minutes = None
+            elif idle_timeout_minutes < 1:
                 console.print("[red]--idle-timeout-minutes must be at least 1.[/red]")
                 raise typer.Exit(1)
-            if timeout_minutes > 0 and idle_timeout_minutes > timeout_minutes:
+            elif timeout_minutes > 0 and idle_timeout_minutes > timeout_minutes:
                 console.print(
                     "[red]--idle-timeout-minutes must be <= --timeout-minutes "
                     f"(got idle={idle_timeout_minutes}, lifetime={timeout_minutes}).[/red]"
@@ -674,7 +711,7 @@ def create(
             if gpu_count > 0 and gpu_type:
                 gpu_slug = "".join(c if c.isalnum() or c == "-" else "-" for c in gpu_type.lower())
                 base_name = f"gpu-{'-'.join(filter(None, gpu_slug.split('-')))}"
-            elif vm:
+            elif use_vm:
                 image_parts = docker_image.split("/")[-1].split(":")[0]
                 image_slug = "".join(
                     c if c.isalnum() or c == "-" else "-" for c in image_parts.lower()
@@ -710,8 +747,11 @@ def create(
                 "[red]Error:[/red] --network-allow and --network-deny are mutually exclusive"
             )
             raise typer.Exit(1)
-        if (network_allow is not None or network_deny is not None) and not vm:
-            console.print("[red]Error:[/red] --network-allow/--network-deny require --vm")
+        if (network_allow is not None or network_deny is not None) and not use_vm:
+            console.print(
+                "[red]Error:[/red] --network-allow/--network-deny require a VM "
+                "sandbox; drop --container"
+            )
             raise typer.Exit(1)
 
         if command and start_command is not None:
@@ -720,11 +760,18 @@ def create(
                 "or --start-command, not both"
             )
             raise typer.Exit(1)
-        if vm and start_command is not None:
-            console.print(
-                "[red]Error:[/red] --start-command is legacy container-only syntax. "
-                "For VMs, pass an executable after '--'."
-            )
+        if use_vm and start_command is not None:
+            if runtime_defaulted:
+                console.print(
+                    "[red]Error:[/red] --start-command is legacy container-only syntax. "
+                    "Pass an executable after '--' for VM sandboxes (the default), "
+                    "or add --container to create a container sandbox."
+                )
+            else:
+                console.print(
+                    "[red]Error:[/red] --start-command is legacy container-only syntax. "
+                    "For VMs, pass an executable after '--'."
+                )
             raise typer.Exit(1)
 
         resolved_start_command: StartCommand | str | None
@@ -735,7 +782,7 @@ def create(
             )
         elif start_command is not None:
             resolved_start_command = start_command
-        elif vm:
+        elif use_vm:
             resolved_start_command = None
         else:
             # Preserve the existing long-running default for container callers.
@@ -750,7 +797,7 @@ def create(
             disk_size_gb=disk_size_gb,
             gpu_count=gpu_count,
             gpu_type=gpu_type,
-            vm=vm,
+            vm=use_vm,
             network_allowlist=network_allow,
             network_denylist=network_deny,
             timeout_minutes=timeout_minutes,
@@ -772,7 +819,8 @@ def create(
         console.print(f"Resources: {cpu_cores} CPU, {memory_gb}GB RAM, {disk_size_gb}GB disk")
         if guaranteed:
             console.print("Scheduling: [green]Guaranteed QoS[/green]")
-        console.print(f"VM: {'Enabled' if vm else 'Disabled'}")
+        runtime_label = "VM (default)" if runtime_defaulted else ("VM" if use_vm else "Container")
+        console.print(f"Runtime: {runtime_label}")
         if gpu_count > 0:
             console.print(f"GPUs: {gpu_type} x{gpu_count}")
         if network_allow is not None:

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -338,7 +338,7 @@ def test_sandbox_create_with_gpu_options(monkeypatch: pytest.MonkeyPatch) -> Non
     output = strip_ansi(result.output)
     assert result.exit_code == 0, f"Failed: {result.output}"
     assert "Successfully created sandbox sbx-gpu-123" in output
-    assert "VM: Enabled" in output
+    assert "Runtime: VM" in output
     assert "GPUs: H100_80GB x1" in output
     assert "Docker Image: team-1/gpu-runtime:v1" in output
     assert captured["request"].docker_image == "team-1/gpu-runtime:v1"
@@ -428,11 +428,37 @@ def test_sandbox_create_container_keeps_legacy_default(
 
     result = runner.invoke(
         app,
-        ["sandbox", "create", "python:3.12", "--yes"],
+        ["sandbox", "create", "python:3.12", "--container", "--yes"],
     )
 
     assert result.exit_code == 0, result.output
+    assert captured["request"].vm is False
     assert captured["request"].start_command == "tail -f /dev/null"
+
+
+def test_sandbox_create_defaults_to_vm_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without --vm/--container the CLI resolves the runtime to VM."""
+    _configure_cli(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def mock_create(self: Any, request: Any) -> Any:
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-default-vm")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "create", "python:3.12", "--yes"],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, result.output
+    assert "Runtime: VM (default)" in output
+    assert captured["request"].vm is True
+    assert captured["request"].start_command is None
 
 
 def test_sandbox_create_container_keeps_explicit_empty_legacy_command(
@@ -449,11 +475,37 @@ def test_sandbox_create_container_keeps_explicit_empty_legacy_command(
 
     result = runner.invoke(
         app,
-        ["sandbox", "create", "python:3.12", "--start-command", "", "--yes"],
+        ["sandbox", "create", "python:3.12", "--container", "--start-command", "", "--yes"],
     )
 
     assert result.exit_code == 0, result.output
     assert captured["request"].start_command == ""
+
+
+def test_sandbox_create_rejects_start_command_for_default_vm_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--start-command without --container must fail with opt-out guidance."""
+    _configure_cli(monkeypatch)
+    called = False
+
+    def mock_create(self: Any, request: Any) -> Any:
+        nonlocal called
+        called = True
+        return SimpleNamespace(id="sbx-should-not-create")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        ["sandbox", "create", "python:3.12", "--start-command", "sleep infinity", "--yes"],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 1
+    assert "container-only" in output
+    assert "--container" in output
+    assert called is False
 
 
 def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -483,7 +535,7 @@ def test_sandbox_create_gpu_without_docker_image(monkeypatch: pytest.MonkeyPatch
 
     output = strip_ansi(result.output)
     assert result.exit_code == 1
-    assert "GPUs require VM sandboxes." in output
+    assert "Docker image is required." in output
     assert "Successfully created sandbox" not in output
     assert "request" not in captured
 
@@ -579,7 +631,10 @@ def test_sandbox_create_requires_gpu_type(monkeypatch: pytest.MonkeyPatch) -> No
     assert called is False
 
 
-def test_sandbox_create_requires_vm_for_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sandbox_create_rejects_gpu_with_container_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GPUs conflict with an explicit --container opt-out."""
     monkeypatch.setenv("PRIME_API_KEY", "dummy")
     monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
 
@@ -598,6 +653,7 @@ def test_sandbox_create_requires_vm_for_gpu(monkeypatch: pytest.MonkeyPatch) -> 
             "sandbox",
             "create",
             "python:3.11-slim",
+            "--container",
             "--gpu-count",
             "1",
             "--gpu-type",
@@ -610,6 +666,42 @@ def test_sandbox_create_requires_vm_for_gpu(monkeypatch: pytest.MonkeyPatch) -> 
     assert result.exit_code == 1
     assert "GPUs require VM sandboxes." in output
     assert called is False
+
+
+def test_sandbox_create_gpu_with_defaulted_vm_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GPU requests work without an explicit --vm now that VM is the default."""
+    monkeypatch.setenv("PRIME_API_KEY", "dummy")
+    monkeypatch.setenv("PRIME_DISABLE_VERSION_CHECK", "1")
+
+    captured: dict[str, Any] = {}
+
+    def mock_create(self: Any, request: Any) -> Any:
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-gpu-default-vm")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "python:3.11-slim",
+            "--gpu-count",
+            "1",
+            "--gpu-type",
+            "H100_80GB",
+            "--yes",
+        ],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, f"Failed: {result.output}"
+    assert "Successfully created sandbox sbx-gpu-default-vm" in output
+    assert captured["request"].vm is True
+    assert captured["request"].gpu_count == 1
 
 
 def test_sandbox_create_rejects_gpu_type_without_count(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Reverts PrimeIntellect-ai/prime#833

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default sandbox runtime and request validation for all create paths; scripts that relied on implicit container behavior or string start commands without `vm=False` will break until updated.
> 
> **Overview**
> Re-applies the **VM sandbox opt-out** model after a prior revert: sandboxes default to **VM-backed** runtimes unless callers explicitly opt into containers.
> 
> **SDK (`CreateSandboxRequest`)**: `vm` is now `Optional[bool]` (unset omits `vm` from API payloads so the platform default applies). Validation is split by runtime: container-only features (`guaranteed`, `registry_credentials_id`, `idle_timeout_minutes`, string `start_command`) require `vm=False`; VM features (egress lists, GPUs) work when `vm` is unset or `True`. String start commands without `vm=False` are rejected.
> 
> **CLI (`prime sandbox create`)**: Adds **`--vm/--container`** with VM as the default when neither flag is passed; the CLI resolves to `vm=True` and sends it explicitly. Container workflows need **`--container`** (including legacy `--start-command`). Error messages and the config summary use **Runtime** instead of a boolean VM line.
> 
> **Docs & examples**: READMEs and `examples/README.md` document VM vs container semantics, expanded CLI/image references, and all string–`start_command` examples set **`vm=False`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f66b79864b4879a70234f02bc5f1bb136676a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->