### PR TITLE
feat(sandboxes): support VM idle timeout

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -281,11 +281,6 @@ class CreateSandboxRequest(BaseModel):
     def validate_idle_timeout(self) -> "CreateSandboxRequest":
         if self.idle_timeout_minutes is None:
             return self
-        if self.vm is not False:
-            raise ValueError(
-                "idle_timeout_minutes is only supported for container "
-                "sandboxes; pass vm=False to create a container sandbox"
-            )
         if self.idle_timeout_minutes < 1:
             raise ValueError("idle_timeout_minutes must be >= 1")
         if self.timeout_minutes > 0 and self.idle_timeout_minutes > self.timeout_minutes:

--- a/packages/prime-sandboxes/tests/test_models.py
+++ b/packages/prime-sandboxes/tests/test_models.py
@@ -266,30 +266,28 @@ def test_registry_credentials_require_container_opt_out():
     assert request.registry_credentials_id == "cred-123"
 
 
-def test_idle_timeout_requires_container_opt_out():
-    """idle_timeout_minutes is container-only; unset vm resolves to VM on the server"""
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="idle-sandbox",
-            docker_image="python:3.11-slim",
-            idle_timeout_minutes=10,
-        )
-
-    with pytest.raises(ValidationError, match="vm=False"):
-        CreateSandboxRequest(
-            name="idle-sandbox",
-            docker_image="python:3.11-slim",
-            idle_timeout_minutes=10,
-            vm=True,
-        )
-
-    request = CreateSandboxRequest(
+def test_idle_timeout_supports_vm_and_container():
+    """idle_timeout_minutes is supported by either sandbox runtime."""
+    default_vm = CreateSandboxRequest(
+        name="idle-sandbox",
+        docker_image="python:3.11-slim",
+        idle_timeout_minutes=10,
+    )
+    vm = CreateSandboxRequest(
+        name="idle-sandbox",
+        docker_image="python:3.11-slim",
+        idle_timeout_minutes=10,
+        vm=True,
+    )
+    container = CreateSandboxRequest(
         name="idle-sandbox",
         docker_image="python:3.11-slim",
         idle_timeout_minutes=10,
         vm=False,
     )
-    assert request.idle_timeout_minutes == 10
+    assert default_vm.idle_timeout_minutes == 10
+    assert vm.idle_timeout_minutes == 10
+    assert container.idle_timeout_minutes == 10
 
 
 def test_sandbox_status_enum():

--- a/packages/prime/src/prime_cli/commands/sandbox.py
+++ b/packages/prime/src/prime_cli/commands/sandbox.py
@@ -565,7 +565,7 @@ def create(
         "--idle-timeout-minutes",
         help=(
             "Terminate the sandbox if no /exec, /upload, /download, or "
-            "/read-file request is seen for this many minutes. Disabled by default."
+            "/read-file operation is active for this many minutes. Disabled by default."
         ),
     ),
     team_id: Optional[str] = typer.Option(
@@ -683,14 +683,7 @@ def create(
             raise typer.Exit(1)
 
         if idle_timeout_minutes is not None:
-            if use_vm:
-                console.print(
-                    "[yellow]Warning:[/yellow] --idle-timeout-minutes is not supported "
-                    "for VM sandboxes and will be ignored. Add --container to use "
-                    "idle-based termination."
-                )
-                idle_timeout_minutes = None
-            elif idle_timeout_minutes < 1:
+            if idle_timeout_minutes < 1:
                 console.print("[red]--idle-timeout-minutes must be at least 1.[/red]")
                 raise typer.Exit(1)
             elif timeout_minutes > 0 and idle_timeout_minutes > timeout_minutes:

--- a/packages/prime/tests/test_sandbox_cli.py
+++ b/packages/prime/tests/test_sandbox_cli.py
@@ -775,6 +775,41 @@ def test_sandbox_create_vm_without_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured["request"].memory_gb == 1.0
 
 
+def test_sandbox_create_vm_supports_idle_timeout_with_unlimited_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_cli(monkeypatch)
+    captured: dict[str, Any] = {}
+
+    def mock_create(self: Any, request: Any) -> Any:
+        captured["request"] = request
+        return SimpleNamespace(id="sbx-vm-idle")
+
+    monkeypatch.setattr("prime_cli.commands.sandbox.SandboxClient.create", mock_create)
+
+    result = runner.invoke(
+        app,
+        [
+            "sandbox",
+            "create",
+            "python:3.12",
+            "--vm",
+            "--timeout-minutes",
+            "-1",
+            "--idle-timeout-minutes",
+            "10",
+            "--yes",
+        ],
+    )
+
+    output = strip_ansi(result.output)
+    assert result.exit_code == 0, result.output
+    assert "Idle Timeout: 10 minutes" in output
+    assert captured["request"].vm is True
+    assert captured["request"].timeout_minutes == -1
+    assert captured["request"].idle_timeout_minutes == 10
+
+
 def test_sandbox_delete_by_label_scopes_to_caller(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- allow idle_timeout_minutes for VM sandbox requests
- forward VM idle timeout from the CLI instead of ignoring it
- support idle timeout together with an unlimited VM lifetime

## Tests
- ruff format --check on changed files
- ruff check on changed files
- pytest packages/prime-sandboxes/tests/test_models.py packages/prime/tests/test_sandbox_cli.py -q (71 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation and CLI forwarding changes with matching unit tests; no auth or data-path changes, though VM idle behavior now depends on backend support matching the updated client contract.
> 
> **Overview**
> **VM sandboxes can now use idle-based termination** the same way containers do. The SDK no longer rejects `idle_timeout_minutes` when `vm` is unset or `True`; only the existing bounds remain (≥ 1 minute, and not above a positive lifetime timeout).
> 
> The **`prime sandbox create` CLI forwards `--idle-timeout-minutes` for VM runs** instead of printing a warning and dropping the flag. A new CLI test covers **`--vm` with `--timeout-minutes -1` and idle timeout 10**, confirming unlimited lifetime plus idle shutdown works end-to-end in the create path.
> 
> Help text for the idle-timeout flag is tweaked to describe inactivity on sandbox operations rather than “requests seen.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4cc75d2651db44af7730d0594b654aeaddb1531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->