### PR TITLE
docs: fix broken sandbox command reference and align docs with VM-default runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,15 +258,17 @@ uv run pytest packages/prime/tests
 uv run pytest packages/prime-sandboxes/tests
 ```
 
-All packages (prime-core, prime-sandboxes, prime) are installed in editable mode. Changes to code are immediately reflected.
+All workspace packages (`prime`, `prime-sandboxes`, `prime-evals`, `prime-tunnel`) are installed in editable mode. Changes to code are immediately reflected.
 
 ### Releasing
 
-This monorepo contains two independently versioned packages: `prime` (CLI + full SDK) and `prime-sandboxes` (lightweight SDK).
+This monorepo contains independently versioned packages: `prime` (CLI + full SDK), `prime-sandboxes`, `prime-evals`, and `prime-tunnel` (lightweight SDKs).
 
 Versions are single-sourced from each package's `__init__.py` file:
 - **prime**: `packages/prime/src/prime_cli/__init__.py`
 - **prime-sandboxes**: `packages/prime-sandboxes/src/prime_sandboxes/__init__.py`
+- **prime-evals**: `packages/prime-evals/src/prime_evals/__init__.py`
+- **prime-tunnel**: `packages/prime-tunnel/src/prime_tunnel/__init__.py`
 
 #### To release a new version:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -137,7 +137,8 @@ from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest, Star
 client = APIClient()
 sandbox_client = SandboxClient(client)
 
-# Create sandbox
+# Create sandbox. Leaving `vm` unset uses the platform default runtime:
+# VM-backed sandboxes (public beta).
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
@@ -154,22 +155,25 @@ sandbox = sandbox_client.create(request)
 print(f"Created sandbox: {sandbox.id}")
 ```
 
-VM sandboxes are opt-in with `vm=True`. They take a structured argv start command
-(`StartCommand`) instead of a command string, and support GPUs and network rules:
+VM sandboxes take a structured argv start command (`StartCommand`) instead of a command
+string, and support GPUs and network rules:
 
 ```python
 vm_request = CreateSandboxRequest(
     name="my-vm-sandbox",
     docker_image="user-1/vm-image:latest",
-    vm=True,
+    vm=True,  # redundant with the default, but explicit for VM-only features
     start_command=StartCommand(executable="python", args=["serve.py", "--port", "8000"]),
     gpu_count=1,
-    gpu_type="RTX_PRO_6000",  # required when gpu_count > 0; GPUs require vm=True
+    gpu_type="RTX_PRO_6000",  # required when gpu_count > 0
     network_allowlist=["api.openai.com"],  # mutually exclusive with network_denylist
 )
 
 vm = sandbox_client.create(vm_request)
 ```
+
+Pass `vm=False` for a container sandbox, which is currently the only runtime that supports
+SSH, port exposure, string start commands, idle timeout, and private-registry credentials.
 
 ### CLI Command Reference
 
@@ -180,18 +184,18 @@ prime sandbox list [--team-id TEAM] [--status STATUS] [--label LABEL] [--page N]
 # Create sandbox
 prime sandbox create IMAGE [OPTIONS]
 
-# Create VM sandbox with GPUs (GPUs require --vm, and --gpu-type when --gpu-count > 0)
+# Opt out to a container sandbox (SSH, port exposure, string start commands, idle timeout)
+prime sandbox create python:3.11-slim --container
+
+# Create VM sandbox with GPUs (--gpu-type is required when --gpu-count > 0)
 prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type RTX_PRO_6000
 
-# Create CPU-only VM sandbox
-prime sandbox create user-1/vm-image:latest --vm
-
 # VM start command: each argv token is separate after --, no shell is involved
-prime sandbox create user-1/vm-image:latest --vm -- python serve.py --port 8000
+prime sandbox create user-1/vm-image:latest -- python serve.py --port 8000
 
-# Restrict VM egress (--network-allow/--network-deny are VM only, repeatable, mutually exclusive)
-prime sandbox create user-1/vm-image:latest --vm --network-allow api.openai.com
-prime sandbox create user-1/vm-image:latest --vm --network-deny 0.0.0.0/0
+# Restrict egress (--network-allow/--network-deny are repeatable and mutually exclusive)
+prime sandbox create user-1/vm-image:latest --network-allow api.openai.com
+prime sandbox create user-1/vm-image:latest --network-deny 0.0.0.0/0
 
 # With environment variables and secrets:
 prime sandbox create python:3.11-slim --env KEY=VALUE --secret API_KEY=secret123
