### PR TITLE
release: cli 0.6.22

### DIFF
--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.34",
+    "prime-sandboxes>=0.2.36",
     "prime-evals>=0.2.3",
     "prime-tunnel>=0.1.9",
     "httpx>=0.25.0",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.21"
+__version__ = "0.6.22"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Release bump for Prime CLI changes merged since v0.6.21.

- bump `prime` CLI/SDK to `0.6.22`
- require `prime-sandboxes>=0.2.36`, matching the latest published sandbox SDK and the `StartCommand` API used by the CLI

Highlights:
- structured sandbox start-command support
- VM sandboxes as the default runtime with a `--container` opt-out
- Lab setup and workspace-hygiene fixes

Validation:
- pre-commit: Ruff, Ruff format, and ty passed
- `uv lock --check` passed
- package build passed; wheel metadata reports `0.6.22` and `prime-sandboxes>=0.2.36`
- Prime tests: 984 passed, 5 skipped, 2 failed in existing Lab environment-detail tests (`test_lab_view_renders_environment_details_without_raw_json` and `test_lab_view_loads_environment_versions_and_actions`); the release diff does not touch their code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version and dependency floor changes in packaging metadata; no application logic in this diff.
> 
> **Overview**
> **Release 0.6.22** for the `prime` CLI/SDK: version is bumped in `__init__.py` and the published package pins **`prime-sandboxes>=0.2.36`** (was `>=0.2.34`) so installs align with the sandbox SDK **`StartCommand`** API the CLI expects.
> 
> This PR is packaging-only; behavior called out for the release (elsewhere) includes structured sandbox start commands, VM sandboxes as the default with a `--container` opt-out, and Lab setup fixes—not modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c5812ab5cc84df05295feaec8bdfc7611518df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->