@@ -205,7 +209,7 @@ prime sandbox run SANDBOX_ID -- python script.py
 # Get sandbox details
 prime sandbox get SANDBOX_ID [--output json]
 
-# Show or replace VM network rules (VM only)
+# Show or replace network rules (not available on container sandboxes)
 prime sandbox network SANDBOX_ID
 prime sandbox network SANDBOX_ID --allow api.openai.com,10.0.0.0/8
 
@@ -237,7 +241,7 @@ prime images push myapp:v1.0.0 --context ./app --dockerfile ./app/Dockerfile
 # Copy an existing public image into Prime instead of building
 prime images push myubuntu:22.04 --source-image ubuntu:22.04
 
-# Pre-build the VM artifact for an existing image (otherwise the first --vm
+# Pre-build the VM artifact for an existing image (otherwise the first VM
 # sandbox using that image triggers a one-time conversion)
 prime images build-vm myapp:v1.0.0
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -92,8 +92,7 @@ uv run python examples/sandbox_file_handling_stress_test.py concurrent
 
 - Creating sandboxes with custom configurations
 - Listing and filtering sandboxes
-- Getting detailed sandbox information
-- Updating sandbox settings
+- Executing commands in a sandbox
 - Retrieving logs
 - Deleting sandboxes
 - Error handling
@@ -132,8 +131,7 @@ This example is useful for:
 ### Creating Sandboxes Programmatically
 
 ```python
-from prime_core import APIClient
-from prime_sandboxes import SandboxClient, CreateSandboxRequest
+from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest, StartCommand
 
 # Initialize client
 client = APIClient()
@@ -143,55 +141,118 @@ sandbox_client = SandboxClient(client)
 request = CreateSandboxRequest(
     name="my-sandbox",
     docker_image="python:3.11-slim",
-    start_command="python app.py",
-    vm=False,  # string start commands are container-only
     cpu_cores=2,
     memory_gb=4,
     disk_size_gb=20,
-    gpu_count=0,
-    gpu_type=None,
     timeout_minutes=60,
     environment_vars={"ENV": "production"},
     secrets={"API_KEY": "your-secret-key"},
-    team_id=None  # Use None for personal account
+    team_id=None,  # Use None for personal account
 )
 
 sandbox = sandbox_client.create(request)
 print(f"Created sandbox: {sandbox.id}")
 ```
 
+VM sandboxes are opt-in with `vm=True`. They take a structured argv start command
+(`StartCommand`) instead of a command string, and support GPUs and network rules:
+
+```python
+vm_request = CreateSandboxRequest(
+    name="my-vm-sandbox",
+    docker_image="user-1/vm-image:latest",
+    vm=True,
+    start_command=StartCommand(executable="python", args=["serve.py", "--port", "8000"]),
+    gpu_count=1,
+    gpu_type="RTX_PRO_6000",  # required when gpu_count > 0; GPUs require vm=True
+    network_allowlist=["api.openai.com"],  # mutually exclusive with network_denylist
+)
+
+vm = sandbox_client.create(vm_request)
+```
+
 ### CLI Command Reference
 
 ```bash
 # List sandboxes
-prime sandbox list [--team_id TEAM] [--status STATUS] [--page N] [--per_page N]
+prime sandbox list [--team-id TEAM] [--status STATUS] [--label LABEL] [--page N] [--num N] [--all]
 
 # Create sandbox
 prime sandbox create IMAGE [OPTIONS]
 
-# Create VM sandbox with GPUs
-prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
+# Create VM sandbox with GPUs (GPUs require --vm, and --gpu-type when --gpu-count > 0)
+prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type RTX_PRO_6000
 
 # Create CPU-only VM sandbox
 prime sandbox create user-1/vm-image:latest --vm
 
+# VM start command: each argv token is separate after --, no shell is involved
+prime sandbox create user-1/vm-image:latest --vm -- python serve.py --port 8000
+
+# Restrict VM egress (--network-allow/--network-deny are VM only, repeatable, mutually exclusive)
+prime sandbox create user-1/vm-image:latest --vm --network-allow api.openai.com
+prime sandbox create user-1/vm-image:latest --vm --network-deny 0.0.0.0/0
+
 # With environment variables and secrets:
 prime sandbox create python:3.11-slim --env KEY=VALUE --secret API_KEY=secret123
+
+# Other create options: --name, --cpu-cores, --memory-gb, --disk-size-gb,
+# --timeout-minutes, --idle-timeout-minutes, --team-id, --region, --label, --yes
 
 # Run command in sandbox
 prime sandbox run SANDBOX_ID -- python script.py
 
 # Get sandbox details
-prime sandbox get SANDBOX_ID
+prime sandbox get SANDBOX_ID [--output json]
 
-# Update sandbox
-prime sandbox update SANDBOX_ID [OPTIONS]
+# Show or replace VM network rules (VM only)
+prime sandbox network SANDBOX_ID
+prime sandbox network SANDBOX_ID --allow api.openai.com,10.0.0.0/8
 
-# Delete sandbox
+# Delete sandboxes (by ID, by label, or all)
 prime sandbox delete SANDBOX_ID
+prime sandbox delete --label experiment-1
+prime sandbox delete --all --yes
 
 # Get logs
 prime sandbox logs SANDBOX_ID
+
+# Upload/download files
+prime sandbox upload SANDBOX_ID local_file.py /remote/path/file.py
+prime sandbox download SANDBOX_ID /remote/file.txt ./local/file.txt
+
+# Expose ports and SSH (container sandboxes)
+prime sandbox expose SANDBOX_ID 8000 [--protocol HTTP|TCP]
+prime sandbox list-ports [SANDBOX_ID]
+prime sandbox unexpose SANDBOX_ID EXPOSURE_ID
+prime sandbox ssh SANDBOX_ID
+```
+
+### Image Command Reference
+
+```bash
+# Build and push an image from a Dockerfile (linux/amd64 by default)
+prime images push myapp:v1.0.0 --context ./app --dockerfile ./app/Dockerfile
+
+# Copy an existing public image into Prime instead of building
+prime images push myubuntu:22.04 --source-image ubuntu:22.04
+
+# Pre-build the VM artifact for an existing image (otherwise the first --vm
+# sandbox using that image triggers a one-time conversion)
+prime images build-vm myapp:v1.0.0
+
+# List images
+prime images list [--search TERM] [--page N] [--num N] [--output json]
+
+# Change visibility
+prime images publish myapp:v1.0.0
+prime images unpublish myapp:v1.0.0
+
+# Rename, retag, or move an image
+prime images update myapp:v1 --name myapp-final --tag v2
+
+# Delete an image
+prime images delete myapp:v1.0.0 --yes
 ```
 
 ## Error Handling

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -198,9 +198,9 @@ for s in sandboxes.sandboxes:
 Use `start_background_job` to run long-running tasks that continue after the API call returns. Poll for completion with `get_background_job`.
 
 ```python
-from prime_sandboxes import SandboxClient, CreateSandboxRequest
+from prime_sandboxes import APIClient, SandboxClient, CreateSandboxRequest
 
-sandbox_client = SandboxClient()
+sandbox_client = SandboxClient(APIClient())
 
 # Create sandbox with extended timeout
 sandbox = sandbox_client.create(CreateSandboxRequest(

--- a/packages/prime/README.md
+++ b/packages/prime/README.md
@@ -187,7 +187,7 @@ Isolated environments for running code remotely:
 prime sandbox create python:3.11
 
 # Create a VM sandbox with GPUs
-prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type H100_80GB
+prime sandbox create user-1/vm-image:latest --vm --gpu-count 1 --gpu-type RTX_PRO_6000
 
 # Create a one-shot VM workload (arguments after -- are preserved exactly)
 prime sandbox create user-1/vm-image:latest -- /worker --platform linux/amd64

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -532,7 +532,7 @@ def create(
     gpu_type: Optional[str] = typer.Option(
         None,
         "--gpu-type",
-        help="GPU type/model (e.g. H100_80GB, A100_80GB). Required when --gpu-count > 0",
+        help="GPU type/model (e.g. RTX_PRO_6000, H200_141GB). Required when --gpu-count > 0",
     ),
     vm: Optional[bool] = typer.Option(
         None,


### PR DESCRIPTION
Stacked on #834 (base is its branch) — documents `--container`/`vm=False`.

Fixes docs that are wrong today:
- `examples/README.md`: `prime_core` import, `--team_id`/`--per_page`, `prime sandbox update` — none exist. Rebuilt from real `--help`.
- `--gpu-type H100_80GB` is invalid for sandboxes (only `RTX_PRO_6000`/`H200*`). Fixed in README + help text.
- `SandboxClient()` needs an `APIClient`.

Second commit drops now-redundant `--vm` per #834. Public docs: PrimeIntellect-ai/public-docs#205