### PR TITLE
async traces client

### DIFF
--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -3,174 +3,93 @@
 Upload and query training, evaluation and inference traces through the Prime
 Traces service.
 
-## Features
+> **⚠️ Prime Traces is in closed beta.** Access is granted per account, and the
+> service is not yet on a public URL.
 
-- **Content-addressed uploads** - Batches are identified by the SHA-256 of
-  their exact bytes, so interrupted uploads are safe to rerun and never store
-  twice
-- **Deterministic batching** - JSONL files are split at byte thresholds without
-  rewriting a single line
-- **Typed reads** - Cursor-paginated summaries over extracted columns and raw
-  document retrieval
-- **Type-safe** - Full type hints and Pydantic models
-- **No CLI dependencies** - Pure SDK, usable in producers and services
-
-## Installation
+## Install
 
 ```bash
-uv add prime-traces
+uv add prime-traces   # or: pip install prime-traces
 ```
 
-or with pip:
+## Upload
 
-```bash
-pip install prime-traces
-```
-
-## Quick Start
-
-### Upload from memory
-
-`upload_records` accepts JSON-compatible mappings as well as objects exposing
-`to_record()`. Verifiers `Trace` / `Episode` and prime-rl `Rollout` objects
-provide that method, so producers can upload completed records without writing
-an intermediate JSONL file:
+`upload_records` takes JSON-compatible mappings or any object exposing
+`to_record()` — which verifiers `Trace` / `Episode` and prime-rl `Rollout`
+already do, so producers can hand over their own objects. Records are
+serialized lazily into bounded batches, so nothing buffers the whole run or
+round-trips through disk.
 
 ```python
 from prime_traces import LineFormat, TracesClient
 
-client = TracesClient()  # PRIME_API_KEY / ~/.prime/config.json
+client = TracesClient()  # PRIME_API_KEY / PRIME_TRACES_URL / ~/.prime/config.json
 
-# Iterable[vf.Trace] or Iterable[prime_rl.orchestrator.types.Rollout]
-receipts = client.upload_records(
-    traces,
-    context={"source": "prime-rl", "run_id": "run_9f3k2m"},
-)
+receipts = client.upload_records(traces, context={"source": "prime-rl"})
 
-# Iterable[vf.Episode] for multi-agent runs
-receipts = client.upload_records(
-    episodes,
-    line_format=LineFormat.EPISODE,
-    context={"source": "verifiers"},
-)
-```
+# One complete episode per record, for multi-agent runs
+receipts = client.upload_records(episodes, line_format=LineFormat.EPISODE)
 
-Records are serialized lazily and fed into bounded batches, so this neither
-buffers the complete iterable nor round-trips through the filesystem. Callers
-that already have encoded JSONL bytes can use `upload_lines` directly.
-
-### Upload a completed JSONL file
-
-```python
-from prime_traces import TracesClient, LineFormat
-
-client = TracesClient()  # PRIME_API_KEY / ~/.prime/config.json
-
-# One bare Verifiers trace per line:
+# Already have a completed JSONL file, or encoded bytes?
 receipts = client.upload_file("traces.jsonl", context={"source": "hosted_eval"})
-
-# One complete episode per line (multi-agent runs):
-receipts = client.upload_file(
-    "episodes.jsonl",
-    line_format=LineFormat.EPISODE,
-    context={"source": "hosted_eval", "suite_commit": "a1f39c2"},
-)
+receipts = client.upload_lines(encoded_lines)
 ```
-
-Uploads are content-addressed: each request is identified by the SHA-256 of its
-exact uncompressed JSONL bytes and sent with an `Idempotency-Key`. Rerunning an
-interrupted upload re-reads the file, reproduces the same bytes and keys, and
-the service replays committed receipts without storing anything twice. A 400
-rejection stops the upload with a bounded error code (`ErrorCode`); 429/503 and
-gateway 502/504 are retried with the same bytes, honoring `Retry-After`.
 
 ## Query
 
 ```python
 page = client.list(run_id="run_9f3k2m", reward_min=0.9, has_error=False)
 for summary in page.items:
-    print(summary.trace_id, summary.score)
+    print(summary.trace_id, summary.score.reward)
 
-for summary in client.iter(task_id="tb2-0187"):  # paginates for you
+for summary in client.iter(task_id="tb2-0187"):   # paginates for you
     ...
 
-summary = client.get("8d3f1a2b...")
-raw = client.get_raw("8d3f1a2b...")          # exact stored trace document
-client.download_raw("8d3f1a2b...", "t.json")  # streamed, for large traces
+summary = client.get(trace_id)
+raw     = client.get_raw(trace_id)                 # exact stored document
+client.download_raw(trace_id, "trace.json")        # streamed, for large traces
 
-client.delete("8d3f1a2b...")        # NotFoundError if the owner has no such trace
-client.delete_run("run_9f3k2m")     # one mutation, synchronous, no job handle
+client.delete(trace_id)
+client.delete_run("run_9f3k2m")
 ```
 
-Deletion is not a no-op on absent rows: the service checks existence first and
-answers 404, so repeating a delete that already succeeded raises
-`NotFoundError`. (The design docs specify it as idempotent; this tracks the
-service as built.) Failures known to occur before delivery, 429 responses, and
-service-coded 503 refusals are retried. Ambiguous response-path failures and
-gateway 502/503/504 responses are surfaced as `AmbiguousDeleteError` without
-replaying the deletion, because a retry could delete a trace written after the
-first request.
+Summaries are projections of the stored document, which is kept verbatim —
+fields the producer never recorded come back as `None`. Deleting something that
+is already gone raises `NotFoundError` rather than passing silently.
 
-Trace point reads/deletes and episode point/member reads currently reject IDs
-containing `/`. ASGI decodes an encoded slash before matching the service's
-`/{resource_id}` routes, so those IDs cannot be addressed until the service
-accepts path-valued route parameters.
-
-Episodes are read-only resources:
+Episodes are read-only:
 
 ```python
-page = client.list_episodes(
-    run_id="run_9f3k2m",
-    environment_id="terminal-bench-2",
-)
-for episode in page.items:
-    print(episode.episode_id, episode.outcome)
-
-if page.items:
-    episode_id = page.items[0].episode_id
-    detail = client.get_episode(episode_id)  # + member aggregate under .traces
-    print(detail.error.type, detail.traces.trace_count)
-
-    # Member trace summaries use the trace filters (except sort) and pagination.
-    client.list_episode_traces(episode_id, has_error=True)
+page   = client.list_episodes(run_id="run_9f3k2m")
+detail = client.get_episode(episode_id)      # + member aggregate under .traces
+members = client.list_episode_traces(episode_id, has_error=True)
 ```
-
-Response shapes mirror the service's pinned models: pages are
-`{items, next_cursor}`, a trace summary nests `model` / `score` / `execution`,
-an episode nests `error` and (on point lookup) the member-trace aggregate
-under `traces`, and unrecorded fields come back as `null`.
 
 ## Configuration
 
-| Source                 | Meaning                                                                                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PRIME_API_KEY`        | Platform API token (needs `traces:read` / `traces:write` scopes)                                                                            |
-| `PRIME_TEAM_ID`        | Optional team context, sent as `X-Prime-Team-ID`                                                                                            |
-| `PRIME_TRACES_URL`     | Base URL of the Prime Traces service; defaults to the platform API base URL. For the service's local compose stack: `http://localhost:8083` |
-| `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)                                                                                |
+| Source                 | Meaning                                                                |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `PRIME_API_KEY`        | Platform API token, needs the `traces` scope                           |
+| `PRIME_TRACES_URL`     | Base URL of the Prime Traces service (**required** during closed beta) |
+| `PRIME_TEAM_ID`        | Optional team context, sent as `X-Prime-Team-ID`                       |
+| `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)           |
 
-## Not implemented yet (open v0 contract decisions)
+Precedence is constructor argument → environment variable → config file.
 
-- Exports, in any form. The service publishes `GET /traces/export` and the two
-  job routes, but all three handlers raise `NotImplementedError` — answered as
-  500, not the 501 they document — and the streaming route declares no query
-  parameters, so there is no filter vocabulary to bind to. Wrapping it now
+## Not yet available
+
+- **Exports** — the service route exists but is unimplemented, so wrapping it
   would ship a method that cannot succeed.
-- `/search` and free-text queries — deferred with the `trace_components`
-  projection.
-- Typed dot-path predicates (`traces.query`) — needs the server-side field
-  registry.
-- An async client — the other prime SDKs ship sync/async pairs, and the main
-  producers (verifiers, prime-rl) are async; add once the sync surface
-  settles rather than freezing a duplicated API now.
+- **Search and free-text queries.**
+- **An async client** — coming once the sync surface settles.
 
-## Documentation
+## Examples
 
-For detailed documentation, visit the
-[Prime Traces SDK documentation](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-traces).
+Runnable scripts covering upload, query, episodes and error handling live in
+[`examples/`](./examples).
 
-## Related Packages
+## Related packages
 
-- [prime](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime) - Prime CLI (`prime traces ...` commands)
-- [prime-sandboxes](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-sandboxes) - Sandboxes SDK
-- [prime-evals](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-evals) - Evals SDK
+- [prime](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime) — Prime CLI, including `prime traces`
+- [prime-sandboxes](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-sandboxes) — Sandboxes SDK
+- [prime-evals](https://github.com/PrimeIntellect-ai/prime/tree/main/packages/prime-evals) — Evals SDK

--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -92,7 +92,7 @@ asyncio.run(main())
 
 | Source                 | Meaning                                                                |
 | ---------------------- | ---------------------------------------------------------------------- |
-| `PRIME_API_KEY`        | Platform API token, needs the `traces` scope                           |
+| `PRIME_API_KEY`        | Platform API token, needs `traces:read` / `traces:write` scopes        |
 | `PRIME_TRACES_URL`     | Base URL of the Prime Traces service (**required** during closed beta) |
 | `PRIME_TEAM_ID`        | Optional team context, sent as `X-Prime-Team-ID`                       |
 | `~/.prime/config.json` | Shared prime CLI config (`api_key`, `team_id`, `traces_url`)           |
@@ -107,8 +107,8 @@ Precedence is constructor argument → environment variable → config file.
 
 ## Examples
 
-Runnable scripts covering upload, query, episodes and error handling live in
-[`examples/`](./examples).
+The runnable [`basic_usage.py`](./examples/basic_usage.py) example covers
+upload, query, downloads and error handling.
 
 ## Related packages
 

--- a/packages/prime-traces/README.md
+++ b/packages/prime-traces/README.md
@@ -65,6 +65,29 @@ detail = client.get_episode(episode_id)      # + member aggregate under .traces
 members = client.list_episode_traces(episode_id, has_error=True)
 ```
 
+## Async
+
+`AsyncTracesClient` mirrors `TracesClient` method for method.
+
+```python
+import asyncio
+from prime_traces import AsyncTracesClient
+
+async def main():
+    async with AsyncTracesClient() as client:
+        await client.upload_records(traces, context={"source": "prime-rl"})
+
+        page, episodes = await asyncio.gather(   # reads overlap
+            client.list(run_id="run_9f3k2m"),
+            client.list_episodes(run_id="run_9f3k2m"),
+        )
+
+        async for summary in client.iter(task_id="tb2-0187"):
+            ...
+
+asyncio.run(main())
+```
+
 ## Configuration
 
 | Source                 | Meaning                                                                |
@@ -81,7 +104,6 @@ Precedence is constructor argument → environment variable → config file.
 - **Exports** — the service route exists but is unimplemented, so wrapping it
   would ship a method that cannot succeed.
 - **Search and free-text queries.**
-- **An async client** — coming once the sync surface settles.
 
 ## Examples
 

--- a/packages/prime-traces/pyproject.toml
+++ b/packages/prime-traces/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/PrimeIntellect-ai/prime.git"
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",
+    "pytest-asyncio>=0.23.0",
     "ruff>=0.13.1",
 ]
 

--- a/packages/prime-traces/src/prime_traces/__init__.py
+++ b/packages/prime-traces/src/prime_traces/__init__.py
@@ -5,16 +5,18 @@ Prime Traces service. Uploads are content-addressed JSONL batches; reads are
 cursor-paginated summaries over extracted columns plus raw-document retrieval.
 """
 
+from .async_traces import AsyncTracesClient
 from .batching import (
     DEFAULT_TARGET_BATCH_BYTES,
     MAX_BATCH_BYTES,
     MAX_BATCH_LINES,
     MAX_LINE_BYTES,
     Batch,
+    aiter_batches,
     iter_batches,
     read_jsonl_lines,
 )
-from .core import Config, TracesAPIClient
+from .core import AsyncTracesAPIClient, Config, TracesAPIClient
 from .exceptions import (
     AmbiguousDeleteError,
     APIError,
@@ -53,11 +55,14 @@ __all__ = [
     # Clients & config
     "TracesClient",
     "TracesAPIClient",
+    "AsyncTracesClient",
+    "AsyncTracesAPIClient",
     "Config",
     "SupportsToRecord",
     "TraceRecord",
     # Batching
     "Batch",
+    "aiter_batches",
     "iter_batches",
     "read_jsonl_lines",
     "DEFAULT_TARGET_BATCH_BYTES",

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -45,6 +45,7 @@ from typing import (
 from .batching import (
     DEFAULT_TARGET_BATCH_BYTES,
     Batch,
+    _run_async_cleanup_safely,
     aiter_batches,
     read_jsonl_lines,
 )
@@ -85,7 +86,7 @@ async def _arecord_lines(records: AsyncIterable[TraceRecord]) -> AsyncIterator[b
     finally:
         close = getattr(iterator, "aclose", None)
         if close is not None:
-            await close()
+            await _run_async_cleanup_safely(close)
 
 
 def _record_lines_for(

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -28,6 +28,7 @@ import asyncio
 import inspect
 import tempfile
 from collections.abc import AsyncIterable
+from contextlib import aclosing
 from pathlib import Path
 from typing import (
     Any,
@@ -76,9 +77,15 @@ BatchCallback = Callable[[Batch, UploadReceipt], Union[None, Awaitable[None]]]
 async def _arecord_lines(records: AsyncIterable[TraceRecord]) -> AsyncIterator[bytes]:
     """Serialize records from an async producer as they arrive."""
     record_number = 0
-    async for record in records:
-        record_number += 1
-        yield await asyncio.to_thread(_encode_record, record, record_number)
+    iterator = aiter(records)
+    try:
+        async for record in iterator:
+            record_number += 1
+            yield await asyncio.to_thread(_encode_record, record, record_number)
+    finally:
+        close = getattr(iterator, "aclose", None)
+        if close is not None:
+            await close()
 
 
 def _record_lines_for(
@@ -232,21 +239,22 @@ class AsyncTracesClient:
     ) -> List[UploadReceipt]:
         """Upload raw JSONL lines, sync or async. See ``upload_file``."""
         receipts: List[UploadReceipt] = []
-        async for batch in aiter_batches(lines, target_bytes=target_batch_bytes):
-            result = await self._send_with_retry(
-                batch,
-                line_format=line_format,
-                context=context,
-                schema_version=schema_version,
-                compress=compress,
-                max_attempts=max_attempts,
-            )
-            receipt = UploadReceipt.model_validate(result)
-            receipts.append(receipt)
-            if on_batch is not None:
-                outcome = on_batch(batch, receipt)
-                if inspect.isawaitable(outcome):
-                    await outcome
+        async with aclosing(aiter_batches(lines, target_bytes=target_batch_bytes)) as batches:
+            async for batch in batches:
+                result = await self._send_with_retry(
+                    batch,
+                    line_format=line_format,
+                    context=context,
+                    schema_version=schema_version,
+                    compress=compress,
+                    max_attempts=max_attempts,
+                )
+                receipt = UploadReceipt.model_validate(result)
+                receipts.append(receipt)
+                if on_batch is not None:
+                    outcome = on_batch(batch, receipt)
+                    if inspect.isawaitable(outcome):
+                        await outcome
         return receipts
 
     async def _send_with_retry(
@@ -391,7 +399,10 @@ class AsyncTracesClient:
                 await asyncio.to_thread(handle.write, chunk)
                 written += len(chunk)
             await asyncio.to_thread(handle.close)
-            await asyncio.to_thread(partial.replace, dest)
+            # Replacing a sibling file is a fast, atomic metadata operation.
+            # Keep this commit step on the event-loop thread so cancellation
+            # cannot report failure after a detached worker replaced ``dest``.
+            partial.replace(dest)
         except BaseException:
             handle.close()
             partial.unlink(missing_ok=True)

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -363,13 +363,10 @@ class AsyncTracesClient:
 
         A trace can be tens of MiB; prefer ``download_raw`` for large traces.
         """
-        chunks = [
-            chunk
-            async for chunk in self.client.stream_bytes(
-                _trace_endpoint(trace_id), params={"raw": "true"}
-            )
-        ]
-        return b"".join(chunks)
+        stream = self.client.stream_bytes(_trace_endpoint(trace_id), params={"raw": "true"})
+        async with aclosing(stream) as chunks:
+            buffered = [chunk async for chunk in chunks]
+        return b"".join(buffered)
 
     async def download_raw(self, trace_id: str, dest: Union[str, Path]) -> int:
         """Stream the raw trace document to ``dest``. Returns bytes written."""
@@ -386,18 +383,21 @@ class AsyncTracesClient:
         ``dest`` or another download's temporary file.
 
         Writes go to a worker thread so a large download does not block the
-        loop between chunks. The cleanup path stays synchronous on purpose: it
-        also runs when the task is being cancelled, where awaiting again would
-        abandon the partial file on disk.
+        loop between chunks. File cleanup stays synchronous on purpose: it also
+        runs when the task is being cancelled, where awaiting again would
+        abandon the partial file on disk. The response iterator is explicitly
+        closed before that cleanup so it cannot retain a pooled connection.
         """
         dest = Path(dest)
         handle = await _open_partial_file_safely(dest)
         partial = Path(handle.name)
         written = 0
         try:
-            async for chunk in self.client.stream_bytes(endpoint, params=params):
-                await asyncio.to_thread(handle.write, chunk)
-                written += len(chunk)
+            stream = self.client.stream_bytes(endpoint, params=params)
+            async with aclosing(stream) as chunks:
+                async for chunk in chunks:
+                    await asyncio.to_thread(handle.write, chunk)
+                    written += len(chunk)
             await asyncio.to_thread(handle.close)
             # Replacing a sibling file is a fast, atomic metadata operation.
             # Keep this commit step on the event-loop thread so cancellation

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -78,7 +78,7 @@ async def _arecord_lines(records: AsyncIterable[TraceRecord]) -> AsyncIterator[b
     record_number = 0
     async for record in records:
         record_number += 1
-        yield _encode_record(record, record_number)
+        yield await asyncio.to_thread(_encode_record, record, record_number)
 
 
 def _record_lines_for(
@@ -105,6 +105,38 @@ def _open_partial_file(dest: Path):
         suffix=".partial",
         delete=False,
     )
+
+
+async def _open_partial_file_safely(dest: Path):
+    """Open a partial file without leaking it when the caller is cancelled.
+
+    Cancelling ``to_thread`` does not stop a worker that is already running.
+    Shield the worker and, if cancellation arrives, wait until it relinquishes
+    the handle before closing and unlinking the file it may have created.
+    """
+    open_task = asyncio.create_task(asyncio.to_thread(_open_partial_file, dest))
+    try:
+        return await asyncio.shield(open_task)
+    except asyncio.CancelledError:
+        # Repeated cancellation requests must not cancel ``open_task`` either;
+        # without its result there is no path to the delete=False filename.
+        while not open_task.done():
+            try:
+                await asyncio.shield(open_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+
+        if not open_task.cancelled():
+            try:
+                handle = open_task.result()
+            except BaseException:
+                pass
+            else:
+                handle.close()
+                Path(handle.name).unlink(missing_ok=True)
+        raise
 
 
 class AsyncTracesClient:
@@ -351,7 +383,7 @@ class AsyncTracesClient:
         abandon the partial file on disk.
         """
         dest = Path(dest)
-        handle = await asyncio.to_thread(_open_partial_file, dest)
+        handle = await _open_partial_file_safely(dest)
         partial = Path(handle.name)
         written = 0
         try:

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -146,6 +146,41 @@ async def _open_partial_file_safely(dest: Path):
         raise
 
 
+async def _run_file_operation_safely(operation: Callable[..., Any], *args: Any) -> Any:
+    """Run a file operation in a worker without abandoning it on cancellation.
+
+    Cancelling an await of ``to_thread`` does not stop a worker that has already
+    started. Keep the worker task shielded and wait for it to relinquish the
+    file before propagating cancellation, so cleanup never races with an
+    outstanding write or close. Waiting remains asynchronous, which keeps the
+    event loop responsive even when the filesystem is slow.
+    """
+    operation_task = asyncio.create_task(asyncio.to_thread(operation, *args))
+    try:
+        return await asyncio.shield(operation_task)
+    except asyncio.CancelledError:
+        # Repeated cancellation requests must not detach the worker from the
+        # file it still owns. Preserve cancellation, but only after the worker
+        # has completed and cleanup can safely use the handle.
+        while not operation_task.done():
+            try:
+                await asyncio.shield(operation_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+
+        if not operation_task.cancelled():
+            try:
+                operation_task.result()
+            except BaseException:
+                # Cancellation remains the caller-visible outcome. Retrieving
+                # a concurrent filesystem error prevents an unobserved-task
+                # warning while the outer cleanup still closes the handle.
+                pass
+        raise
+
+
 class AsyncTracesClient:
     """Async client for the Prime Traces API."""
 
@@ -396,9 +431,9 @@ class AsyncTracesClient:
             stream = self.client.stream_bytes(endpoint, params=params)
             async with aclosing(stream) as chunks:
                 async for chunk in chunks:
-                    await asyncio.to_thread(handle.write, chunk)
+                    await _run_file_operation_safely(handle.write, chunk)
                     written += len(chunk)
-            await asyncio.to_thread(handle.close)
+            await _run_file_operation_safely(handle.close)
             # Replacing a sibling file is a fast, atomic metadata operation.
             # Keep this commit step on the event-loop thread so cancellation
             # cannot report failure after a detached worker replaced ``dest``.

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -114,6 +114,14 @@ def _open_partial_file(dest: Path):
     )
 
 
+def _discard_partial_file(handle: Any, partial: Path) -> None:
+    """Close a staged download and unlink it even when close/flush fails."""
+    try:
+        handle.close()
+    finally:
+        partial.unlink(missing_ok=True)
+
+
 async def _open_partial_file_safely(dest: Path):
     """Open a partial file without leaking it when the caller is cancelled.
 
@@ -141,8 +149,12 @@ async def _open_partial_file_safely(dest: Path):
             except BaseException:
                 pass
             else:
-                handle.close()
-                Path(handle.name).unlink(missing_ok=True)
+                try:
+                    _discard_partial_file(handle, Path(handle.name))
+                except BaseException:
+                    # Cancellation is the caller-visible outcome. Cleanup is
+                    # best-effort, but close must never prevent the unlink.
+                    pass
         raise
 
 
@@ -439,8 +451,12 @@ class AsyncTracesClient:
             # cannot report failure after a detached worker replaced ``dest``.
             partial.replace(dest)
         except BaseException:
-            handle.close()
-            partial.unlink(missing_ok=True)
+            try:
+                _discard_partial_file(handle, partial)
+            except BaseException:
+                # Preserve the stream, filesystem or cancellation failure that
+                # brought us here; cleanup has still attempted both operations.
+                pass
             raise
         return written
 

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -81,7 +81,7 @@ async def _arecord_lines(records: AsyncIterable[TraceRecord]) -> AsyncIterator[b
     try:
         async for record in iterator:
             record_number += 1
-            yield await asyncio.to_thread(_encode_record, record, record_number)
+            yield await _run_sync_operation_safely(_encode_record, record, record_number)
     finally:
         close = getattr(iterator, "aclose", None)
         if close is not None:
@@ -158,14 +158,14 @@ async def _open_partial_file_safely(dest: Path):
         raise
 
 
-async def _run_file_operation_safely(operation: Callable[..., Any], *args: Any) -> Any:
-    """Run a file operation in a worker without abandoning it on cancellation.
+async def _run_sync_operation_safely(operation: Callable[..., Any], *args: Any) -> Any:
+    """Run synchronous work in a worker without abandoning it on cancellation.
 
     Cancelling an await of ``to_thread`` does not stop a worker that has already
-    started. Keep the worker task shielded and wait for it to relinquish the
-    file before propagating cancellation, so cleanup never races with an
-    outstanding write or close. Waiting remains asynchronous, which keeps the
-    event loop responsive even when the filesystem is slow.
+    started. Keep the worker task shielded and wait for it to finish before
+    propagating cancellation, so producer or file cleanup never races with
+    outstanding synchronous work. Waiting remains asynchronous, which keeps
+    the event loop responsive while the worker finishes.
     """
     operation_task = asyncio.create_task(asyncio.to_thread(operation, *args))
     try:
@@ -187,8 +187,8 @@ async def _run_file_operation_safely(operation: Callable[..., Any], *args: Any) 
                 operation_task.result()
             except BaseException:
                 # Cancellation remains the caller-visible outcome. Retrieving
-                # a concurrent filesystem error prevents an unobserved-task
-                # warning while the outer cleanup still closes the handle.
+                # a concurrent operation error prevents an unobserved-task
+                # warning while the outer cleanup releases owned resources.
                 pass
         raise
 
@@ -443,9 +443,9 @@ class AsyncTracesClient:
             stream = self.client.stream_bytes(endpoint, params=params)
             async with aclosing(stream) as chunks:
                 async for chunk in chunks:
-                    await _run_file_operation_safely(handle.write, chunk)
+                    await _run_sync_operation_safely(handle.write, chunk)
                     written += len(chunk)
-            await _run_file_operation_safely(handle.close)
+            await _run_sync_operation_safely(handle.close)
             # Replacing a sibling file is a fast, atomic metadata operation.
             # Keep this commit step on the event-loop thread so cancellation
             # cannot report failure after a detached worker replaced ``dest``.

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -1,37 +1,54 @@
-"""High-level client for Prime Traces.
+"""Async high-level client for Prime Traces.
 
-Wraps the wire client with upload batching/retry and typed read paths.
+The asyncio counterpart of ``traces.TracesClient``, with the same method
+names, arguments, return types and failure semantics. Everything that decides
+*what* a call does — filter encoding, ID encoding, record serialization,
+batching, retry classification — is imported from the sync modules rather than
+restated, so the two surfaces cannot answer the same question differently. The
+async client owns only the awaiting, plus two things a sync client never has
+to think about:
 
-The read surface matches the service's pinned response models
-(``prime-traces/src/traces/models.py`` and ``src/episodes/models.py`` in the
-platform repo): pages are ``{items, next_cursor}``, trace summaries nest
-``model``/``score``/``execution``, episodes nest ``error`` and the member
-aggregate.
+- Blocking work is moved off the event loop. Reading a JSONL file, hashing a
+  batch, gzipping a body and writing a download to disk all happen in worker
+  threads, so one 30 MiB upload does not stall every other task in the
+  process.
+- Producers may be async. ``upload_records`` and ``upload_lines`` accept an
+  async iterable as readily as a sync one, so rollouts can stream straight
+  from an async generator without being collected first.
 
-Deliberately not implemented (open v0 contract decisions — do not freeze
-them here): exports in any form — the service publishes ``GET /traces/export``
-and the job routes, but all three handlers raise ``NotImplementedError``,
-which FastAPI answers as 500, and the streaming route declares no query
-parameters, so there is no filter vocabulary to bind to; ``/search``; episode
-writes (episodes are read-only, written only as a side effect of
-episode-grouped uploads); and the dot-path query compiler (needs the server-side
-field registry).
+Uploads still send one batch at a time. The contract allows 2–8 requests in
+flight per producer, but that is a throughput decision to make against the
+running service, and a concurrent version has to answer what a durable
+rejection means for batches already in flight — so the ordering, the receipt
+sequence and the stop-on-400 behaviour stay identical to the sync client for
+now.
 """
 
-import json
+import asyncio
+import inspect
 import tempfile
-import time
+from collections.abc import AsyncIterable
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Protocol, Union
-from urllib.parse import quote
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
 
 from .batching import (
     DEFAULT_TARGET_BATCH_BYTES,
     Batch,
-    iter_batches,
+    aiter_batches,
     read_jsonl_lines,
 )
-from .core.client import TracesAPIClient, retry_delay
+from .core.async_client import AsyncTracesAPIClient, retry_sleep
+from .core.client import retry_delay
 from .exceptions import RetryableAPIError, TransportError
 from .models import (
     EpisodeDetail,
@@ -41,113 +58,66 @@ from .models import (
     TraceSummary,
     UploadReceipt,
 )
+from .traces import (
+    DEFAULT_MAX_ATTEMPTS,
+    TraceRecord,
+    _build_params,
+    _encode_record,
+    _episode_endpoint,
+    _record_lines,
+    _trace_endpoint,
+)
 
-DEFAULT_MAX_ATTEMPTS = 5
-
-
-class SupportsToRecord(Protocol):
-    """An in-memory trace or episode that can produce its JSON record.
-
-    Verifiers ``Trace`` / ``Episode`` and prime-rl ``Rollout`` objects satisfy
-    this protocol without prime-traces importing either producer package.
-    """
-
-    def to_record(self) -> Mapping[str, Any]: ...
-
-
-TraceRecord = Union[Mapping[str, Any], SupportsToRecord]
+#: An ``on_batch`` hook may be a plain callable or a coroutine function; the
+#: uploader awaits whatever it returns if that turns out to be awaitable.
+BatchCallback = Callable[[Batch, UploadReceipt], Union[None, Awaitable[None]]]
 
 
-def _encode_record(record: TraceRecord, record_number: int) -> bytes:
-    """Serialize one in-memory record as a compact UTF-8 JSONL line.
-
-    Shared with the async client so both surfaces produce byte-identical
-    lines — and therefore the same content-addressed upload IDs — for the
-    same records.
-    """
-    if isinstance(record, Mapping):
-        value = record
-    else:
-        to_record = getattr(record, "to_record", None)
-        if not callable(to_record):
-            raise TypeError(f"Record {record_number} must be a mapping or implement to_record()")
-        value = to_record()
-        if not isinstance(value, Mapping):
-            raise TypeError(f"Record {record_number} to_record() must return a mapping")
-
-    # Compact separators match common JSONL writers, ensure_ascii=False
-    # keeps the wire representation UTF-8, and allow_nan=False prevents
-    # emitting JavaScript-only NaN/Infinity values that strict JSON rejects.
-    return (
-        json.dumps(
-            dict(value),
-            ensure_ascii=False,
-            allow_nan=False,
-            separators=(",", ":"),
-        ).encode("utf-8")
-        + b"\n"
-    )
-
-
-def _record_lines(records: Iterable[TraceRecord]) -> Iterator[bytes]:
-    """Serialize in-memory records lazily as compact UTF-8 JSONL lines."""
-    for record_number, record in enumerate(records, start=1):
+async def _arecord_lines(records: AsyncIterable[TraceRecord]) -> AsyncIterator[bytes]:
+    """Serialize records from an async producer as they arrive."""
+    record_number = 0
+    async for record in records:
+        record_number += 1
         yield _encode_record(record, record_number)
 
 
-def _build_params(
-    pairs: Iterable[tuple], context: Optional[Dict[str, str]] = None
-) -> Dict[str, object]:
-    """Drop unset filters and expand the context map to ``context.<key>``."""
-    params: Dict[str, object] = {key: value for key, value in pairs if value is not None}
-    if context:
-        for key, value in context.items():
-            params[f"context.{key}"] = value
-    return params
+def _record_lines_for(
+    records: Union[Iterable[TraceRecord], AsyncIterable[TraceRecord]],
+) -> Union[Iterable[bytes], AsyncIterator[bytes]]:
+    """Encode records, preserving whether the source is sync or async.
+
+    ``aiter_batches`` consumes a synchronous source entirely in a worker
+    thread, so handing it the sync generator — rather than adapting it to an
+    async one here — is what keeps ``json.dumps`` over large records off the
+    event loop.
+    """
+    if isinstance(records, AsyncIterable):
+        return _arecord_lines(records)
+    return _record_lines(records)
 
 
-def _encoded_id_segment(identifier: str, *, parameter_name: str) -> str:
-    """Encode a resource ID as one URL path segment."""
-    if "/" in identifier:
-        # ASGI decodes %2F before Starlette route matching, so the service's
-        # /{resource}/{id} routes see an extra path segment and return 404.
-        # Fail locally until that route accepts a path-valued parameter rather
-        # than issuing a request that cannot address the uploaded resource.
-        raise ValueError(
-            f"{parameter_name} cannot contain '/' until the service supports path-valued IDs"
-        )
-    encoded = quote(identifier, safe="")
-    # RFC 3986 leaves periods unescaped even with ``safe=""``. A segment that
-    # is exactly "." or ".." is special, though: HTTP clients normalize it
-    # away before sending the request, which would target the collection or API
-    # root instead of the requested trace. Percent-encode those two IDs
-    # explicitly so they remain ordinary path-segment values on the wire.
-    if encoded in {".", ".."}:
-        encoded = encoded.replace(".", "%2E")
-    return encoded
+def _open_partial_file(dest: Path):
+    """Open the sibling temporary file a download is staged through."""
+    return tempfile.NamedTemporaryFile(
+        mode="wb",
+        dir=dest.parent,
+        prefix=".prime-traces-",
+        suffix=".partial",
+        delete=False,
+    )
 
 
-def _trace_endpoint(trace_id: str) -> str:
-    """Build a trace endpoint with the ID encoded as one path segment."""
-    return f"/traces/{_encoded_id_segment(trace_id, parameter_name='trace_id')}"
+class AsyncTracesClient:
+    """Async client for the Prime Traces API."""
 
-
-def _episode_endpoint(episode_id: str) -> str:
-    """Build an episode endpoint with the ID encoded as one path segment."""
-    return f"/episodes/{_encoded_id_segment(episode_id, parameter_name='episode_id')}"
-
-
-class TracesClient:
-    """Client for the Prime Traces API."""
-
-    def __init__(self, api_client: Optional[TracesAPIClient] = None, **client_kwargs):
-        self.client = api_client or TracesAPIClient(**client_kwargs)
+    def __init__(self, api_client: Optional[AsyncTracesAPIClient] = None, **client_kwargs):
+        self.client = api_client or AsyncTracesAPIClient(**client_kwargs)
 
     # -- upload -------------------------------------------------------------
 
-    def upload_records(
+    async def upload_records(
         self,
-        records: Iterable[TraceRecord],
+        records: Union[Iterable[TraceRecord], AsyncIterable[TraceRecord]],
         *,
         line_format: LineFormat = LineFormat.TRACE,
         context: Optional[Dict[str, str]] = None,
@@ -155,18 +125,18 @@ class TracesClient:
         compress: bool = True,
         target_batch_bytes: int = DEFAULT_TARGET_BATCH_BYTES,
         max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-        on_batch: Optional[Callable[[Batch, UploadReceipt], None]] = None,
+        on_batch: Optional[BatchCallback] = None,
     ) -> List[UploadReceipt]:
         """Upload trace or episode records directly from memory.
 
         Each input may be a JSON-compatible mapping or an object implementing
         ``to_record()``, including verifiers ``Trace`` / ``Episode`` and
-        prime-rl ``Rollout`` objects. Records are serialized lazily and passed
-        through the same bounded batching path as JSONL files, so the complete
-        input is never buffered or written to disk.
+        prime-rl ``Rollout`` objects. The records may arrive from an async
+        producer: an async generator of rollouts uploads incrementally, in
+        bounded batches, without ever being collected into a list.
         """
-        return self.upload_lines(
-            _record_lines(records),
+        return await self.upload_lines(
+            _record_lines_for(records),
             line_format=line_format,
             context=context,
             schema_version=schema_version,
@@ -176,7 +146,7 @@ class TracesClient:
             on_batch=on_batch,
         )
 
-    def upload_file(
+    async def upload_file(
         self,
         path: Union[str, Path],
         *,
@@ -186,7 +156,7 @@ class TracesClient:
         compress: bool = True,
         target_batch_bytes: int = DEFAULT_TARGET_BATCH_BYTES,
         max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-        on_batch: Optional[Callable[[Batch, UploadReceipt], None]] = None,
+        on_batch: Optional[BatchCallback] = None,
     ) -> List[UploadReceipt]:
         """Upload a completed JSONL file of traces (or episodes).
 
@@ -202,11 +172,10 @@ class TracesClient:
         ambiguous failure safe, because a request that did land replays its
         receipt instead of storing twice.
 
-        Batches are sent sequentially in v0. The contract allows 2–8 requests
-        in flight per producer; add bounded concurrency here once the service
-        is up and throughput is measured.
+        The file is read in a worker thread, so a large upload does not block
+        the loop between requests.
         """
-        return self.upload_lines(
+        return await self.upload_lines(
             read_jsonl_lines(path),
             line_format=line_format,
             context=context,
@@ -217,9 +186,9 @@ class TracesClient:
             on_batch=on_batch,
         )
 
-    def upload_lines(
+    async def upload_lines(
         self,
-        lines: Iterable[bytes],
+        lines: Union[Iterable[bytes], AsyncIterable[bytes]],
         *,
         line_format: LineFormat = LineFormat.TRACE,
         context: Optional[Dict[str, str]] = None,
@@ -227,12 +196,12 @@ class TracesClient:
         compress: bool = True,
         target_batch_bytes: int = DEFAULT_TARGET_BATCH_BYTES,
         max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-        on_batch: Optional[Callable[[Batch, UploadReceipt], None]] = None,
+        on_batch: Optional[BatchCallback] = None,
     ) -> List[UploadReceipt]:
-        """Upload an iterable of raw JSONL lines. See ``upload_file``."""
+        """Upload raw JSONL lines, sync or async. See ``upload_file``."""
         receipts: List[UploadReceipt] = []
-        for batch in iter_batches(lines, target_bytes=target_batch_bytes):
-            result = self._send_with_retry(
+        async for batch in aiter_batches(lines, target_bytes=target_batch_bytes):
+            result = await self._send_with_retry(
                 batch,
                 line_format=line_format,
                 context=context,
@@ -243,10 +212,12 @@ class TracesClient:
             receipt = UploadReceipt.model_validate(result)
             receipts.append(receipt)
             if on_batch is not None:
-                on_batch(batch, receipt)
+                outcome = on_batch(batch, receipt)
+                if inspect.isawaitable(outcome):
+                    await outcome
         return receipts
 
-    def _send_with_retry(
+    async def _send_with_retry(
         self,
         batch: Batch,
         *,
@@ -261,7 +232,7 @@ class TracesClient:
         last_error: Optional[Exception] = None
         for attempt in range(max_attempts):
             try:
-                return self.client.upload_batch(
+                return await self.client.upload_batch(
                     batch.data,
                     batch.idempotency_key,
                     line_format=line_format,
@@ -273,13 +244,13 @@ class TracesClient:
                 last_error = exc
                 if attempt == max_attempts - 1:
                     break
-                time.sleep(retry_delay(exc, attempt))
+                await retry_sleep(retry_delay(exc, attempt))
         assert last_error is not None
         raise last_error
 
     # -- traces: read -------------------------------------------------------
 
-    def list(
+    async def list(
         self,
         *,
         run_id: Optional[str] = None,
@@ -325,9 +296,9 @@ class TracesClient:
             ),
             context,
         )
-        return TraceListPage.model_validate(self.client.get_json("/traces", params=params))
+        return TraceListPage.model_validate(await self.client.get_json("/traces", params=params))
 
-    def iter(self, **filters) -> Iterator[TraceSummary]:
+    async def iter(self, **filters: Any) -> AsyncIterator[TraceSummary]:
         """Iterate all matching trace summaries across pages.
 
         Transient failures are retried inside the API client with a bounded
@@ -336,28 +307,35 @@ class TracesClient:
         """
         cursor = filters.pop("cursor", None)
         while True:
-            page = self.list(cursor=cursor, **filters)
-            yield from page.items
+            page = await self.list(cursor=cursor, **filters)
+            for summary in page.items:
+                yield summary
             if not page.next_cursor:
                 return
             cursor = page.next_cursor
 
-    def get(self, trace_id: str) -> TraceSummary:
+    async def get(self, trace_id: str) -> TraceSummary:
         """Get one trace summary."""
-        return TraceSummary.model_validate(self.client.get_json(_trace_endpoint(trace_id)))
+        return TraceSummary.model_validate(await self.client.get_json(_trace_endpoint(trace_id)))
 
-    def get_raw(self, trace_id: str) -> bytes:
+    async def get_raw(self, trace_id: str) -> bytes:
         """Get the stored raw trace document, buffered in memory.
 
         A trace can be tens of MiB; prefer ``download_raw`` for large traces.
         """
-        return b"".join(self.client.stream_bytes(_trace_endpoint(trace_id), params={"raw": "true"}))
+        chunks = [
+            chunk
+            async for chunk in self.client.stream_bytes(
+                _trace_endpoint(trace_id), params={"raw": "true"}
+            )
+        ]
+        return b"".join(chunks)
 
-    def download_raw(self, trace_id: str, dest: Union[str, Path]) -> int:
+    async def download_raw(self, trace_id: str, dest: Union[str, Path]) -> int:
         """Stream the raw trace document to ``dest``. Returns bytes written."""
-        return self._stream_to_file(_trace_endpoint(trace_id), {"raw": "true"}, dest)
+        return await self._stream_to_file(_trace_endpoint(trace_id), {"raw": "true"}, dest)
 
-    def _stream_to_file(
+    async def _stream_to_file(
         self, endpoint: str, params: Optional[Dict[str, object]], dest: Union[str, Path]
     ) -> int:
         """Stream a response body to ``dest`` without clobbering it on failure.
@@ -366,32 +344,31 @@ class TracesClient:
         ``dest`` only after the stream ends cleanly, so a failed request — or a
         connection cut mid-stream — never truncates an existing file at
         ``dest`` or another download's temporary file.
+
+        Writes go to a worker thread so a large download does not block the
+        loop between chunks. The cleanup path stays synchronous on purpose: it
+        also runs when the task is being cancelled, where awaiting again would
+        abandon the partial file on disk.
         """
         dest = Path(dest)
-        partial: Optional[Path] = None
+        handle = await asyncio.to_thread(_open_partial_file, dest)
+        partial = Path(handle.name)
         written = 0
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="wb",
-                dir=dest.parent,
-                prefix=".prime-traces-",
-                suffix=".partial",
-                delete=False,
-            ) as f:
-                partial = Path(f.name)
-                for chunk in self.client.stream_bytes(endpoint, params=params):
-                    f.write(chunk)
-                    written += len(chunk)
-            partial.replace(dest)
+            async for chunk in self.client.stream_bytes(endpoint, params=params):
+                await asyncio.to_thread(handle.write, chunk)
+                written += len(chunk)
+            await asyncio.to_thread(handle.close)
+            await asyncio.to_thread(partial.replace, dest)
         except BaseException:
-            if partial is not None:
-                partial.unlink(missing_ok=True)
+            handle.close()
+            partial.unlink(missing_ok=True)
             raise
         return written
 
     # -- traces: delete -----------------------------------------------------
 
-    def delete(self, trace_id: str, *, created_at: Optional[str] = None) -> None:
+    async def delete(self, trace_id: str, *, created_at: Optional[str] = None) -> None:
         """Delete every stored copy of one trace (202 Accepted).
 
         ``created_at`` is an optional performance hint that lets the service
@@ -405,33 +382,29 @@ class TracesClient:
         copy uploaded between attempts.
 
         Raises ``NotFoundError`` when the owner has no such trace — including
-        on a repeat of a delete that already succeeded. The design docs
-        specify deletion as idempotent at the API level; the service checks
-        existence first and answers 404 instead. Callers treating deletion as
-        "make sure this is gone" should catch ``NotFoundError``.
+        on a repeat of a delete that already succeeded. Callers treating
+        deletion as "make sure this is gone" should catch ``NotFoundError``.
         """
         params = {"created_at": created_at} if created_at else None
-        self.client.delete(_trace_endpoint(trace_id), params=params)
+        await self.client.delete(_trace_endpoint(trace_id), params=params)
 
-    def delete_run(self, run_id: str) -> None:
+    async def delete_run(self, run_id: str) -> None:
         """Delete every trace in a run (202 Accepted).
 
         One mutation over the ``run_id`` predicate, not N per-trace calls, and
-        synchronous: the service answers 202 with an empty body, so there is
-        no job to poll. (The design docs specify ``202 { job_id }``; nothing
-        server-side issues one, so no job handle is returned here rather than
-        a permanent ``None``.)
+        synchronous on the service side: it answers 202 with an empty body, so
+        there is no job to poll.
 
         Episode rows are not touched. Raises ``NotFoundError`` when the run
         holds no traces for this owner — see ``delete`` on repeats. An
         ``AmbiguousDeleteError`` is not retried because a replay could delete
         traces added to the run after the first request.
         """
-        self.client.delete("/traces", params={"run_id": run_id})
+        await self.client.delete("/traces", params={"run_id": run_id})
 
     # -- episodes (read-only in v0) -----------------------------------------
 
-    def list_episodes(
+    async def list_episodes(
         self,
         *,
         run_id: Optional[str] = None,
@@ -460,18 +433,22 @@ class TracesClient:
                 ("cursor", cursor),
             )
         )
-        return EpisodeListPage.model_validate(self.client.get_json("/episodes", params=params))
+        return EpisodeListPage.model_validate(
+            await self.client.get_json("/episodes", params=params)
+        )
 
-    def get_episode(self, episode_id: str) -> EpisodeDetail:
+    async def get_episode(self, episode_id: str) -> EpisodeDetail:
         """Episode-owned fields plus the read-time member-trace aggregate.
 
         The response carries the episode row's own ``has_error``/``error``
         alongside ``traces.any_trace_error``, so an environment-hook failure
         stays visible even when every individual trace succeeded.
         """
-        return EpisodeDetail.model_validate(self.client.get_json(_episode_endpoint(episode_id)))
+        return EpisodeDetail.model_validate(
+            await self.client.get_json(_episode_endpoint(episode_id))
+        )
 
-    def list_episode_traces(
+    async def list_episode_traces(
         self,
         episode_id: str,
         *,
@@ -517,14 +494,14 @@ class TracesClient:
             context,
         )
         return TraceListPage.model_validate(
-            self.client.get_json(f"{_episode_endpoint(episode_id)}/traces", params=params)
+            await self.client.get_json(f"{_episode_endpoint(episode_id)}/traces", params=params)
         )
 
-    def close(self) -> None:
-        self.client.close()
+    async def aclose(self) -> None:
+        await self.client.aclose()
 
-    def __enter__(self) -> "TracesClient":
+    async def __aenter__(self) -> "AsyncTracesClient":
         return self
 
-    def __exit__(self, *exc_info) -> None:
-        self.close()
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()

--- a/packages/prime-traces/src/prime_traces/async_traces.py
+++ b/packages/prime-traces/src/prime_traces/async_traces.py
@@ -1,28 +1,4 @@
-"""Async high-level client for Prime Traces.
-
-The asyncio counterpart of ``traces.TracesClient``, with the same method
-names, arguments, return types and failure semantics. Everything that decides
-*what* a call does — filter encoding, ID encoding, record serialization,
-batching, retry classification — is imported from the sync modules rather than
-restated, so the two surfaces cannot answer the same question differently. The
-async client owns only the awaiting, plus two things a sync client never has
-to think about:
-
-- Blocking work is moved off the event loop. Reading a JSONL file, hashing a
-  batch, gzipping a body and writing a download to disk all happen in worker
-  threads, so one 30 MiB upload does not stall every other task in the
-  process.
-- Producers may be async. ``upload_records`` and ``upload_lines`` accept an
-  async iterable as readily as a sync one, so rollouts can stream straight
-  from an async generator without being collected first.
-
-Uploads still send one batch at a time. The contract allows 2–8 requests in
-flight per producer, but that is a throughput decision to make against the
-running service, and a concurrent version has to answer what a durable
-rejection means for batches already in flight — so the ordering, the receipt
-sequence and the stop-on-400 behaviour stay identical to the sync client for
-now.
-"""
+"""Async high-level client for Prime Traces."""
 
 import asyncio
 import inspect

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -22,7 +22,7 @@ import threading
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncGenerator, Generator, Iterable, Iterator, Union
+from typing import AsyncGenerator, Callable, Generator, Iterable, Iterator, Union
 
 from .exceptions import TraceTooLargeError
 
@@ -85,6 +85,36 @@ def read_jsonl_lines(path: Union[str, Path]) -> Iterator[bytes]:
     """
     with open(path, "rb") as f:
         yield from f
+
+
+async def _run_sync_cleanup_safely(operation: Callable[[], None]) -> None:
+    """Finish worker-thread cleanup before propagating cancellation.
+
+    Cancelling ``to_thread`` only cancels the coroutine waiting for the worker;
+    it does not stop the worker itself. Shield its task and wait through repeat
+    cancellation requests so callers cannot regain control while a synchronous
+    source is still open in the background.
+    """
+    operation_task = asyncio.create_task(asyncio.to_thread(operation))
+    try:
+        await asyncio.shield(operation_task)
+    except asyncio.CancelledError:
+        while not operation_task.done():
+            try:
+                await asyncio.shield(operation_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+
+        if not operation_task.cancelled():
+            try:
+                operation_task.result()
+            except BaseException:
+                # Cancellation remains caller-visible. Retrieving a concurrent
+                # cleanup error also prevents an unobserved-task warning.
+                pass
+        raise
 
 
 class _BatchBuilder:
@@ -229,7 +259,7 @@ async def aiter_batches(
                     return
                 yield batch
         finally:
-            await asyncio.to_thread(close_iterator)
+            await _run_sync_cleanup_safely(close_iterator)
     else:
         builder = _BatchBuilder(
             target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -134,7 +134,10 @@ async def _run_async_cleanup_safely(operation: Callable[[], Awaitable[None]]) ->
     Shield the close task and wait through further cancellation requests so
     the source is closed before its consumer regains control.
     """
-    operation_task = asyncio.create_task(operation())
+    # ``aclose`` is an optional duck-typed hook on user-provided sources. It
+    # may return any Awaitable (including a Future), while ``create_task`` only
+    # accepts coroutine objects.
+    operation_task = asyncio.ensure_future(operation())
     try:
         await asyncio.shield(operation_task)
     except asyncio.CancelledError:

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -22,7 +22,7 @@ import threading
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncIterator, Generator, Iterable, Iterator, Union
+from typing import AsyncGenerator, Generator, Iterable, Iterator, Union
 
 from .exceptions import TraceTooLargeError
 
@@ -178,7 +178,7 @@ async def aiter_batches(
     target_bytes: int = DEFAULT_TARGET_BATCH_BYTES,
     max_line_bytes: int = MAX_LINE_BYTES,
     max_lines: int = MAX_BATCH_LINES,
-) -> AsyncIterator[Batch]:
+) -> AsyncGenerator[Batch, None]:
     """Async counterpart of ``iter_batches``, accepting either kind of input.
 
     Batching is CPU- and disk-bound, not I/O-concurrent, so the work is moved
@@ -222,13 +222,22 @@ async def aiter_batches(
             target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
         )
         line_number = 0
-        async for line in lines:
-            line_number += 1
-            if not line.strip():
-                continue
-            if builder.closes_before(line_number, line):
-                yield await asyncio.to_thread(builder.close)
-            builder.add(line_number, line)
+        iterator = aiter(lines)
+        try:
+            async for line in iterator:
+                line_number += 1
+                if not line.strip():
+                    continue
+                if builder.closes_before(line_number, line):
+                    yield await asyncio.to_thread(builder.close)
+                builder.add(line_number, line)
 
-        if builder.pending:
-            yield await asyncio.to_thread(builder.close)
+            if builder.pending:
+                yield await asyncio.to_thread(builder.close)
+        finally:
+            # ``async for`` does not close an iterator when this batching
+            # generator is abandoned. Propagate cleanup to async generators
+            # that may own files, connections or producer tasks.
+            close = getattr(iterator, "aclose", None)
+            if close is not None:
+                await close()

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -46,6 +46,19 @@ MAX_BATCH_LINES = 1_000_000
 DEFAULT_TARGET_BATCH_BYTES = 30 * MIB
 
 
+def _is_blank_line(line: bytes) -> bool:
+    """Whether ``line`` contains only ASCII whitespace, without copying it."""
+    return not line or line.isspace()
+
+
+def _line_content_size(line: bytes) -> int:
+    """Return the byte length after trailing LF terminators, without slicing."""
+    end = len(line)
+    while end and line[end - 1] == 0x0A:
+        end -= 1
+    return end
+
+
 @dataclass(frozen=True)
 class Batch:
     """One upload request's exact bytes and content-addressed identity."""
@@ -105,7 +118,7 @@ class _BatchBuilder:
 
     def closes_before(self, line_number: int, line: bytes) -> bool:
         """Validate ``line``, then report whether it must start a new batch."""
-        content_size = len(line.rstrip(b"\n"))
+        content_size = _line_content_size(line)
         if content_size > self._max_line_bytes:
             raise TraceTooLargeError(line_number, content_size, self._max_line_bytes)
         return bool(self._buffer) and (
@@ -162,7 +175,7 @@ def iter_batches(
         target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
     )
     for line_number, line in enumerate(lines, start=1):
-        if not line.strip():
+        if _is_blank_line(line):
             continue
         if builder.closes_before(line_number, line):
             yield builder.close()
@@ -226,7 +239,7 @@ async def aiter_batches(
         try:
             async for line in iterator:
                 line_number += 1
-                if not line.strip():
+                if _is_blank_line(line):
                     continue
                 if builder.closes_before(line_number, line):
                     yield await asyncio.to_thread(builder.close)

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -18,10 +18,11 @@ The contract this implements (see the Prime Traces design docs):
 
 import asyncio
 import hashlib
+import threading
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncIterator, Iterable, Iterator, Union
+from typing import AsyncIterator, Generator, Iterable, Iterator, Union
 
 from .exceptions import TraceTooLargeError
 
@@ -142,7 +143,7 @@ def iter_batches(
     target_bytes: int = DEFAULT_TARGET_BATCH_BYTES,
     max_line_bytes: int = MAX_LINE_BYTES,
     max_lines: int = MAX_BATCH_LINES,
-) -> Iterator[Batch]:
+) -> Generator[Batch, None, None]:
     """Group JSONL lines into content-addressed request batches.
 
     Whitespace-only lines are skipped. Each kept line contributes its exact
@@ -192,17 +193,30 @@ async def aiter_batches(
         iterator = iter_batches(
             lines, target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
         )
+        iterator_lock = threading.Lock()
+
+        def next_batch() -> Union[Batch, None]:
+            # Cancelling ``to_thread`` does not stop the worker. Serialize
+            # ``next`` and ``close`` so cleanup cannot close a generator that
+            # the worker is still executing.
+            with iterator_lock:
+                return next(iterator, None)
+
+        def close_iterator() -> None:
+            with iterator_lock:
+                iterator.close()
+
         try:
             while True:
                 # `next` re-enters the generator in a worker thread, one batch
                 # at a time, so an aborted upload stops reading the source
                 # instead of draining it into memory.
-                batch = await asyncio.to_thread(next, iterator, None)
+                batch = await asyncio.to_thread(next_batch)
                 if batch is None:
                     return
                 yield batch
         finally:
-            iterator.close()
+            await asyncio.to_thread(close_iterator)
     else:
         builder = _BatchBuilder(
             target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -22,7 +22,7 @@ import threading
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncGenerator, Callable, Generator, Iterable, Iterator, Union
+from typing import AsyncGenerator, Awaitable, Callable, Generator, Iterable, Iterator, Union
 
 from .exceptions import TraceTooLargeError
 
@@ -96,6 +96,36 @@ async def _run_sync_cleanup_safely(operation: Callable[[], None]) -> None:
     source is still open in the background.
     """
     operation_task = asyncio.create_task(asyncio.to_thread(operation))
+    try:
+        await asyncio.shield(operation_task)
+    except asyncio.CancelledError:
+        while not operation_task.done():
+            try:
+                await asyncio.shield(operation_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+
+        if not operation_task.cancelled():
+            try:
+                operation_task.result()
+            except BaseException:
+                # Cancellation remains caller-visible. Retrieving a concurrent
+                # cleanup error also prevents an unobserved-task warning.
+                pass
+        raise
+
+
+async def _run_async_cleanup_safely(operation: Callable[[], Awaitable[None]]) -> None:
+    """Finish async source cleanup before propagating cancellation.
+
+    A repeated cancellation request can otherwise interrupt an iterator's
+    ``aclose()`` while it is releasing files, connections or producer tasks.
+    Shield the close task and wait through further cancellation requests so
+    the source is closed before its consumer regains control.
+    """
+    operation_task = asyncio.create_task(operation())
     try:
         await asyncio.shield(operation_task)
     except asyncio.CancelledError:
@@ -283,4 +313,4 @@ async def aiter_batches(
             # that may own files, connections or producer tasks.
             close = getattr(iterator, "aclose", None)
             if close is not None:
-                await close()
+                await _run_async_cleanup_safely(close)

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -16,10 +16,12 @@ The contract this implements (see the Prime Traces design docs):
   deterministic for a given input.
 """
 
+import asyncio
 import hashlib
+from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator, Union
+from typing import AsyncIterator, Iterable, Iterator, Union
 
 from .exceptions import TraceTooLargeError
 
@@ -71,6 +73,69 @@ def read_jsonl_lines(path: Union[str, Path]) -> Iterator[bytes]:
         yield from f
 
 
+class _BatchBuilder:
+    """Accumulation state behind ``iter_batches`` and ``aiter_batches``.
+
+    Both entry points must produce identical batches — and therefore identical
+    idempotency keys — for the same lines, so the closing rules live here once
+    rather than being restated per entry point.
+    """
+
+    def __init__(self, *, target_bytes: int, max_line_bytes: int, max_lines: int) -> None:
+        if target_bytes <= 0:
+            raise ValueError("target_bytes must be positive")
+        if target_bytes > MAX_BATCH_BYTES:
+            raise ValueError(
+                f"target_bytes ({target_bytes}) exceeds the {MAX_BATCH_BYTES} byte request cap"
+            )
+        if max_lines <= 0:
+            raise ValueError("max_lines must be positive")
+        self._target_bytes = target_bytes
+        self._max_line_bytes = max_line_bytes
+        self._max_lines = max_lines
+        self._buffer: list[bytes] = []
+        self._buffered_size = 0
+        self._batch_start_line = 0
+
+    @property
+    def pending(self) -> bool:
+        """Whether any line is buffered and awaiting a final ``close()``."""
+        return bool(self._buffer)
+
+    def closes_before(self, line_number: int, line: bytes) -> bool:
+        """Validate ``line``, then report whether it must start a new batch."""
+        content_size = len(line.rstrip(b"\n"))
+        if content_size > self._max_line_bytes:
+            raise TraceTooLargeError(line_number, content_size, self._max_line_bytes)
+        return bool(self._buffer) and (
+            self._buffered_size + len(line) > self._target_bytes
+            or len(self._buffer) >= self._max_lines
+        )
+
+    def add(self, line_number: int, line: bytes) -> None:
+        if not self._buffer:
+            self._batch_start_line = line_number
+        self._buffer.append(line)
+        self._buffered_size += len(line)
+
+    def close(self) -> Batch:
+        """Seal the buffered lines into a batch and reset.
+
+        This is where the joining and hashing happen, so it is the one call
+        worth handing to a worker thread on the async path.
+        """
+        data = b"".join(self._buffer)
+        batch = Batch(
+            data=data,
+            digest=hashlib.sha256(data).hexdigest(),
+            num_lines=len(self._buffer),
+            first_line_number=self._batch_start_line,
+        )
+        self._buffer = []
+        self._buffered_size = 0
+        return batch
+
+
 def iter_batches(
     lines: Iterable[bytes],
     *,
@@ -92,45 +157,64 @@ def iter_batches(
     ``too_many_traces_in_upload`` — a 400 the retry semantics treat as
     "correct the file" when the file is fine and only the chunking is not.
     """
-    if target_bytes <= 0:
-        raise ValueError("target_bytes must be positive")
-    if target_bytes > MAX_BATCH_BYTES:
-        raise ValueError(
-            f"target_bytes ({target_bytes}) exceeds the {MAX_BATCH_BYTES} byte request cap"
-        )
-    if max_lines <= 0:
-        raise ValueError("max_lines must be positive")
-
-    buffer: list[bytes] = []
-    buffered_size = 0
-    batch_start_line = 0
-
-    def close() -> Batch:
-        nonlocal buffer, buffered_size
-        data = b"".join(buffer)
-        batch = Batch(
-            data=data,
-            digest=hashlib.sha256(data).hexdigest(),
-            num_lines=len(buffer),
-            first_line_number=batch_start_line,
-        )
-        buffer = []
-        buffered_size = 0
-        return batch
-
+    builder = _BatchBuilder(
+        target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
+    )
     for line_number, line in enumerate(lines, start=1):
         if not line.strip():
             continue
-        content_size = len(line.rstrip(b"\n"))
-        if content_size > max_line_bytes:
-            raise TraceTooLargeError(line_number, content_size, max_line_bytes)
+        if builder.closes_before(line_number, line):
+            yield builder.close()
+        builder.add(line_number, line)
 
-        if buffer and (buffered_size + len(line) > target_bytes or len(buffer) >= max_lines):
-            yield close()
-        if not buffer:
-            batch_start_line = line_number
-        buffer.append(line)
-        buffered_size += len(line)
+    if builder.pending:
+        yield builder.close()
 
-    if buffer:
-        yield close()
+
+async def aiter_batches(
+    lines: Union[Iterable[bytes], AsyncIterable[bytes]],
+    *,
+    target_bytes: int = DEFAULT_TARGET_BATCH_BYTES,
+    max_line_bytes: int = MAX_LINE_BYTES,
+    max_lines: int = MAX_BATCH_LINES,
+) -> AsyncIterator[Batch]:
+    """Async counterpart of ``iter_batches``, accepting either kind of input.
+
+    Batching is CPU- and disk-bound, not I/O-concurrent, so the work is moved
+    off the event loop rather than made concurrent: a synchronous input — a
+    file's lines, or records serialized on demand — is consumed entirely in a
+    worker thread, and for an async input only the joining and hashing in
+    ``close()`` is handed off. Batch boundaries and digests are identical to
+    ``iter_batches`` either way, which is what keeps a resumed upload
+    replaying the receipts of the batches it already committed.
+    """
+    if not isinstance(lines, AsyncIterable):
+        iterator = iter_batches(
+            lines, target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
+        )
+        try:
+            while True:
+                # `next` re-enters the generator in a worker thread, one batch
+                # at a time, so an aborted upload stops reading the source
+                # instead of draining it into memory.
+                batch = await asyncio.to_thread(next, iterator, None)
+                if batch is None:
+                    return
+                yield batch
+        finally:
+            iterator.close()
+    else:
+        builder = _BatchBuilder(
+            target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
+        )
+        line_number = 0
+        async for line in lines:
+            line_number += 1
+            if not line.strip():
+                continue
+            if builder.closes_before(line_number, line):
+                yield await asyncio.to_thread(builder.close)
+            builder.add(line_number, line)
+
+        if builder.pending:
+            yield await asyncio.to_thread(builder.close)

--- a/packages/prime-traces/src/prime_traces/batching.py
+++ b/packages/prime-traces/src/prime_traces/batching.py
@@ -22,7 +22,16 @@ import threading
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncGenerator, Awaitable, Callable, Generator, Iterable, Iterator, Union
+from typing import (
+    AsyncGenerator,
+    Awaitable,
+    Callable,
+    Generator,
+    Iterable,
+    Iterator,
+    Optional,
+    Union,
+)
 
 from .exceptions import TraceTooLargeError
 
@@ -263,8 +272,23 @@ async def aiter_batches(
     replaying the receipts of the batches it already committed.
     """
     if not isinstance(lines, AsyncIterable):
+        active_source: Optional[Iterator[bytes]] = None
+
+        def source_lines() -> Generator[bytes, None, None]:
+            nonlocal active_source
+            # Construct the source iterator lazily so even user-defined
+            # ``__iter__`` work stays off the event loop. Keep it separately so
+            # cleanup can close it after this proxy or ``iter_batches`` exits.
+            active_source = iter(lines)
+            for line in active_source:
+                yield line
+
+        source_iterator = source_lines()
         iterator = iter_batches(
-            lines, target_bytes=target_bytes, max_line_bytes=max_line_bytes, max_lines=max_lines
+            source_iterator,
+            target_bytes=target_bytes,
+            max_line_bytes=max_line_bytes,
+            max_lines=max_lines,
         )
         iterator_lock = threading.Lock()
 
@@ -277,7 +301,19 @@ async def aiter_batches(
 
         def close_iterator() -> None:
             with iterator_lock:
-                iterator.close()
+                try:
+                    iterator.close()
+                finally:
+                    # ``iter_batches`` uses an ordinary ``for`` loop, whose
+                    # generator close does not propagate to the iterator it is
+                    # consuming. Close both the lazy proxy and the actual source
+                    # so retained file or producer iterators release resources.
+                    try:
+                        source_iterator.close()
+                    finally:
+                        close = getattr(active_source, "close", None)
+                        if close is not None:
+                            close()
 
         try:
             while True:

--- a/packages/prime-traces/src/prime_traces/core/__init__.py
+++ b/packages/prime-traces/src/prime_traces/core/__init__.py
@@ -1,7 +1,9 @@
+from .async_client import AsyncTracesAPIClient
 from .client import TracesAPIClient, raise_for_response
 from .config import Config
 
 __all__ = [
+    "AsyncTracesAPIClient",
     "Config",
     "TracesAPIClient",
     "raise_for_response",

--- a/packages/prime-traces/src/prime_traces/core/async_client.py
+++ b/packages/prime-traces/src/prime_traces/core/async_client.py
@@ -48,7 +48,7 @@ async def _run_async_cleanup_safely(operation: Callable[[], Awaitable[None]]) ->
     cancellation requests so an HTTP response cannot remain checked out from
     the connection pool.
     """
-    operation_task = asyncio.create_task(operation())
+    operation_task = asyncio.ensure_future(operation())
     try:
         await asyncio.shield(operation_task)
     except asyncio.CancelledError:
@@ -231,7 +231,7 @@ class AsyncTracesAPIClient(BaseTracesAPIClient):
                 await retry_sleep(retry_delay(error, attempt))
 
     async def aclose(self) -> None:
-        await self.client.aclose()
+        await _run_async_cleanup_safely(self.client.aclose)
 
     async def __aenter__(self) -> "AsyncTracesAPIClient":
         return self

--- a/packages/prime-traces/src/prime_traces/core/async_client.py
+++ b/packages/prime-traces/src/prime_traces/core/async_client.py
@@ -13,7 +13,7 @@ streamed download to disk. Everything else here is I/O the loop can await.
 
 import asyncio
 import gzip as gzip_module
-from typing import Any, AsyncIterator, Dict, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
 
 import httpx
 
@@ -38,6 +38,36 @@ async def retry_sleep(seconds: float) -> None:
     other coroutine in the process.
     """
     await asyncio.sleep(seconds)
+
+
+async def _run_async_cleanup_safely(operation: Callable[[], Awaitable[None]]) -> None:
+    """Finish async resource cleanup before propagating cancellation.
+
+    A caller may cancel a task again while its first cancellation is already
+    unwinding. Run cleanup in a shielded task and wait through repeated
+    cancellation requests so an HTTP response cannot remain checked out from
+    the connection pool.
+    """
+    operation_task = asyncio.create_task(operation())
+    try:
+        await asyncio.shield(operation_task)
+    except asyncio.CancelledError:
+        while not operation_task.done():
+            try:
+                await asyncio.shield(operation_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+
+        if not operation_task.cancelled():
+            try:
+                operation_task.result()
+            except BaseException:
+                # Cancellation remains caller-visible. Retrieving a concurrent
+                # close error also prevents an unobserved-task warning.
+                pass
+        raise
 
 
 class AsyncTracesAPIClient(BaseTracesAPIClient):
@@ -173,15 +203,19 @@ class AsyncTracesAPIClient(BaseTracesAPIClient):
             last = attempt == IDEMPOTENT_RETRY_ATTEMPTS - 1
             yielded = False
             try:
-                async with self.client.stream(
-                    "GET", self._url(endpoint), params=params
-                ) as response:
+                # Own the response directly instead of using ``client.stream``
+                # so its close can be protected from repeated cancellation.
+                request = self.client.build_request("GET", self._url(endpoint), params=params)
+                response = await self.client.send(request, stream=True)
+                try:
                     if not response.is_success:
                         await response.aread()
                         raise_for_response(response)
                     async for chunk in response.aiter_bytes():
                         yielded = True
                         yield chunk
+                finally:
+                    await _run_async_cleanup_safely(response.aclose)
                 return
             except APIError as exc:
                 # Already typed by raise_for_response.

--- a/packages/prime-traces/src/prime_traces/core/async_client.py
+++ b/packages/prime-traces/src/prime_traces/core/async_client.py
@@ -1,0 +1,206 @@
+"""Async HTTP client for the Prime Traces service.
+
+The asyncio counterpart of ``core.client.TracesAPIClient``. It shares that
+module's configuration, response mapping and retry classification, so the two
+transports cannot disagree about what a response means or when a replay is
+safe; only the awaiting differs.
+
+Two kinds of work are handed to worker threads rather than run on the event
+loop: gzipping an upload body (a batch is tens of MiB, and compressing one
+inline would stall every other task for as long as it takes) and writing a
+streamed download to disk. Everything else here is I/O the loop can await.
+"""
+
+import asyncio
+import gzip as gzip_module
+from typing import Any, AsyncIterator, Dict, Optional
+
+import httpx
+
+from ..exceptions import AmbiguousDeleteError, APIError, RetryableAPIError
+from ..models import LineFormat
+from .client import (
+    AMBIGUOUS_TRANSPORT_ERRORS,
+    DEFAULT_TIMEOUT,
+    IDEMPOTENT_RETRY_ATTEMPTS,
+    BaseTracesAPIClient,
+    is_ambiguous_delete_failure,
+    raise_for_response,
+    retry_delay,
+)
+
+
+async def retry_sleep(seconds: float) -> None:
+    """Wait out a retry delay.
+
+    A named indirection rather than a bare ``asyncio.sleep`` call so tests can
+    record the delays this SDK chooses without patching ``asyncio`` for every
+    other coroutine in the process.
+    """
+    await asyncio.sleep(seconds)
+
+
+class AsyncTracesAPIClient(BaseTracesAPIClient):
+    """Thin asynchronous client for the Prime Traces REST API."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        team_id: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        timeout: Optional[httpx.Timeout] = None,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+    ):
+        super().__init__(api_key=api_key, base_url=base_url, team_id=team_id)
+        self.client = httpx.AsyncClient(
+            headers=self._default_headers(user_agent),
+            follow_redirects=True,
+            timeout=timeout or DEFAULT_TIMEOUT,
+            transport=transport,
+        )
+
+    # -- write path ---------------------------------------------------------
+
+    async def upload_batch(
+        self,
+        body: bytes,
+        idempotency_key: str,
+        *,
+        line_format: LineFormat = LineFormat.TRACE,
+        schema_version: int = 1,
+        context: Optional[Dict[str, str]] = None,
+        compress: bool = True,
+    ) -> Dict[str, Any]:
+        """POST one content-addressed JSONL request. See the sync client."""
+        self._check_auth()
+
+        # mtime=0 keeps the compressed bytes reproducible across retries.
+        compressed = (
+            await asyncio.to_thread(gzip_module.compress, body, mtime=0) if compress else None
+        )
+        files = self._multipart_files(
+            body, schema_version=schema_version, context=context, compressed=compressed
+        )
+
+        try:
+            response = await self.client.post(
+                self._url("/traces"),
+                headers=self._upload_headers(idempotency_key, line_format),
+                files=files,
+            )
+        except Exception as exc:
+            raise self._wrap_transport_errors(exc) from exc
+
+        return self._upload_result(response)
+
+    # -- read path ----------------------------------------------------------
+
+    async def _idempotent_request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]],
+    ) -> httpx.Response:
+        """Send with bounded retries when replay is known to be safe.
+
+        Same policy as the sync client: GET retries every transient failure,
+        DELETE retries only failures that could not have reached the service
+        plus explicit service refusals, and anything that may hide a completed
+        deletion surfaces as ``AmbiguousDeleteError``.
+        """
+        is_delete = method.upper() == "DELETE"
+        for attempt in range(IDEMPOTENT_RETRY_ATTEMPTS):
+            last = attempt == IDEMPOTENT_RETRY_ATTEMPTS - 1
+            try:
+                response = await self.client.request(method, self._url(endpoint), params=params)
+            except Exception as exc:
+                error = self._wrap_transport_errors(exc)
+                if error is exc:
+                    raise
+                if is_delete and isinstance(exc, AMBIGUOUS_TRANSPORT_ERRORS):
+                    raise AmbiguousDeleteError(f"Delete outcome is unknown: {error}") from exc
+                if last:
+                    raise error from exc
+                await retry_sleep(retry_delay(error, attempt))
+                continue
+            try:
+                raise_for_response(response)
+            except RetryableAPIError as exc:
+                if is_delete and is_ambiguous_delete_failure(exc):
+                    raise AmbiguousDeleteError(
+                        f"Delete outcome is unknown after HTTP {exc.status_code}: {exc}",
+                        status_code=exc.status_code,
+                        code=exc.code,
+                    ) from exc
+                if last:
+                    raise
+                await retry_sleep(retry_delay(exc, attempt))
+                continue
+            return response
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    async def get_json(
+        self, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        self._check_auth()
+        response = await self._idempotent_request("GET", endpoint, params)
+        result = response.json()
+        if not isinstance(result, dict):
+            raise APIError("API response was not a dictionary")
+        return result
+
+    async def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> None:
+        """Send a DELETE and discard the body — 202 carries none.
+
+        See the sync client: an ambiguous failure that may hide a completed
+        deletion is returned to the caller rather than replayed.
+        """
+        self._check_auth()
+        await self._idempotent_request("DELETE", endpoint, params)
+
+    async def stream_bytes(
+        self, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> AsyncIterator[bytes]:
+        """Stream a response body in chunks (a raw trace can be 64 MiB).
+
+        As in the sync client, transient failures are retried only until the
+        first body byte has been yielded: a mid-stream retry would silently
+        restart the body under the consumer.
+        """
+        self._check_auth()
+        for attempt in range(IDEMPOTENT_RETRY_ATTEMPTS):
+            last = attempt == IDEMPOTENT_RETRY_ATTEMPTS - 1
+            yielded = False
+            try:
+                async with self.client.stream(
+                    "GET", self._url(endpoint), params=params
+                ) as response:
+                    if not response.is_success:
+                        await response.aread()
+                        raise_for_response(response)
+                    async for chunk in response.aiter_bytes():
+                        yielded = True
+                        yield chunk
+                return
+            except APIError as exc:
+                # Already typed by raise_for_response.
+                if yielded or last or not isinstance(exc, RetryableAPIError):
+                    raise
+                await retry_sleep(retry_delay(exc, attempt))
+            except Exception as exc:
+                error = self._wrap_transport_errors(exc)
+                if error is exc:
+                    raise
+                if yielded or last:
+                    raise error from exc
+                await retry_sleep(retry_delay(error, attempt))
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+    async def __aenter__(self) -> "AsyncTracesAPIClient":
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        await self.aclose()

--- a/packages/prime-traces/src/prime_traces/core/async_client.py
+++ b/packages/prime-traces/src/prime_traces/core/async_client.py
@@ -1,15 +1,4 @@
-"""Async HTTP client for the Prime Traces service.
-
-The asyncio counterpart of ``core.client.TracesAPIClient``. It shares that
-module's configuration, response mapping and retry classification, so the two
-transports cannot disagree about what a response means or when a replay is
-safe; only the awaiting differs.
-
-Two kinds of work are handed to worker threads rather than run on the event
-loop: gzipping an upload body (a batch is tens of MiB, and compressing one
-inline would stall every other task for as long as it takes) and writing a
-streamed download to disk. Everything else here is I/O the loop can await.
-"""
+"""Async HTTP client for the Prime Traces service."""
 
 import asyncio
 import gzip as gzip_module
@@ -132,13 +121,7 @@ class AsyncTracesAPIClient(BaseTracesAPIClient):
         endpoint: str,
         params: Optional[Dict[str, Any]],
     ) -> httpx.Response:
-        """Send with bounded retries when replay is known to be safe.
-
-        Same policy as the sync client: GET retries every transient failure,
-        DELETE retries only failures that could not have reached the service
-        plus explicit service refusals, and anything that may hide a completed
-        deletion surfaces as ``AmbiguousDeleteError``.
-        """
+        """Send with bounded retries when replay is known to be safe."""
         is_delete = method.upper() == "DELETE"
         for attempt in range(IDEMPOTENT_RETRY_ATTEMPTS):
             last = attempt == IDEMPOTENT_RETRY_ATTEMPTS - 1
@@ -181,23 +164,14 @@ class AsyncTracesAPIClient(BaseTracesAPIClient):
         return result
 
     async def delete(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> None:
-        """Send a DELETE and discard the body — 202 carries none.
-
-        See the sync client: an ambiguous failure that may hide a completed
-        deletion is returned to the caller rather than replayed.
-        """
+        """Send a DELETE and discard the body — 202 carries none."""
         self._check_auth()
         await self._idempotent_request("DELETE", endpoint, params)
 
     async def stream_bytes(
         self, endpoint: str, params: Optional[Dict[str, Any]] = None
     ) -> AsyncIterator[bytes]:
-        """Stream a response body in chunks (a raw trace can be 64 MiB).
-
-        As in the sync client, transient failures are retried only until the
-        first body byte has been yielded: a mid-stream retry would silently
-        restart the body under the consumer.
-        """
+        """Stream a response body in chunks (a raw trace can be 64 MiB)."""
         self._check_auth()
         for attempt in range(IDEMPOTENT_RETRY_ATTEMPTS):
             last = attempt == IDEMPOTENT_RETRY_ATTEMPTS - 1

--- a/packages/prime-traces/src/prime_traces/core/client.py
+++ b/packages/prime-traces/src/prime_traces/core/client.py
@@ -9,6 +9,10 @@ ambiguous replay could delete data written after the first attempt. Uploads are
 POSTs whose retry safety comes from content addressing rather than the method,
 so their loop lives in ``TracesClient``, where the attempt budget is
 caller-configurable and Retry-After is honored against it.
+
+The response mapping, the retry classification and the client configuration in
+this module are the single source of truth for both transports: the async
+client in ``core.async_client`` differs only in how it awaits I/O.
 """
 
 import gzip as gzip_module
@@ -68,7 +72,7 @@ _SERVICE_REFUSAL_CODES = frozenset(
 #: client did not receive its response. Connection establishment, proxy setup,
 #: pool acquisition and local protocol failures are deliberately absent: the
 #: service cannot have processed a request that was never sent.
-_AMBIGUOUS_TRANSPORT_ERRORS = (
+AMBIGUOUS_TRANSPORT_ERRORS = (
     httpx.CloseError,
     httpx.DecodingError,
     httpx.ReadError,
@@ -99,6 +103,19 @@ def retry_delay(error: Exception, attempt: int) -> float:
         _BACKOFF_CAP_SECONDS,
         _BACKOFF_BASE_SECONDS * (2**attempt),
     ) * (0.5 + random.random())
+
+
+def is_ambiguous_delete_failure(error: RetryableAPIError) -> bool:
+    """Whether a retryable response leaves a DELETE's outcome unknown.
+
+    A codeless or unknown-code 503 may have come from an intermediary after
+    the request was forwarded, so it is ambiguous in the same way 502/504 are.
+    A service refusal code proves the service declined the operation, which
+    makes replaying it safe.
+    """
+    return error.status_code in _AMBIGUOUS_RETRY_STATUSES or (
+        error.status_code == 503 and error.code not in _SERVICE_REFUSAL_CODES
+    )
 
 
 def _default_user_agent() -> str:
@@ -204,17 +221,22 @@ def raise_for_response(response: httpx.Response) -> None:
     raise APIError(f"HTTP {status}: {message}", status_code=status, code=code)
 
 
-class TracesAPIClient:
-    """Thin synchronous client for the Prime Traces REST API."""
+#: Generous read/write budget: one request body can be 256 MiB.
+DEFAULT_TIMEOUT = httpx.Timeout(120.0, connect=10.0)
+
+
+class BaseTracesAPIClient:
+    """Configuration, headers, routing and error wrapping for both transports.
+
+    Everything here is transport-independent, so the sync and async clients
+    cannot drift on how a credential, a team or a base URL is resolved.
+    """
 
     def __init__(
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         team_id: Optional[str] = None,
-        user_agent: Optional[str] = None,
-        timeout: Optional[httpx.Timeout] = None,
-        transport: Optional[httpx.BaseTransport] = None,
     ):
         self.config = Config()
         # For api_key and team_id, None means "resolve from config" and any
@@ -226,6 +248,7 @@ class TracesAPIClient:
         self.base_url = _normalize_base_url(base_url or self.config.traces_url)
         self.team_id = team_id if team_id is not None else self.config.team_id
 
+    def _default_headers(self, user_agent: Optional[str]) -> Dict[str, str]:
         # No default Content-Type here: uploads are multipart (httpx must own
         # the boundary header) and reads set JSON per-request.
         headers = {"User-Agent": user_agent or _default_user_agent()}
@@ -235,14 +258,7 @@ class TracesAPIClient:
             # Spelled exactly as the service declares it (auth/dependencies.py
             # TEAM_HEADER) — case-insensitive on the wire, greppable in code.
             headers["X-Prime-Team-ID"] = self.team_id
-
-        self.client = httpx.Client(
-            headers=headers,
-            follow_redirects=True,
-            # Generous read/write budget: one request body can be 256 MiB.
-            timeout=timeout or httpx.Timeout(120.0, connect=10.0),
-            transport=transport,
-        )
+        return headers
 
     def _check_auth(self) -> None:
         if not self.api_key:
@@ -265,6 +281,75 @@ class TracesAPIClient:
             )
         return exc
 
+    def _multipart_files(
+        self,
+        body: bytes,
+        *,
+        schema_version: int,
+        context: Optional[Dict[str, str]],
+        compressed: Optional[bytes],
+    ) -> Dict[str, Any]:
+        """Build the upload's multipart parts.
+
+        ``compressed`` is the gzip member when compressing, else None. Gzip is
+        transport-only: the digest and all limits are defined over the
+        uncompressed bytes, so compressing changes nothing but upload time.
+        """
+        metadata: Dict[str, Any] = {"schema_version": schema_version}
+        if context:
+            metadata["context"] = context
+
+        if compressed is not None:
+            traces_part: Any = (
+                "traces.jsonl",
+                compressed,
+                "application/x-ndjson",
+                {"Content-Encoding": "gzip"},
+            )
+        else:
+            traces_part = ("traces.jsonl", body, "application/x-ndjson")
+
+        return {
+            "metadata": (None, json_module.dumps(metadata).encode(), "application/json"),
+            "traces": traces_part,
+        }
+
+    @staticmethod
+    def _upload_headers(idempotency_key: str, line_format: LineFormat) -> Dict[str, str]:
+        headers = {"Idempotency-Key": idempotency_key}
+        if line_format is LineFormat.EPISODE:
+            headers["X-Prime-Line-Format"] = LineFormat.EPISODE.value
+        return headers
+
+    @staticmethod
+    def _upload_result(response: httpx.Response) -> Dict[str, Any]:
+        raise_for_response(response)
+        result = response.json()
+        if not isinstance(result, dict):
+            raise APIError("API response was not a dictionary")
+        return result
+
+
+class TracesAPIClient(BaseTracesAPIClient):
+    """Thin synchronous client for the Prime Traces REST API."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        team_id: Optional[str] = None,
+        user_agent: Optional[str] = None,
+        timeout: Optional[httpx.Timeout] = None,
+        transport: Optional[httpx.BaseTransport] = None,
+    ):
+        super().__init__(api_key=api_key, base_url=base_url, team_id=team_id)
+        self.client = httpx.Client(
+            headers=self._default_headers(user_agent),
+            follow_redirects=True,
+            timeout=timeout or DEFAULT_TIMEOUT,
+            transport=transport,
+        )
+
     # -- write path ---------------------------------------------------------
 
     def upload_batch(
@@ -286,41 +371,22 @@ class TracesAPIClient:
         """
         self._check_auth()
 
-        metadata: Dict[str, Any] = {"schema_version": schema_version}
-        if context:
-            metadata["context"] = context
-
-        headers = {"Idempotency-Key": idempotency_key}
-        if line_format is LineFormat.EPISODE:
-            headers["X-Prime-Line-Format"] = LineFormat.EPISODE.value
-
-        if compress:
-            # mtime=0 keeps the compressed bytes reproducible across retries.
-            traces_content = gzip_module.compress(body, mtime=0)
-            traces_part = (
-                "traces.jsonl",
-                traces_content,
-                "application/x-ndjson",
-                {"Content-Encoding": "gzip"},
-            )
-        else:
-            traces_part = ("traces.jsonl", body, "application/x-ndjson")  # type: ignore[assignment]
-
-        files = {
-            "metadata": (None, json_module.dumps(metadata).encode(), "application/json"),
-            "traces": traces_part,
-        }
+        # mtime=0 keeps the compressed bytes reproducible across retries.
+        compressed = gzip_module.compress(body, mtime=0) if compress else None
+        files = self._multipart_files(
+            body, schema_version=schema_version, context=context, compressed=compressed
+        )
 
         try:
-            response = self.client.post(self._url("/traces"), headers=headers, files=files)
+            response = self.client.post(
+                self._url("/traces"),
+                headers=self._upload_headers(idempotency_key, line_format),
+                files=files,
+            )
         except Exception as exc:
             raise self._wrap_transport_errors(exc) from exc
 
-        raise_for_response(response)
-        result = response.json()
-        if not isinstance(result, dict):
-            raise APIError("API response was not a dictionary")
-        return result
+        return self._upload_result(response)
 
     # -- read path ----------------------------------------------------------
 
@@ -349,7 +415,7 @@ class TracesAPIClient:
                 error = self._wrap_transport_errors(exc)
                 if error is exc:
                     raise
-                if is_delete and isinstance(exc, _AMBIGUOUS_TRANSPORT_ERRORS):
+                if is_delete and isinstance(exc, AMBIGUOUS_TRANSPORT_ERRORS):
                     raise AmbiguousDeleteError(f"Delete outcome is unknown: {error}") from exc
                 if last:
                     raise error from exc
@@ -358,10 +424,7 @@ class TracesAPIClient:
             try:
                 raise_for_response(response)
             except RetryableAPIError as exc:
-                ambiguous_status = exc.status_code in _AMBIGUOUS_RETRY_STATUSES or (
-                    exc.status_code == 503 and exc.code not in _SERVICE_REFUSAL_CODES
-                )
-                if is_delete and ambiguous_status:
+                if is_delete and is_ambiguous_delete_failure(exc):
                     raise AmbiguousDeleteError(
                         f"Delete outcome is unknown after HTTP {exc.status_code}: {exc}",
                         status_code=exc.status_code,

--- a/packages/prime-traces/tests/_samples.py
+++ b/packages/prime-traces/tests/_samples.py
@@ -1,0 +1,50 @@
+"""Shared response samples for the sync and async client contract tests."""
+
+# Keep this representative of the wire-level summary contract.
+SUMMARY = {
+    "trace_id": "8d3f1a2b",
+    "upload_id": "5ee85e41",
+    "episode_id": None,
+    "created_at": "2026-07-20T18:02:11.482Z",
+    "ingested_at": "2026-07-20T18:06:02.117Z",
+    "run_id": "run_9f3k2m",
+    "environment_id": "terminal-bench-2",
+    "model": {"provider": "prime", "id": "deepseek-v4-flash"},
+    "task_id": "tb2-0187",
+    "agent_name": "solver",
+    "score": {"reward": 0.85, "outcome": "done"},
+    "execution": {"has_error": False, "is_truncated": False},
+    "duration_ms": 215537,
+    "total_tokens": 84213,
+    "size_bytes": 417284,
+    "context": {"source": "hosted_eval"},
+}
+
+# Keep this representative of the wire-level episode contract.
+EPISODE = {
+    "episode_id": "ep-1",
+    "upload_id": "5ee85e41",
+    "schema_version": 1,
+    "created_at": "2026-07-20T18:02:11.482Z",
+    "ingested_at": "2026-07-20T18:06:02.117Z",
+    "run_id": "run_9f3k2m",
+    "environment_id": "terminal-bench-2",
+    "outcome": "done",
+    "has_error": False,
+    "error": {"type": None, "message": None},
+}
+
+EMPTY_AGGREGATE = {
+    "trace_count": 0,
+    "total_tokens": 0,
+    "total_duration_ms": 0,
+    "any_trace_error": False,
+    "agent_names": [],
+}
+
+RESERVED_TRACE_ID = "trace?with#reserved%chars and space"
+ENCODED_TRACE_PATH = b"/api/v1/traces/trace%3Fwith%23reserved%25chars%20and%20space"
+RESERVED_EPISODE_ID = "episode?with#reserved%chars and space"
+ENCODED_EPISODE_PATH = b"/api/v1/episodes/episode%3Fwith%23reserved%25chars%20and%20space"
+
+UNAVAILABLE = {"error": {"code": "storage_unavailable", "message": "try again"}}

--- a/packages/prime-traces/tests/conftest.py
+++ b/packages/prime-traces/tests/conftest.py
@@ -4,7 +4,12 @@ from typing import Callable
 import httpx
 import pytest
 
-from prime_traces import TracesAPIClient, TracesClient
+from prime_traces import (
+    AsyncTracesAPIClient,
+    AsyncTracesClient,
+    TracesAPIClient,
+    TracesClient,
+)
 
 _PRIME_ENV_VARS = (
     "PRIME_API_KEY",
@@ -45,15 +50,42 @@ def make_client() -> Callable[..., TracesClient]:
     return _make
 
 
+@pytest.fixture
+def make_async_client() -> Callable[..., AsyncTracesClient]:
+    """The async twin of ``make_client``, over the same MockTransport."""
+
+    def _make(handler: Callable[[httpx.Request], httpx.Response]) -> AsyncTracesClient:
+        api_client = AsyncTracesAPIClient(
+            api_key="test-key",
+            base_url="http://testserver",
+            # "" forces no team header rather than resolving from config.
+            team_id="",
+            transport=httpx.MockTransport(handler),
+        )
+        return AsyncTracesClient(api_client=api_client)
+
+    return _make
+
+
 @pytest.fixture(autouse=True)
 def no_sleep(monkeypatch):
     """Record retry sleeps instead of actually sleeping.
 
     Upload retries sleep in ``traces``; idempotent read retries sleep in
     ``core.client``. One list records both so tests assert on delays without
-    caring which loop slept.
+    caring which loop slept — and the async clients feed the same list, so a
+    delay assertion holds for whichever surface the test drives.
     """
     sleeps: list = []
     monkeypatch.setattr("prime_traces.traces.time.sleep", sleeps.append)
     monkeypatch.setattr("prime_traces.core.client.time.sleep", sleeps.append)
+
+    async def record(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    # ``retry_sleep`` exists to be replaceable here: patching ``asyncio.sleep``
+    # itself would reach every coroutine in the process, including the test
+    # framework's own.
+    monkeypatch.setattr("prime_traces.core.async_client.retry_sleep", record)
+    monkeypatch.setattr("prime_traces.async_traces.retry_sleep", record)
     return sleeps

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -227,7 +227,24 @@ class TestPointReads:
         self, make_async_client, monkeypatch, tmp_path
     ):
         stream_closed = asyncio.Event()
-        write_started = asyncio.Event()
+        write_started = threading.Event()
+        release_write = threading.Event()
+        close_called = threading.Event()
+
+        partial = tmp_path / ".prime-traces-controlled.partial"
+        partial.touch()
+
+        class SlowHandle:
+            name = str(partial)
+
+            def write(self, chunk):
+                write_started.set()
+                if not release_write.wait(timeout=5):
+                    raise TimeoutError("test did not release file write")
+                return len(chunk)
+
+            def close(self):
+                close_called.set()
 
         async def stream_bytes(*args, **kwargs):
             try:
@@ -240,25 +257,80 @@ class TestPointReads:
 
         client = make_async_client(handler)
         monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
-        original_to_thread = asyncio.to_thread
-
-        async def stall_file_write(function, *args, **kwargs):
-            if getattr(function, "__name__", None) == "write":
-                write_started.set()
-                await asyncio.Event().wait()
-            return await original_to_thread(function, *args, **kwargs)
-
-        monkeypatch.setattr(async_traces_module.asyncio, "to_thread", stall_file_write)
+        monkeypatch.setattr(async_traces_module, "_open_partial_file", lambda dest: SlowHandle())
 
         dest = tmp_path / "trace.json"
         task = asyncio.create_task(client.download_raw("8d3f1a2b", dest))
-        await write_started.wait()
+        await asyncio.to_thread(write_started.wait)
         task.cancel()
+        # Give cancellation time to reach the shielded write. The event loop
+        # must remain responsive while the real worker thread stays blocked.
+        await asyncio.sleep(0.01)
+
+        pending_while_write = not task.done()
+        closed_before_write_finished = close_called.is_set()
+        release_write.set()
 
         with pytest.raises(asyncio.CancelledError):
             await task
 
+        assert pending_while_write
+        assert not closed_before_write_finished
         assert stream_closed.is_set()
+        assert not dest.exists()
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_close_waits_for_worker(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        close_started = threading.Event()
+        release_close = threading.Event()
+        close_calls = 0
+
+        partial = tmp_path / ".prime-traces-controlled.partial"
+        partial.touch()
+
+        class SlowCloseHandle:
+            name = str(partial)
+
+            def write(self, chunk):
+                return len(chunk)
+
+            def close(self):
+                nonlocal close_calls
+                close_calls += 1
+                if close_calls == 1:
+                    close_started.set()
+                    if not release_close.wait(timeout=5):
+                        raise TimeoutError("test did not release file close")
+
+        async def stream_bytes(*args, **kwargs):
+            yield b'{"version":4,"id":"8d3f1a2b"}'
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        client = make_async_client(handler)
+        monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
+        monkeypatch.setattr(
+            async_traces_module, "_open_partial_file", lambda dest: SlowCloseHandle()
+        )
+
+        dest = tmp_path / "trace.json"
+        task = asyncio.create_task(client.download_raw("8d3f1a2b", dest))
+        await asyncio.to_thread(close_started.wait)
+        task.cancel()
+        await asyncio.sleep(0.01)
+
+        pending_while_close = not task.done()
+        release_close.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert pending_while_close
+        assert close_calls == 2
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
 

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -222,6 +222,30 @@ class TestPointReads:
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
+    @pytest.mark.asyncio
+    async def test_final_replace_is_an_uncancellable_commit(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        loop_thread = threading.get_ident()
+        replace_thread = None
+        original_replace = async_traces_module.Path.replace
+
+        def observed_replace(path, target):
+            nonlocal replace_thread
+            replace_thread = threading.get_ident()
+            return original_replace(path, target)
+
+        monkeypatch.setattr(async_traces_module.Path, "replace", observed_replace)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"complete")
+
+        dest = tmp_path / "trace.json"
+        await make_async_client(handler).download_raw("8d3f1a2b", dest)
+
+        assert replace_thread == loop_thread
+        assert dest.read_bytes() == b"complete"
+
     @pytest.mark.parametrize(
         ("status", "code", "expected"),
         [

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -813,6 +813,53 @@ class TestClientLifecycle:
         assert api_client.client.is_closed
 
     @pytest.mark.asyncio
+    async def test_repeated_cancellation_waits_for_transport_close(self):
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+        transport_closed = False
+
+        class SlowClosingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                return httpx.Response(200, json=SUMMARY)
+
+            async def aclose(self) -> None:
+                nonlocal transport_closed
+                close_started.set()
+                await release_close.wait()
+                transport_closed = True
+
+        api_client = AsyncTracesAPIClient(
+            api_key="test-key",
+            base_url="http://testserver",
+            team_id="",
+            transport=SlowClosingTransport(),
+        )
+        context_entered = asyncio.Event()
+
+        async def use_client():
+            async with api_client:
+                context_entered.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(use_client())
+        await context_entered.wait()
+
+        # The first cancellation exits the context; the second arrives while
+        # the transport is still releasing pooled resources.
+        task.cancel()
+        await close_started.wait()
+        task.cancel()
+        await asyncio.sleep(0.01)
+
+        assert not task.done()
+        assert not transport_closed
+
+        release_close.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert transport_closed
+
+    @pytest.mark.asyncio
     async def test_team_header_is_sent_when_configured(self):
         captured = {}
 

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -1,0 +1,491 @@
+"""Async read, delete and episode paths.
+
+The pinned response shapes and the reserved-ID cases are imported from
+``test_reads`` rather than restated: one definition of the service contract,
+asserted against both clients. Referencing the module (not the test classes)
+keeps the sync suite from being collected twice.
+"""
+
+import httpx
+import pytest
+import test_reads
+
+from prime_traces import (
+    AmbiguousDeleteError,
+    APIError,
+    AsyncTracesAPIClient,
+    AsyncTracesClient,
+    ForbiddenError,
+    NotFoundError,
+    RetryableAPIError,
+    TransportError,
+    UnauthorizedError,
+)
+
+SUMMARY = test_reads.SUMMARY
+RESERVED_TRACE_ID = test_reads.RESERVED_TRACE_ID
+ENCODED_TRACE_PATH = test_reads.ENCODED_TRACE_PATH
+RESERVED_EPISODE_ID = test_reads.RESERVED_EPISODE_ID
+ENCODED_EPISODE_PATH = test_reads.ENCODED_EPISODE_PATH
+EPISODE = test_reads.TestEpisodes.EPISODE
+EMPTY_AGGREGATE = test_reads.TestEpisodes.EMPTY_AGGREGATE
+
+UNAVAILABLE = {"error": {"code": "storage_unavailable", "message": "try again"}}
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_filters_encode_as_documented_query_params(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"items": [SUMMARY], "next_cursor": None})
+
+        page = await make_async_client(handler).list(
+            run_id="run_9f3k2m",
+            environment_id="terminal-bench-2",
+            reward_min=0.5,
+            has_error=False,
+            context={"source": "hosted_eval"},
+            limit=50,
+        )
+
+        assert captured["params"] == {
+            "run_id": "run_9f3k2m",
+            "environment_id": "terminal-bench-2",
+            "reward_min": "0.5",
+            "has_error": "false",
+            "context.source": "hosted_eval",
+            "limit": "50",
+        }
+        [summary] = page.items
+        assert summary.trace_id == "8d3f1a2b"
+        assert summary.score.reward == 0.85
+        assert summary.model.id == "deepseek-v4-flash"
+
+    @pytest.mark.asyncio
+    async def test_iter_follows_cursor(self, make_async_client):
+        pages = {
+            None: {"items": [{**SUMMARY, "trace_id": "t1"}], "next_cursor": "c1"},
+            "c1": {"items": [{**SUMMARY, "trace_id": "t2"}], "next_cursor": None},
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=pages[request.url.params.get("cursor")])
+
+        client = make_async_client(handler)
+        ids = [summary.trace_id async for summary in client.iter(run_id="run_9f3k2m")]
+        assert ids == ["t1", "t2"]
+
+    @pytest.mark.asyncio
+    async def test_iter_stops_reading_when_the_consumer_breaks(self, make_async_client):
+        """Abandoning the generator must not keep paging in the background."""
+        requests = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request.url.params.get("cursor"))
+            return httpx.Response(
+                200, json={"items": [SUMMARY], "next_cursor": f"c{len(requests)}"}
+            )
+
+        client = make_async_client(handler)
+        pages = client.iter()
+        try:
+            async for _ in pages:
+                break
+        finally:
+            await pages.aclose()
+        assert len(requests) == 1
+
+
+class TestPointReads:
+    @pytest.mark.asyncio
+    async def test_get_summary(self, make_async_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v1/traces/8d3f1a2b"
+            return httpx.Response(200, json=SUMMARY)
+
+        summary = await make_async_client(handler).get("8d3f1a2b")
+        assert summary.task_id == "tb2-0187"
+
+    @pytest.mark.asyncio
+    async def test_get_encodes_trace_id_as_one_path_segment(self, make_async_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.raw_path == ENCODED_TRACE_PATH
+            return httpx.Response(200, json=SUMMARY)
+
+        await make_async_client(handler).get(RESERVED_TRACE_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_rejects_trace_id_with_slash_before_request(self, make_async_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        with pytest.raises(ValueError, match="cannot contain '/'"):
+            await make_async_client(handler).get("trace/child")
+
+    @pytest.mark.asyncio
+    async def test_get_raw_streams_document(self, make_async_client):
+        raw = b'{"version":4,"id":"8d3f1a2b","steps":[]}'
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert dict(request.url.params) == {"raw": "true"}
+            return httpx.Response(200, content=raw)
+
+        assert await make_async_client(handler).get_raw("8d3f1a2b") == raw
+
+    @pytest.mark.asyncio
+    async def test_download_raw_writes_file(self, make_async_client, tmp_path):
+        raw = b'{"version":4,"id":"8d3f1a2b"}'
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=raw)
+
+        dest = tmp_path / "trace.json"
+        written = await make_async_client(handler).download_raw("8d3f1a2b", dest)
+        assert written == len(raw)
+        assert dest.read_bytes() == raw
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_download_raw_failure_preserves_existing_file(self, make_async_client, tmp_path):
+        dest = tmp_path / "trace.json"
+        dest.write_bytes(b"previous good document")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                404, json={"error": {"code": "trace_not_found", "message": "gone"}}
+            )
+
+        with pytest.raises(NotFoundError):
+            await make_async_client(handler).download_raw("8d3f1a2b", dest)
+        assert dest.read_bytes() == b"previous good document"
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_partial_is_cleaned_up_when_the_stream_breaks_midway(
+        self, make_async_client, tmp_path
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            # An async body: httpx.AsyncClient refuses to stream a sync one.
+            async def body():
+                yield b'{"version":4,'
+                raise httpx.ReadError("connection reset")
+
+            return httpx.Response(200, content=body())
+
+        dest = tmp_path / "trace.json"
+        with pytest.raises(TransportError):
+            await make_async_client(handler).download_raw("8d3f1a2b", dest)
+        # A mid-stream failure is never retried under the consumer, so the
+        # prefix that did arrive is discarded rather than left as a document.
+        assert not dest.exists()
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.parametrize(
+        ("status", "code", "expected"),
+        [
+            (404, "trace_not_found", NotFoundError),
+            (401, None, UnauthorizedError),
+            (403, "service_not_enabled", ForbiddenError),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_errors_are_typed(self, make_async_client, status, code, expected):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status, json={"error": {"code": code, "message": "nope"}})
+
+        with pytest.raises(expected) as caught:
+            await make_async_client(handler).get("8d3f1a2b")
+        assert caught.value.status_code == status
+        assert caught.value.code == code
+
+
+class TestReadRetries:
+    @pytest.mark.asyncio
+    async def test_get_retries_transient_503_honoring_retry_after(
+        self, make_async_client, no_sleep
+    ):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            if len(attempts) == 1:
+                return httpx.Response(503, headers={"Retry-After": "3"}, json=UNAVAILABLE)
+            return httpx.Response(200, json=SUMMARY)
+
+        summary = await make_async_client(handler).get("8d3f1a2b")
+        assert summary.trace_id == "8d3f1a2b"
+        assert len(attempts) == 2
+        assert no_sleep == [3.0]
+
+    @pytest.mark.asyncio
+    async def test_get_gives_up_after_bounded_attempts(self, make_async_client, no_sleep):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            return httpx.Response(503, json=UNAVAILABLE)
+
+        with pytest.raises(RetryableAPIError):
+            await make_async_client(handler).get("8d3f1a2b")
+        assert len(attempts) == 3
+        assert len(no_sleep) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_does_not_retry_404(self, make_async_client, no_sleep):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            return httpx.Response(
+                404, json={"error": {"code": "trace_not_found", "message": "gone"}}
+            )
+
+        with pytest.raises(NotFoundError):
+            await make_async_client(handler).get("8d3f1a2b")
+        assert len(attempts) == 1
+        assert no_sleep == []
+
+    @pytest.mark.asyncio
+    async def test_get_retries_transport_failures(self, make_async_client, no_sleep):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            if len(attempts) == 1:
+                raise httpx.ConnectError("connection refused", request=request)
+            return httpx.Response(200, json=SUMMARY)
+
+        await make_async_client(handler).get("8d3f1a2b")
+        assert len(attempts) == 2
+        assert len(no_sleep) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_retries_before_first_byte(self, make_async_client, no_sleep, tmp_path):
+        raw = b'{"version":4,"id":"8d3f1a2b"}'
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            if len(attempts) == 1:
+                return httpx.Response(503, json=UNAVAILABLE)
+            return httpx.Response(200, content=raw)
+
+        dest = tmp_path / "trace.json"
+        written = await make_async_client(handler).download_raw("8d3f1a2b", dest)
+        assert written == len(raw)
+        assert dest.read_bytes() == raw
+        assert len(attempts) == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_failure_mid_body_is_not_retried(
+        self, make_async_client, no_sleep, tmp_path
+    ):
+        attempts = []
+
+        async def broken_body():
+            yield b'{"version":4,'
+            raise httpx.ReadError("connection reset mid-body")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            return httpx.Response(200, content=broken_body())
+
+        with pytest.raises(TransportError):
+            await make_async_client(handler).download_raw("8d3f1a2b", tmp_path / "trace.json")
+        assert len(attempts) == 1
+        assert no_sleep == []
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_trace_with_created_at_hint(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["method"] = request.method
+            captured["path"] = request.url.path
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(202)
+
+        await make_async_client(handler).delete("8d3f1a2b", created_at="2026-07-20T18:02:11.482Z")
+        assert captured["method"] == "DELETE"
+        assert captured["path"] == "/api/v1/traces/8d3f1a2b"
+        assert captured["params"] == {"created_at": "2026-07-20T18:02:11.482Z"}
+
+    @pytest.mark.asyncio
+    async def test_delete_run_sends_run_id_and_expects_no_body(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["path"] = request.url.path
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(202)
+
+        assert await make_async_client(handler).delete_run("run_9f3k2m") is None
+        assert captured["path"] == "/api/v1/traces"
+        assert captured["params"] == {"run_id": "run_9f3k2m"}
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_transport_failure_is_not_retried(self, make_async_client, no_sleep):
+        """A replay could delete a trace written after the first attempt."""
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            raise httpx.ReadError("connection reset", request=request)
+
+        with pytest.raises(AmbiguousDeleteError) as caught:
+            await make_async_client(handler).delete("8d3f1a2b")
+        assert caught.value.status_code is None
+        assert len(attempts) == 1
+        assert no_sleep == []
+
+    @pytest.mark.parametrize("status", [502, 504])
+    @pytest.mark.asyncio
+    async def test_ambiguous_gateway_failure_is_not_retried(
+        self, make_async_client, no_sleep, status
+    ):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            return httpx.Response(status, text="upstream connect error")
+
+        with pytest.raises(AmbiguousDeleteError) as caught:
+            await make_async_client(handler).delete("8d3f1a2b")
+        assert caught.value.status_code == status
+        assert len(attempts) == 1
+        assert no_sleep == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_code_503_delete_is_not_retried(self, make_async_client, no_sleep):
+        """A codeless 503 may have come from an intermediary after the request
+        was forwarded, so the deletion may already have landed."""
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            return httpx.Response(503, text="no healthy upstream")
+
+        with pytest.raises(AmbiguousDeleteError):
+            await make_async_client(handler).delete("8d3f1a2b")
+        assert len(attempts) == 1
+
+    @pytest.mark.asyncio
+    async def test_service_refusal_503_delete_is_retried(self, make_async_client, no_sleep):
+        """A service code proves the service declined it — nothing was deleted."""
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.url.path)
+            if len(attempts) == 1:
+                return httpx.Response(503, json=UNAVAILABLE)
+            return httpx.Response(202)
+
+        await make_async_client(handler).delete("8d3f1a2b")
+        assert len(attempts) == 2
+        assert len(no_sleep) == 1
+
+
+class TestEpisodes:
+    @pytest.mark.asyncio
+    async def test_list_episodes_filters_and_envelope(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"items": [EPISODE], "next_cursor": None})
+
+        page = await make_async_client(handler).list_episodes(
+            run_id="run_9f3k2m", outcome="done", has_error=False
+        )
+        assert captured["params"] == {
+            "run_id": "run_9f3k2m",
+            "outcome": "done",
+            "has_error": "false",
+        }
+        [episode] = page.items
+        assert episode.episode_id == "ep-1"
+        assert episode.error.type is None
+
+    @pytest.mark.asyncio
+    async def test_get_episode_nests_member_aggregate(self, make_async_client):
+        detail = {**EPISODE, "traces": {**EMPTY_AGGREGATE, "trace_count": 2}}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v1/episodes/ep-1"
+            return httpx.Response(200, json=detail)
+
+        episode = await make_async_client(handler).get_episode("ep-1")
+        assert episode.traces.trace_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_episode_encodes_episode_id_as_one_path_segment(self, make_async_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.raw_path == ENCODED_EPISODE_PATH
+            return httpx.Response(
+                200, json={**EPISODE, "episode_id": RESERVED_EPISODE_ID, "traces": EMPTY_AGGREGATE}
+            )
+
+        await make_async_client(handler).get_episode(RESERVED_EPISODE_ID)
+
+    @pytest.mark.asyncio
+    async def test_list_episode_traces_forwards_backend_filters(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["path"] = request.url.path
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"items": [SUMMARY], "next_cursor": None})
+
+        page = await make_async_client(handler).list_episode_traces(
+            "ep-1", has_error=True, context={"source": "hosted_eval"}
+        )
+        assert captured["path"] == "/api/v1/episodes/ep-1/traces"
+        assert captured["params"] == {"has_error": "true", "context.source": "hosted_eval"}
+        assert page.items[0].trace_id == "8d3f1a2b"
+
+
+class TestClientLifecycle:
+    @pytest.mark.asyncio
+    async def test_async_context_manager_closes_the_transport(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=SUMMARY)
+
+        api_client = AsyncTracesAPIClient(
+            api_key="test-key",
+            base_url="http://testserver",
+            team_id="",
+            transport=httpx.MockTransport(handler),
+        )
+        async with AsyncTracesClient(api_client=api_client) as client:
+            await client.get("8d3f1a2b")
+        assert api_client.client.is_closed
+
+    @pytest.mark.asyncio
+    async def test_team_header_is_sent_when_configured(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["team"] = request.headers.get("X-Prime-Team-ID")
+            return httpx.Response(200, json=SUMMARY)
+
+        api_client = AsyncTracesAPIClient(
+            api_key="test-key",
+            base_url="http://testserver",
+            team_id="team_42",
+            transport=httpx.MockTransport(handler),
+        )
+        await api_client.get_json("/traces/8d3f1a2b")
+        assert captured["team"] == "team_42"
+        await api_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_fails_loudly_at_request_time(self):
+        api_client = AsyncTracesAPIClient(api_key="", base_url="http://testserver", team_id="")
+        with pytest.raises(APIError, match="No API key configured"):
+            await api_client.get_json("/traces")
+        await api_client.aclose()

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -6,10 +6,14 @@ asserted against both clients. Referencing the module (not the test classes)
 keeps the sync suite from being collected twice.
 """
 
+import asyncio
+import threading
+
 import httpx
 import pytest
 import test_reads
 
+import prime_traces.async_traces as async_traces_module
 from prime_traces import (
     AmbiguousDeleteError,
     APIError,
@@ -180,6 +184,41 @@ class TestPointReads:
             await make_async_client(handler).download_raw("8d3f1a2b", dest)
         # A mid-stream failure is never retried under the consumer, so the
         # prefix that did arrive is discarded rather than left as a document.
+        assert not dest.exists()
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_partial_open_cleans_up_file(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        started = threading.Event()
+        release = threading.Event()
+        opened = threading.Event()
+        original_open = async_traces_module._open_partial_file
+
+        def delayed_open(dest):
+            started.set()
+            release.wait()
+            handle = original_open(dest)
+            opened.set()
+            return handle
+
+        monkeypatch.setattr(async_traces_module, "_open_partial_file", delayed_open)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        dest = tmp_path / "trace.json"
+        task = asyncio.create_task(make_async_client(handler).download_raw("8d3f1a2b", dest))
+        await asyncio.to_thread(started.wait)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.to_thread(opened.wait)
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
 

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -223,6 +223,42 @@ class TestPointReads:
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
     @pytest.mark.asyncio
+    async def test_stream_failure_unlinks_partial_when_close_also_fails(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        partial = tmp_path / ".prime-traces-controlled.partial"
+        partial.touch()
+
+        class FailingCloseHandle:
+            name = str(partial)
+
+            def write(self, chunk):
+                return len(chunk)
+
+            def close(self):
+                raise OSError("flush failed")
+
+        async def stream_bytes(*args, **kwargs):
+            yield b'{"version":4,'
+            raise RuntimeError("stream failed")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        client = make_async_client(handler)
+        monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
+        monkeypatch.setattr(
+            async_traces_module, "_open_partial_file", lambda dest: FailingCloseHandle()
+        )
+
+        dest = tmp_path / "trace.json"
+        with pytest.raises(RuntimeError, match="stream failed"):
+            await client.download_raw("8d3f1a2b", dest)
+
+        assert not partial.exists()
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
     async def test_cancellation_during_write_closes_response_stream(
         self, make_async_client, monkeypatch, tmp_path
     ):
@@ -276,6 +312,69 @@ class TestPointReads:
 
         assert pending_while_write
         assert not closed_before_write_finished
+        assert stream_closed.is_set()
+        assert not dest.exists()
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_repeated_cancellation_waits_for_http_response_close(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        write_started = threading.Event()
+        release_write = threading.Event()
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+        stream_closed = asyncio.Event()
+
+        partial = tmp_path / ".prime-traces-controlled.partial"
+        partial.touch()
+
+        class SlowHandle:
+            name = str(partial)
+
+            def write(self, chunk):
+                write_started.set()
+                if not release_write.wait(timeout=5):
+                    raise TimeoutError("test did not release file write")
+                return len(chunk)
+
+            def close(self):
+                pass
+
+        class SlowClosingStream(httpx.AsyncByteStream):
+            async def __aiter__(self):
+                yield b'{"version":4,"id":"8d3f1a2b"}'
+
+            async def aclose(self):
+                close_started.set()
+                await release_close.wait()
+                stream_closed.set()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, stream=SlowClosingStream())
+
+        client = make_async_client(handler)
+        monkeypatch.setattr(async_traces_module, "_open_partial_file", lambda dest: SlowHandle())
+
+        dest = tmp_path / "trace.json"
+        task = asyncio.create_task(client.download_raw("8d3f1a2b", dest))
+        await asyncio.to_thread(write_started.wait)
+
+        task.cancel()
+        release_write.set()
+        await close_started.wait()
+
+        # A caller may repeat cancellation while cleanup is in progress. The
+        # response close must finish before cancellation reaches the caller.
+        task.cancel()
+        await asyncio.sleep(0.01)
+        pending_while_closing = not task.done()
+        release_close.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert pending_while_closing
         assert stream_closed.is_set()
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
@@ -368,6 +467,44 @@ class TestPointReads:
         await asyncio.to_thread(opened.wait)
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_partial_open_unlinks_file_when_close_fails(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        started = threading.Event()
+        release = threading.Event()
+        partial = tmp_path / ".prime-traces-controlled.partial"
+
+        class FailingCloseHandle:
+            name = str(partial)
+
+            def close(self):
+                raise OSError("flush failed")
+
+        def delayed_open(dest):
+            started.set()
+            release.wait()
+            partial.touch()
+            return FailingCloseHandle()
+
+        monkeypatch.setattr(async_traces_module, "_open_partial_file", delayed_open)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        dest = tmp_path / "trace.json"
+        task = asyncio.create_task(make_async_client(handler).download_raw("8d3f1a2b", dest))
+        await asyncio.to_thread(started.wait)
+
+        task.cancel()
+        await asyncio.sleep(0)
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not partial.exists()
+        assert not dest.exists()
 
     @pytest.mark.asyncio
     async def test_final_replace_is_an_uncancellable_commit(

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -188,6 +188,81 @@ class TestPointReads:
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
     @pytest.mark.asyncio
+    async def test_local_write_failure_closes_response_stream(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        stream_closed = asyncio.Event()
+
+        async def stream_bytes(*args, **kwargs):
+            try:
+                yield b'{"version":4,'
+                yield b'"id":"8d3f1a2b"}'
+            finally:
+                stream_closed.set()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        client = make_async_client(handler)
+        monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
+        original_to_thread = asyncio.to_thread
+
+        async def fail_file_write(function, *args, **kwargs):
+            if getattr(function, "__name__", None) == "write":
+                raise OSError("disk full")
+            return await original_to_thread(function, *args, **kwargs)
+
+        monkeypatch.setattr(async_traces_module.asyncio, "to_thread", fail_file_write)
+
+        dest = tmp_path / "trace.json"
+        with pytest.raises(OSError, match="disk full"):
+            await client.download_raw("8d3f1a2b", dest)
+
+        assert stream_closed.is_set()
+        assert not dest.exists()
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_write_closes_response_stream(
+        self, make_async_client, monkeypatch, tmp_path
+    ):
+        stream_closed = asyncio.Event()
+        write_started = asyncio.Event()
+
+        async def stream_bytes(*args, **kwargs):
+            try:
+                yield b'{"version":4,"id":"8d3f1a2b"}'
+            finally:
+                stream_closed.set()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        client = make_async_client(handler)
+        monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
+        original_to_thread = asyncio.to_thread
+
+        async def stall_file_write(function, *args, **kwargs):
+            if getattr(function, "__name__", None) == "write":
+                write_started.set()
+                await asyncio.Event().wait()
+            return await original_to_thread(function, *args, **kwargs)
+
+        monkeypatch.setattr(async_traces_module.asyncio, "to_thread", stall_file_write)
+
+        dest = tmp_path / "trace.json"
+        task = asyncio.create_task(client.download_raw("8d3f1a2b", dest))
+        await write_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert stream_closed.is_set()
+        assert not dest.exists()
+        assert list(tmp_path.glob(".prime-traces-*")) == []
+
+    @pytest.mark.asyncio
     async def test_cancellation_during_partial_open_cleans_up_file(
         self, make_async_client, monkeypatch, tmp_path
     ):

--- a/packages/prime-traces/tests/test_async_reads.py
+++ b/packages/prime-traces/tests/test_async_reads.py
@@ -1,9 +1,7 @@
 """Async read, delete and episode paths.
 
-The pinned response shapes and the reserved-ID cases are imported from
-``test_reads`` rather than restated: one definition of the service contract,
-asserted against both clients. Referencing the module (not the test classes)
-keeps the sync suite from being collected twice.
+Shared response samples live in ``_samples`` so the test modules do not import
+one another.
 """
 
 import asyncio
@@ -11,30 +9,20 @@ import threading
 
 import httpx
 import pytest
-import test_reads
+from _samples import (
+    SUMMARY,
+    UNAVAILABLE,
+)
 
 import prime_traces.async_traces as async_traces_module
 from prime_traces import (
     AmbiguousDeleteError,
-    APIError,
     AsyncTracesAPIClient,
     AsyncTracesClient,
-    ForbiddenError,
     NotFoundError,
     RetryableAPIError,
     TransportError,
-    UnauthorizedError,
 )
-
-SUMMARY = test_reads.SUMMARY
-RESERVED_TRACE_ID = test_reads.RESERVED_TRACE_ID
-ENCODED_TRACE_PATH = test_reads.ENCODED_TRACE_PATH
-RESERVED_EPISODE_ID = test_reads.RESERVED_EPISODE_ID
-ENCODED_EPISODE_PATH = test_reads.ENCODED_EPISODE_PATH
-EPISODE = test_reads.TestEpisodes.EPISODE
-EMPTY_AGGREGATE = test_reads.TestEpisodes.EMPTY_AGGREGATE
-
-UNAVAILABLE = {"error": {"code": "storage_unavailable", "message": "try again"}}
 
 
 class TestList:
@@ -105,31 +93,6 @@ class TestList:
 
 class TestPointReads:
     @pytest.mark.asyncio
-    async def test_get_summary(self, make_async_client):
-        def handler(request: httpx.Request) -> httpx.Response:
-            assert request.url.path == "/api/v1/traces/8d3f1a2b"
-            return httpx.Response(200, json=SUMMARY)
-
-        summary = await make_async_client(handler).get("8d3f1a2b")
-        assert summary.task_id == "tb2-0187"
-
-    @pytest.mark.asyncio
-    async def test_get_encodes_trace_id_as_one_path_segment(self, make_async_client):
-        def handler(request: httpx.Request) -> httpx.Response:
-            assert request.url.raw_path == ENCODED_TRACE_PATH
-            return httpx.Response(200, json=SUMMARY)
-
-        await make_async_client(handler).get(RESERVED_TRACE_ID)
-
-    @pytest.mark.asyncio
-    async def test_get_rejects_trace_id_with_slash_before_request(self, make_async_client):
-        def handler(request: httpx.Request) -> httpx.Response:
-            pytest.fail(f"unexpected request: {request.url}")
-
-        with pytest.raises(ValueError, match="cannot contain '/'"):
-            await make_async_client(handler).get("trace/child")
-
-    @pytest.mark.asyncio
     async def test_get_raw_streams_document(self, make_async_client):
         raw = b'{"version":4,"id":"8d3f1a2b","steps":[]}'
 
@@ -168,10 +131,13 @@ class TestPointReads:
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
     @pytest.mark.asyncio
-    async def test_partial_is_cleaned_up_when_the_stream_breaks_midway(
-        self, make_async_client, tmp_path
+    async def test_midstream_failure_is_not_retried_and_cleans_up(
+        self, make_async_client, no_sleep, tmp_path
     ):
+        attempts = []
+
         def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
             # An async body: httpx.AsyncClient refuses to stream a sync one.
             async def body():
                 yield b'{"version":4,'
@@ -184,6 +150,8 @@ class TestPointReads:
             await make_async_client(handler).download_raw("8d3f1a2b", dest)
         # A mid-stream failure is never retried under the consumer, so the
         # prefix that did arrive is discarded rather than left as a document.
+        assert len(attempts) == 1
+        assert no_sleep == []
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
@@ -222,41 +190,17 @@ class TestPointReads:
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
-    @pytest.mark.asyncio
-    async def test_stream_failure_unlinks_partial_when_close_also_fails(
-        self, make_async_client, monkeypatch, tmp_path
-    ):
+    def test_discard_partial_unlinks_even_when_close_fails(self, tmp_path):
         partial = tmp_path / ".prime-traces-controlled.partial"
         partial.touch()
 
         class FailingCloseHandle:
-            name = str(partial)
-
-            def write(self, chunk):
-                return len(chunk)
-
             def close(self):
                 raise OSError("flush failed")
 
-        async def stream_bytes(*args, **kwargs):
-            yield b'{"version":4,'
-            raise RuntimeError("stream failed")
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            pytest.fail(f"unexpected request: {request.url}")
-
-        client = make_async_client(handler)
-        monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
-        monkeypatch.setattr(
-            async_traces_module, "_open_partial_file", lambda dest: FailingCloseHandle()
-        )
-
-        dest = tmp_path / "trace.json"
-        with pytest.raises(RuntimeError, match="stream failed"):
-            await client.download_raw("8d3f1a2b", dest)
-
+        with pytest.raises(OSError, match="flush failed"):
+            async_traces_module._discard_partial_file(FailingCloseHandle(), partial)
         assert not partial.exists()
-        assert not dest.exists()
 
     @pytest.mark.asyncio
     async def test_cancellation_during_write_closes_response_stream(
@@ -317,123 +261,6 @@ class TestPointReads:
         assert list(tmp_path.glob(".prime-traces-*")) == []
 
     @pytest.mark.asyncio
-    async def test_repeated_cancellation_waits_for_http_response_close(
-        self, make_async_client, monkeypatch, tmp_path
-    ):
-        write_started = threading.Event()
-        release_write = threading.Event()
-        close_started = asyncio.Event()
-        release_close = asyncio.Event()
-        stream_closed = asyncio.Event()
-
-        partial = tmp_path / ".prime-traces-controlled.partial"
-        partial.touch()
-
-        class SlowHandle:
-            name = str(partial)
-
-            def write(self, chunk):
-                write_started.set()
-                if not release_write.wait(timeout=5):
-                    raise TimeoutError("test did not release file write")
-                return len(chunk)
-
-            def close(self):
-                pass
-
-        class SlowClosingStream(httpx.AsyncByteStream):
-            async def __aiter__(self):
-                yield b'{"version":4,"id":"8d3f1a2b"}'
-
-            async def aclose(self):
-                close_started.set()
-                await release_close.wait()
-                stream_closed.set()
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, stream=SlowClosingStream())
-
-        client = make_async_client(handler)
-        monkeypatch.setattr(async_traces_module, "_open_partial_file", lambda dest: SlowHandle())
-
-        dest = tmp_path / "trace.json"
-        task = asyncio.create_task(client.download_raw("8d3f1a2b", dest))
-        await asyncio.to_thread(write_started.wait)
-
-        task.cancel()
-        release_write.set()
-        await close_started.wait()
-
-        # A caller may repeat cancellation while cleanup is in progress. The
-        # response close must finish before cancellation reaches the caller.
-        task.cancel()
-        await asyncio.sleep(0.01)
-        pending_while_closing = not task.done()
-        release_close.set()
-
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-        assert pending_while_closing
-        assert stream_closed.is_set()
-        assert not dest.exists()
-        assert list(tmp_path.glob(".prime-traces-*")) == []
-
-    @pytest.mark.asyncio
-    async def test_cancellation_during_close_waits_for_worker(
-        self, make_async_client, monkeypatch, tmp_path
-    ):
-        close_started = threading.Event()
-        release_close = threading.Event()
-        close_calls = 0
-
-        partial = tmp_path / ".prime-traces-controlled.partial"
-        partial.touch()
-
-        class SlowCloseHandle:
-            name = str(partial)
-
-            def write(self, chunk):
-                return len(chunk)
-
-            def close(self):
-                nonlocal close_calls
-                close_calls += 1
-                if close_calls == 1:
-                    close_started.set()
-                    if not release_close.wait(timeout=5):
-                        raise TimeoutError("test did not release file close")
-
-        async def stream_bytes(*args, **kwargs):
-            yield b'{"version":4,"id":"8d3f1a2b"}'
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            pytest.fail(f"unexpected request: {request.url}")
-
-        client = make_async_client(handler)
-        monkeypatch.setattr(client.client, "stream_bytes", stream_bytes)
-        monkeypatch.setattr(
-            async_traces_module, "_open_partial_file", lambda dest: SlowCloseHandle()
-        )
-
-        dest = tmp_path / "trace.json"
-        task = asyncio.create_task(client.download_raw("8d3f1a2b", dest))
-        await asyncio.to_thread(close_started.wait)
-        task.cancel()
-        await asyncio.sleep(0.01)
-
-        pending_while_close = not task.done()
-        release_close.set()
-
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-        assert pending_while_close
-        assert close_calls == 2
-        assert not dest.exists()
-        assert list(tmp_path.glob(".prime-traces-*")) == []
-
-    @pytest.mark.asyncio
     async def test_cancellation_during_partial_open_cleans_up_file(
         self, make_async_client, monkeypatch, tmp_path
     ):
@@ -467,87 +294,6 @@ class TestPointReads:
         await asyncio.to_thread(opened.wait)
         assert not dest.exists()
         assert list(tmp_path.glob(".prime-traces-*")) == []
-
-    @pytest.mark.asyncio
-    async def test_cancelled_partial_open_unlinks_file_when_close_fails(
-        self, make_async_client, monkeypatch, tmp_path
-    ):
-        started = threading.Event()
-        release = threading.Event()
-        partial = tmp_path / ".prime-traces-controlled.partial"
-
-        class FailingCloseHandle:
-            name = str(partial)
-
-            def close(self):
-                raise OSError("flush failed")
-
-        def delayed_open(dest):
-            started.set()
-            release.wait()
-            partial.touch()
-            return FailingCloseHandle()
-
-        monkeypatch.setattr(async_traces_module, "_open_partial_file", delayed_open)
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            pytest.fail(f"unexpected request: {request.url}")
-
-        dest = tmp_path / "trace.json"
-        task = asyncio.create_task(make_async_client(handler).download_raw("8d3f1a2b", dest))
-        await asyncio.to_thread(started.wait)
-
-        task.cancel()
-        await asyncio.sleep(0)
-        release.set()
-
-        with pytest.raises(asyncio.CancelledError):
-            await task
-        assert not partial.exists()
-        assert not dest.exists()
-
-    @pytest.mark.asyncio
-    async def test_final_replace_is_an_uncancellable_commit(
-        self, make_async_client, monkeypatch, tmp_path
-    ):
-        loop_thread = threading.get_ident()
-        replace_thread = None
-        original_replace = async_traces_module.Path.replace
-
-        def observed_replace(path, target):
-            nonlocal replace_thread
-            replace_thread = threading.get_ident()
-            return original_replace(path, target)
-
-        monkeypatch.setattr(async_traces_module.Path, "replace", observed_replace)
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, content=b"complete")
-
-        dest = tmp_path / "trace.json"
-        await make_async_client(handler).download_raw("8d3f1a2b", dest)
-
-        assert replace_thread == loop_thread
-        assert dest.read_bytes() == b"complete"
-
-    @pytest.mark.parametrize(
-        ("status", "code", "expected"),
-        [
-            (404, "trace_not_found", NotFoundError),
-            (401, None, UnauthorizedError),
-            (403, "service_not_enabled", ForbiddenError),
-        ],
-    )
-    @pytest.mark.asyncio
-    async def test_errors_are_typed(self, make_async_client, status, code, expected):
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(status, json={"error": {"code": code, "message": "nope"}})
-
-        with pytest.raises(expected) as caught:
-            await make_async_client(handler).get("8d3f1a2b")
-        assert caught.value.status_code == status
-        assert caught.value.code == code
-
 
 class TestReadRetries:
     @pytest.mark.asyncio
@@ -626,26 +372,6 @@ class TestReadRetries:
         assert dest.read_bytes() == raw
         assert len(attempts) == 2
 
-    @pytest.mark.asyncio
-    async def test_stream_failure_mid_body_is_not_retried(
-        self, make_async_client, no_sleep, tmp_path
-    ):
-        attempts = []
-
-        async def broken_body():
-            yield b'{"version":4,'
-            raise httpx.ReadError("connection reset mid-body")
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            attempts.append(request.url.path)
-            return httpx.Response(200, content=broken_body())
-
-        with pytest.raises(TransportError):
-            await make_async_client(handler).download_raw("8d3f1a2b", tmp_path / "trace.json")
-        assert len(attempts) == 1
-        assert no_sleep == []
-
-
 class TestDelete:
     @pytest.mark.asyncio
     async def test_delete_trace_with_created_at_hint(self, make_async_client):
@@ -661,19 +387,6 @@ class TestDelete:
         assert captured["method"] == "DELETE"
         assert captured["path"] == "/api/v1/traces/8d3f1a2b"
         assert captured["params"] == {"created_at": "2026-07-20T18:02:11.482Z"}
-
-    @pytest.mark.asyncio
-    async def test_delete_run_sends_run_id_and_expects_no_body(self, make_async_client):
-        captured = {}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            captured["path"] = request.url.path
-            captured["params"] = dict(request.url.params)
-            return httpx.Response(202)
-
-        assert await make_async_client(handler).delete_run("run_9f3k2m") is None
-        assert captured["path"] == "/api/v1/traces"
-        assert captured["params"] == {"run_id": "run_9f3k2m"}
 
     @pytest.mark.asyncio
     async def test_ambiguous_transport_failure_is_not_retried(self, make_async_client, no_sleep):
@@ -708,20 +421,6 @@ class TestDelete:
         assert no_sleep == []
 
     @pytest.mark.asyncio
-    async def test_unknown_code_503_delete_is_not_retried(self, make_async_client, no_sleep):
-        """A codeless 503 may have come from an intermediary after the request
-        was forwarded, so the deletion may already have landed."""
-        attempts = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            attempts.append(request.url.path)
-            return httpx.Response(503, text="no healthy upstream")
-
-        with pytest.raises(AmbiguousDeleteError):
-            await make_async_client(handler).delete("8d3f1a2b")
-        assert len(attempts) == 1
-
-    @pytest.mark.asyncio
     async def test_service_refusal_503_delete_is_retried(self, make_async_client, no_sleep):
         """A service code proves the service declined it — nothing was deleted."""
         attempts = []
@@ -738,47 +437,6 @@ class TestDelete:
 
 
 class TestEpisodes:
-    @pytest.mark.asyncio
-    async def test_list_episodes_filters_and_envelope(self, make_async_client):
-        captured = {}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            captured["params"] = dict(request.url.params)
-            return httpx.Response(200, json={"items": [EPISODE], "next_cursor": None})
-
-        page = await make_async_client(handler).list_episodes(
-            run_id="run_9f3k2m", outcome="done", has_error=False
-        )
-        assert captured["params"] == {
-            "run_id": "run_9f3k2m",
-            "outcome": "done",
-            "has_error": "false",
-        }
-        [episode] = page.items
-        assert episode.episode_id == "ep-1"
-        assert episode.error.type is None
-
-    @pytest.mark.asyncio
-    async def test_get_episode_nests_member_aggregate(self, make_async_client):
-        detail = {**EPISODE, "traces": {**EMPTY_AGGREGATE, "trace_count": 2}}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            assert request.url.path == "/api/v1/episodes/ep-1"
-            return httpx.Response(200, json=detail)
-
-        episode = await make_async_client(handler).get_episode("ep-1")
-        assert episode.traces.trace_count == 2
-
-    @pytest.mark.asyncio
-    async def test_get_episode_encodes_episode_id_as_one_path_segment(self, make_async_client):
-        def handler(request: httpx.Request) -> httpx.Response:
-            assert request.url.raw_path == ENCODED_EPISODE_PATH
-            return httpx.Response(
-                200, json={**EPISODE, "episode_id": RESERVED_EPISODE_ID, "traces": EMPTY_AGGREGATE}
-            )
-
-        await make_async_client(handler).get_episode(RESERVED_EPISODE_ID)
-
     @pytest.mark.asyncio
     async def test_list_episode_traces_forwards_backend_filters(self, make_async_client):
         captured = {}
@@ -858,28 +516,3 @@ class TestClientLifecycle:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert transport_closed
-
-    @pytest.mark.asyncio
-    async def test_team_header_is_sent_when_configured(self):
-        captured = {}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            captured["team"] = request.headers.get("X-Prime-Team-ID")
-            return httpx.Response(200, json=SUMMARY)
-
-        api_client = AsyncTracesAPIClient(
-            api_key="test-key",
-            base_url="http://testserver",
-            team_id="team_42",
-            transport=httpx.MockTransport(handler),
-        )
-        await api_client.get_json("/traces/8d3f1a2b")
-        assert captured["team"] == "team_42"
-        await api_client.aclose()
-
-    @pytest.mark.asyncio
-    async def test_missing_api_key_fails_loudly_at_request_time(self):
-        api_client = AsyncTracesAPIClient(api_key="", base_url="http://testserver", team_id="")
-        with pytest.raises(APIError, match="No API key configured"):
-            await api_client.get_json("/traces")
-        await api_client.aclose()

--- a/packages/prime-traces/tests/test_async_upload.py
+++ b/packages/prime-traces/tests/test_async_upload.py
@@ -1,0 +1,322 @@
+"""Async upload path.
+
+Parity with the sync uploader is the point: the same lines must produce the
+same batches, the same idempotency keys and the same wire bytes, whichever
+client sent them. What is tested here beyond that is what only the async
+client can do — accept an async producer, await an async ``on_batch`` hook,
+and keep the event loop free while it reads and hashes.
+"""
+
+import asyncio
+import gzip
+import hashlib
+import json
+import threading
+
+import httpx
+import pytest
+from test_upload_wire import parse_multipart
+
+from prime_traces import (
+    ErrorCode,
+    LineFormat,
+    RetryableAPIError,
+    TransportError,
+    ValidationRejectedError,
+    iter_batches,
+)
+
+RAW = b'{"id":"a"}\n{"id":"b"}\n'
+LINES = [b'{"id":"a"}\n', b'{"id":"b"}\n']
+COMMITTED = {"upload_id": "x" * 64, "status": "committed"}
+
+
+async def alines(values):
+    for value in values:
+        yield value
+
+
+class TestRequestShape:
+    @pytest.mark.asyncio
+    async def test_upload_lines_matches_the_sync_wire_contract(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            captured["content"] = request.content
+            return httpx.Response(201, json=COMMITTED)
+
+        client = make_async_client(handler)
+        [receipt] = await client.upload_lines(
+            LINES, context={"source": "hosted_eval"}, compress=False
+        )
+
+        request = captured["request"]
+        assert request.url.path == "/api/v1/traces"
+        assert request.headers["Authorization"] == "Bearer test-key"
+        assert request.headers["Idempotency-Key"] == f"sha256:{hashlib.sha256(RAW).hexdigest()}"
+        # Bare-trace format is the default and the header stays off the wire.
+        assert "X-Prime-Line-Format" not in request.headers
+
+        parts = parse_multipart(captured["content"], request.headers["content-type"])
+        assert parts["traces"][1] == RAW
+        assert json.loads(parts["metadata"][1]) == {
+            "schema_version": 1,
+            "context": {"source": "hosted_eval"},
+        }
+        assert receipt.status == "committed"
+
+    @pytest.mark.asyncio
+    async def test_compression_is_transport_only(self, make_async_client):
+        """Gzipping happens in a worker thread; the digest and the decompressed
+        bytes must still be the ones defined over the uncompressed input."""
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            captured["content"] = request.content
+            return httpx.Response(201, json=COMMITTED)
+
+        await make_async_client(handler).upload_lines(LINES)
+
+        request = captured["request"]
+        parts = parse_multipart(captured["content"], request.headers["content-type"])
+        headers, body = parts["traces"]
+        assert headers["content-encoding"] == "gzip"
+        assert gzip.decompress(body) == RAW
+        assert request.headers["Idempotency-Key"] == f"sha256:{hashlib.sha256(RAW).hexdigest()}"
+
+    @pytest.mark.asyncio
+    async def test_episode_format_sets_the_header(self, make_async_client):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            return httpx.Response(201, json=COMMITTED)
+
+        await make_async_client(handler).upload_lines(LINES, line_format=LineFormat.EPISODE)
+        assert captured["request"].headers["X-Prime-Line-Format"] == "episode"
+
+    @pytest.mark.asyncio
+    async def test_upload_file_reads_and_batches_like_the_sync_client(
+        self, make_async_client, tmp_path
+    ):
+        path = tmp_path / "traces.jsonl"
+        path.write_bytes(RAW)
+        keys = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            keys.append(request.headers["Idempotency-Key"])
+            return httpx.Response(201, json=COMMITTED)
+
+        receipts = await make_async_client(handler).upload_file(path, compress=False)
+        assert len(receipts) == 1
+        assert keys == [batch.idempotency_key for batch in iter_batches([RAW])]
+
+
+class TestAsyncProducers:
+    @pytest.mark.asyncio
+    async def test_async_records_upload_without_being_collected(self, make_async_client):
+        captured = {}
+
+        class RecordObject:
+            def to_record(self):
+                return {"id": "b", "nested": {"ok": True}}
+
+        async def records():
+            yield {"id": "a", "label": "café"}
+            yield RecordObject()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["request"] = request
+            captured["content"] = request.content
+            return httpx.Response(201, json=COMMITTED)
+
+        client = make_async_client(handler)
+        [receipt] = await client.upload_records(records(), compress=False)
+
+        # Byte-for-byte what the sync client produces for the same records.
+        expected = b'{"id":"a","label":"caf\xc3\xa9"}\n{"id":"b","nested":{"ok":true}}\n'
+        request = captured["request"]
+        assert request.headers["Idempotency-Key"] == (
+            f"sha256:{hashlib.sha256(expected).hexdigest()}"
+        )
+        parts = parse_multipart(captured["content"], request.headers["content-type"])
+        assert parts["traces"][1] == expected
+        assert receipt.status == "committed"
+
+    @pytest.mark.asyncio
+    async def test_async_lines_batch_identically_to_sync_lines(self, make_async_client):
+        many = [b'{"i":%d}\n' % i for i in range(40)]
+        keys = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            keys.append(request.headers["Idempotency-Key"])
+            return httpx.Response(201, json=COMMITTED)
+
+        client = make_async_client(handler)
+        receipts = await client.upload_lines(alines(many), target_batch_bytes=40, compress=False)
+
+        expected = [batch.idempotency_key for batch in iter_batches(many, target_bytes=40)]
+        assert len(expected) > 1  # the split is what makes this worth asserting
+        assert keys == expected
+        assert len(receipts) == len(expected)
+
+    @pytest.mark.asyncio
+    async def test_async_record_rejection_happens_before_any_request(self, make_async_client):
+        async def records():
+            yield {"id": "a"}
+            yield object()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json=COMMITTED)
+
+        with pytest.raises(TypeError, match="Record 2 must be a mapping"):
+            await make_async_client(handler).upload_records(records())
+
+    @pytest.mark.asyncio
+    async def test_sync_source_is_consumed_off_the_event_loop(self, make_async_client):
+        """A synchronous producer blocks its thread, not the loop.
+
+        This is the whole reason to reach for the async client: reading and
+        hashing a file must not stall the tasks running alongside it.
+        """
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                ticks += 1
+                await asyncio.sleep(0.001)
+
+        def slow_lines():
+            for i in range(3):
+                # Not time.sleep: the no_sleep fixture patches that away.
+                # Event.wait blocks whichever thread reaches it, which is
+                # exactly the property under test.
+                threading.Event().wait(0.05)
+                yield b'{"i":%d}\n' % i
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json=COMMITTED)
+
+        background = asyncio.create_task(ticker())
+        try:
+            await make_async_client(handler).upload_lines(slow_lines(), compress=False)
+        finally:
+            background.cancel()
+
+        # ~150 ms of blocking work: on the loop the ticker would be frozen for
+        # all of it. A loose floor keeps this from turning into a timing test.
+        assert ticks > 10
+
+
+class TestBatchCallback:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("is_async", [False, True])
+    async def test_on_batch_may_be_sync_or_a_coroutine_function(self, make_async_client, is_async):
+        seen = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json=COMMITTED)
+
+        def sync_hook(batch, receipt):
+            seen.append((batch.num_lines, receipt.status))
+
+        async def async_hook(batch, receipt):
+            await asyncio.sleep(0)
+            seen.append((batch.num_lines, receipt.status))
+
+        client = make_async_client(handler)
+        await client.upload_lines(LINES, on_batch=async_hook if is_async else sync_hook)
+        assert seen == [(2, "committed")]
+
+
+class TestUploadRetries:
+    @pytest.mark.asyncio
+    async def test_retries_the_same_bytes_honoring_retry_after(self, make_async_client, no_sleep):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.headers["Idempotency-Key"])
+            if len(attempts) == 1:
+                return httpx.Response(
+                    429,
+                    headers={"Retry-After": "2"},
+                    json={"error": {"code": "rate_limited", "message": "slow down"}},
+                )
+            return httpx.Response(201, json=COMMITTED)
+
+        [receipt] = await make_async_client(handler).upload_lines(LINES)
+        assert receipt.status == "committed"
+        assert len(set(attempts)) == 1
+        assert no_sleep == [2.0]
+
+    @pytest.mark.asyncio
+    async def test_retries_transport_failures_with_same_key(self, make_async_client, no_sleep):
+        attempts = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request.headers["Idempotency-Key"])
+            if len(attempts) == 1:
+                raise httpx.ConnectError("connection refused", request=request)
+            if len(attempts) == 2:
+                # Ambiguous: the server may have processed the request. Safe
+                # only because the same key replays the committed receipt.
+                raise httpx.ReadError("connection reset mid-response", request=request)
+            return httpx.Response(201, json=COMMITTED)
+
+        [receipt] = await make_async_client(handler).upload_lines(LINES)
+        assert receipt.status == "committed"
+        assert len(set(attempts)) == 1
+        assert len(no_sleep) == 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts(self, make_async_client, no_sleep):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "0.1"},
+                json={"error": {"code": "rate_limited", "message": "slow down"}},
+            )
+
+        with pytest.raises(RetryableAPIError) as exc_info:
+            await make_async_client(handler).upload_lines(LINES, max_attempts=3)
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.code == "rate_limited"
+        assert len(no_sleep) == 2  # sleeps between attempts, not after the last
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_exhausts_attempts(self, make_async_client, no_sleep):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        with pytest.raises(TransportError):
+            await make_async_client(handler).upload_lines(LINES, max_attempts=2)
+        assert len(no_sleep) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_positive_max_attempts_rejected(self, make_async_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        with pytest.raises(ValueError, match="max_attempts"):
+            await make_async_client(handler).upload_lines(LINES, max_attempts=0)
+
+    @pytest.mark.asyncio
+    async def test_durable_rejection_stops_the_upload(self, make_async_client):
+        requests = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(
+                400,
+                json={"error": {"code": "invalid_trace", "message": "line 7: not a trace"}},
+            )
+
+        many = [b'{"i":%d}\n' % i for i in range(40)]
+        with pytest.raises(ValidationRejectedError) as exc_info:
+            await make_async_client(handler).upload_lines(many, target_batch_bytes=40)
+        assert ErrorCode(exc_info.value.code) is ErrorCode.INVALID_TRACE
+        # The first rejection stops the run rather than pushing the rest.
+        assert len(requests) == 1

--- a/packages/prime-traces/tests/test_async_upload.py
+++ b/packages/prime-traces/tests/test_async_upload.py
@@ -168,6 +168,49 @@ class TestAsyncProducers:
         assert serialization_thread != loop_thread
 
     @pytest.mark.asyncio
+    async def test_cancellation_waits_for_async_record_serialization(self, make_async_client):
+        serialization_started = threading.Event()
+        release_serialization = threading.Event()
+        serialization_finished = threading.Event()
+        producer_closed = False
+
+        class SlowRecord:
+            def to_record(self):
+                serialization_started.set()
+                release_serialization.wait()
+                serialization_finished.set()
+                return {"id": "a"}
+
+        async def records():
+            nonlocal producer_closed
+            try:
+                yield SlowRecord()
+            finally:
+                producer_closed = True
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        task = asyncio.create_task(
+            make_async_client(handler).upload_records(records(), compress=False)
+        )
+        await asyncio.to_thread(serialization_started.wait)
+
+        task.cancel()
+        await asyncio.sleep(0.01)
+
+        assert not task.done()
+        assert not serialization_finished.is_set()
+        assert not producer_closed
+
+        release_serialization.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert serialization_finished.is_set()
+        assert producer_closed
+
+    @pytest.mark.asyncio
     async def test_async_lines_batch_identically_to_sync_lines(self, make_async_client):
         many = [b'{"i":%d}\n' % i for i in range(40)]
         keys = []

--- a/packages/prime-traces/tests/test_async_upload.py
+++ b/packages/prime-traces/tests/test_async_upload.py
@@ -197,6 +197,31 @@ class TestAsyncProducers:
             await make_async_client(handler).upload_records(records())
 
     @pytest.mark.asyncio
+    async def test_failed_upload_closes_the_async_record_producer(self, make_async_client):
+        closed = False
+
+        async def records():
+            nonlocal closed
+            try:
+                for i in range(20):
+                    yield {"id": i}
+            finally:
+                closed = True
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={"error": {"code": "invalid_trace", "message": "bad batch"}},
+            )
+
+        with pytest.raises(ValidationRejectedError):
+            await make_async_client(handler).upload_records(
+                records(), target_batch_bytes=40, compress=False
+            )
+
+        assert closed
+
+    @pytest.mark.asyncio
     async def test_sync_source_is_consumed_off_the_event_loop(self, make_async_client):
         """A synchronous producer blocks its thread, not the loop.
 

--- a/packages/prime-traces/tests/test_async_upload.py
+++ b/packages/prime-traces/tests/test_async_upload.py
@@ -18,22 +18,14 @@ import pytest
 from test_upload_wire import parse_multipart
 
 from prime_traces import (
-    ErrorCode,
-    LineFormat,
     RetryableAPIError,
     TransportError,
     ValidationRejectedError,
-    iter_batches,
 )
 
 RAW = b'{"id":"a"}\n{"id":"b"}\n'
 LINES = [b'{"id":"a"}\n', b'{"id":"b"}\n']
 COMMITTED = {"upload_id": "x" * 64, "status": "committed"}
-
-
-async def alines(values):
-    for value in values:
-        yield value
 
 
 class TestRequestShape:
@@ -87,17 +79,6 @@ class TestRequestShape:
         assert request.headers["Idempotency-Key"] == f"sha256:{hashlib.sha256(RAW).hexdigest()}"
 
     @pytest.mark.asyncio
-    async def test_episode_format_sets_the_header(self, make_async_client):
-        captured = {}
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            captured["request"] = request
-            return httpx.Response(201, json=COMMITTED)
-
-        await make_async_client(handler).upload_lines(LINES, line_format=LineFormat.EPISODE)
-        assert captured["request"].headers["X-Prime-Line-Format"] == "episode"
-
-    @pytest.mark.asyncio
     async def test_upload_file_reads_and_batches_like_the_sync_client(
         self, make_async_client, tmp_path
     ):
@@ -111,7 +92,7 @@ class TestRequestShape:
 
         receipts = await make_async_client(handler).upload_file(path, compress=False)
         assert len(receipts) == 1
-        assert keys == [batch.idempotency_key for batch in iter_batches([RAW])]
+        assert keys == [f"sha256:{hashlib.sha256(RAW).hexdigest()}"]
 
 
 class TestAsyncProducers:
@@ -270,37 +251,9 @@ class TestAsyncProducers:
         assert producer_closed
 
     @pytest.mark.asyncio
-    async def test_async_lines_batch_identically_to_sync_lines(self, make_async_client):
-        many = [b'{"i":%d}\n' % i for i in range(40)]
-        keys = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            keys.append(request.headers["Idempotency-Key"])
-            return httpx.Response(201, json=COMMITTED)
-
-        client = make_async_client(handler)
-        receipts = await client.upload_lines(alines(many), target_batch_bytes=40, compress=False)
-
-        expected = [batch.idempotency_key for batch in iter_batches(many, target_bytes=40)]
-        assert len(expected) > 1  # the split is what makes this worth asserting
-        assert keys == expected
-        assert len(receipts) == len(expected)
-
-    @pytest.mark.asyncio
-    async def test_async_record_rejection_happens_before_any_request(self, make_async_client):
-        async def records():
-            yield {"id": "a"}
-            yield object()
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(201, json=COMMITTED)
-
-        with pytest.raises(TypeError, match="Record 2 must be a mapping"):
-            await make_async_client(handler).upload_records(records())
-
-    @pytest.mark.asyncio
     async def test_failed_upload_closes_the_async_record_producer(self, make_async_client):
         closed = False
+        requests = []
 
         async def records():
             nonlocal closed
@@ -311,6 +264,7 @@ class TestAsyncProducers:
                 closed = True
 
         def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
             return httpx.Response(
                 400,
                 json={"error": {"code": "invalid_trace", "message": "bad batch"}},
@@ -322,42 +276,7 @@ class TestAsyncProducers:
             )
 
         assert closed
-
-    @pytest.mark.asyncio
-    async def test_sync_source_is_consumed_off_the_event_loop(self, make_async_client):
-        """A synchronous producer blocks its thread, not the loop.
-
-        This is the whole reason to reach for the async client: reading and
-        hashing a file must not stall the tasks running alongside it.
-        """
-        ticks = 0
-
-        async def ticker():
-            nonlocal ticks
-            while True:
-                ticks += 1
-                await asyncio.sleep(0.001)
-
-        def slow_lines():
-            for i in range(3):
-                # Not time.sleep: the no_sleep fixture patches that away.
-                # Event.wait blocks whichever thread reaches it, which is
-                # exactly the property under test.
-                threading.Event().wait(0.05)
-                yield b'{"i":%d}\n' % i
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(201, json=COMMITTED)
-
-        background = asyncio.create_task(ticker())
-        try:
-            await make_async_client(handler).upload_lines(slow_lines(), compress=False)
-        finally:
-            background.cancel()
-
-        # ~150 ms of blocking work: on the loop the ticker would be frozen for
-        # all of it. A loose floor keeps this from turning into a timing test.
-        assert ticks > 10
+        assert len(requests) == 1
 
 
 class TestBatchCallback:
@@ -421,28 +340,32 @@ class TestUploadRetries:
         assert len(no_sleep) == 2
 
     @pytest.mark.asyncio
-    async def test_gives_up_after_max_attempts(self, make_async_client, no_sleep):
+    @pytest.mark.parametrize(
+        ("failure", "expected"),
+        [("response", RetryableAPIError), ("transport", TransportError)],
+    )
+    async def test_gives_up_after_max_attempts(
+        self, make_async_client, no_sleep, failure, expected
+    ):
+        attempts = []
+
         def handler(request: httpx.Request) -> httpx.Response:
+            attempts.append(request)
+            if failure == "transport":
+                raise httpx.ConnectError("connection refused", request=request)
             return httpx.Response(
                 429,
                 headers={"Retry-After": "0.1"},
                 json={"error": {"code": "rate_limited", "message": "slow down"}},
             )
 
-        with pytest.raises(RetryableAPIError) as exc_info:
+        with pytest.raises(expected) as exc_info:
             await make_async_client(handler).upload_lines(LINES, max_attempts=3)
-        assert exc_info.value.status_code == 429
-        assert exc_info.value.code == "rate_limited"
+        if failure == "response":
+            assert exc_info.value.status_code == 429
+            assert exc_info.value.code == "rate_limited"
+        assert len(attempts) == 3
         assert len(no_sleep) == 2  # sleeps between attempts, not after the last
-
-    @pytest.mark.asyncio
-    async def test_transport_failure_exhausts_attempts(self, make_async_client, no_sleep):
-        def handler(request: httpx.Request) -> httpx.Response:
-            raise httpx.ConnectError("connection refused", request=request)
-
-        with pytest.raises(TransportError):
-            await make_async_client(handler).upload_lines(LINES, max_attempts=2)
-        assert len(no_sleep) == 1
 
     @pytest.mark.asyncio
     async def test_non_positive_max_attempts_rejected(self, make_async_client):
@@ -451,21 +374,3 @@ class TestUploadRetries:
 
         with pytest.raises(ValueError, match="max_attempts"):
             await make_async_client(handler).upload_lines(LINES, max_attempts=0)
-
-    @pytest.mark.asyncio
-    async def test_durable_rejection_stops_the_upload(self, make_async_client):
-        requests = []
-
-        def handler(request: httpx.Request) -> httpx.Response:
-            requests.append(request)
-            return httpx.Response(
-                400,
-                json={"error": {"code": "invalid_trace", "message": "line 7: not a trace"}},
-            )
-
-        many = [b'{"i":%d}\n' % i for i in range(40)]
-        with pytest.raises(ValidationRejectedError) as exc_info:
-            await make_async_client(handler).upload_lines(many, target_batch_bytes=40)
-        assert ErrorCode(exc_info.value.code) is ErrorCode.INVALID_TRACE
-        # The first rejection stops the run rather than pushing the rest.
-        assert len(requests) == 1

--- a/packages/prime-traces/tests/test_async_upload.py
+++ b/packages/prime-traces/tests/test_async_upload.py
@@ -146,6 +146,28 @@ class TestAsyncProducers:
         assert receipt.status == "committed"
 
     @pytest.mark.asyncio
+    async def test_async_record_serialization_runs_off_the_event_loop(self, make_async_client):
+        loop_thread = threading.get_ident()
+        serialization_thread = None
+
+        class RecordObject:
+            def to_record(self):
+                nonlocal serialization_thread
+                serialization_thread = threading.get_ident()
+                return {"id": "a"}
+
+        async def records():
+            yield RecordObject()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json=COMMITTED)
+
+        await make_async_client(handler).upload_records(records(), compress=False)
+
+        assert serialization_thread is not None
+        assert serialization_thread != loop_thread
+
+    @pytest.mark.asyncio
     async def test_async_lines_batch_identically_to_sync_lines(self, make_async_client):
         many = [b'{"i":%d}\n' % i for i in range(40)]
         keys = []

--- a/packages/prime-traces/tests/test_async_upload.py
+++ b/packages/prime-traces/tests/test_async_upload.py
@@ -211,6 +211,65 @@ class TestAsyncProducers:
         assert producer_closed
 
     @pytest.mark.asyncio
+    async def test_repeated_cancellation_waits_for_async_record_producer_close(
+        self, make_async_client
+    ):
+        serialization_started = threading.Event()
+        release_serialization = threading.Event()
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+        producer_closed = False
+
+        class SlowRecord:
+            def to_record(self):
+                serialization_started.set()
+                release_serialization.wait()
+                return {"id": "a"}
+
+        class SlowClosingRecords:
+            def __init__(self):
+                self.first = True
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.first:
+                    self.first = False
+                    return SlowRecord()
+                raise StopAsyncIteration
+
+            async def aclose(self):
+                nonlocal producer_closed
+                close_started.set()
+                await release_close.wait()
+                producer_closed = True
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            pytest.fail(f"unexpected request: {request.url}")
+
+        task = asyncio.create_task(
+            make_async_client(handler).upload_records(SlowClosingRecords(), compress=False)
+        )
+        await asyncio.to_thread(serialization_started.wait)
+
+        task.cancel()
+        release_serialization.set()
+        await close_started.wait()
+
+        # A second cancellation while producer cleanup is awaiting must not
+        # detach the close task and return control with producer resources open.
+        task.cancel()
+        await asyncio.sleep(0.01)
+        assert not task.done()
+        assert not producer_closed
+
+        release_close.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert producer_closed
+
+    @pytest.mark.asyncio
     async def test_async_lines_batch_identically_to_sync_lines(self, make_async_client):
         many = [b'{"i":%d}\n' % i for i in range(40)]
         keys = []

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -1,4 +1,6 @@
+import asyncio
 import hashlib
+import threading
 
 import pytest
 
@@ -200,3 +202,32 @@ class TestAsyncBatching:
 
         # Enough for the first batch and its lookahead, nowhere near the file.
         assert consumed < len(self.LINES)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_waits_for_sync_source_before_closing_iterator(self):
+        """Cancellation must not close a generator still running in a worker."""
+        started = threading.Event()
+        release = threading.Event()
+        closed = threading.Event()
+
+        def slow_lines():
+            try:
+                started.set()
+                release.wait()
+                yield line("{}")
+            finally:
+                closed.set()
+
+        batches = aiter_batches(slow_lines())
+        task = asyncio.create_task(batches.__anext__())
+        await asyncio.to_thread(started.wait)
+
+        task.cancel()
+        # Let cancellation enter aiter_batches while next_batch still owns the
+        # synchronous generator, reproducing the old close-while-running race.
+        await asyncio.sleep(0)
+        release.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert closed.is_set()

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -5,6 +5,7 @@ import pytest
 from prime_traces import (
     MAX_BATCH_BYTES,
     TraceTooLargeError,
+    aiter_batches,
     iter_batches,
     read_jsonl_lines,
 )
@@ -12,6 +13,15 @@ from prime_traces import (
 
 def line(payload: str) -> bytes:
     return payload.encode() + b"\n"
+
+
+async def alines(values):
+    for value in values:
+        yield value
+
+
+async def collect(source, **kwargs):
+    return [batch async for batch in aiter_batches(source, **kwargs)]
 
 
 class TestBatchIdentity:
@@ -110,3 +120,83 @@ class TestFileReading:
         [batch] = iter_batches(read_jsonl_lines(path))
         assert batch.data == content
         assert batch.num_lines == 3
+
+
+class TestAsyncBatching:
+    """`aiter_batches` must be a scheduling change, not a batching change.
+
+    A producer that switches to the async client — or resumes an interrupted
+    upload from the other one — has to reproduce the same upload IDs, so every
+    closing rule is asserted to agree with `iter_batches` rather than merely
+    to look reasonable.
+    """
+
+    LINES = [line(f'{{"id":"{i}","pad":"{"x" * 40}"}}') for i in range(50)]
+
+    def identity(self, batches):
+        return [(b.digest, b.num_lines, b.first_line_number) for b in batches]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("target_bytes", [200, 4096])
+    async def test_async_source_batches_identically(self, target_bytes):
+        expected = self.identity(iter_batches(self.LINES, target_bytes=target_bytes))
+        actual = self.identity(await collect(alines(self.LINES), target_bytes=target_bytes))
+        assert actual == expected
+
+    @pytest.mark.asyncio
+    async def test_sync_source_batches_identically(self):
+        expected = self.identity(iter_batches(self.LINES, target_bytes=200))
+        actual = self.identity(await collect(self.LINES, target_bytes=200))
+        assert actual == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("as_async", [False, True])
+    async def test_blank_lines_skipped_and_line_numbers_follow_the_source(self, as_async):
+        lines = [b"\n", line('{"id":"a"}'), b"   \n", line('{"id":"b"}')]
+        source = alines(lines) if as_async else lines
+        [batch] = await collect(source, target_bytes=1024)
+        assert batch.data == b'{"id":"a"}\n{"id":"b"}\n'
+        # Numbering counts the blank lines it skipped, as the sync path does.
+        assert batch.first_line_number == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("as_async", [False, True])
+    async def test_closes_at_max_lines(self, as_async):
+        lines = [line(f'{{"i":{i}}}') for i in range(5)]
+        source = alines(lines) if as_async else lines
+        batches = await collect(source, target_bytes=1024, max_lines=2)
+        assert [b.num_lines for b in batches] == [2, 2, 1]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("as_async", [False, True])
+    async def test_oversized_line_rejected_locally(self, as_async):
+        lines = [line('{"i":1}'), line('{"pad":"' + "x" * 64 + '"}')]
+        source = alines(lines) if as_async else lines
+        with pytest.raises(TraceTooLargeError) as exc_info:
+            await collect(source, max_line_bytes=32)
+        assert exc_info.value.line_number == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("as_async", [False, True])
+    async def test_target_above_request_cap_rejected(self, as_async):
+        source = alines([line("{}")]) if as_async else [line("{}")]
+        with pytest.raises(ValueError):
+            await collect(source, target_bytes=MAX_BATCH_BYTES + 1)
+
+    @pytest.mark.asyncio
+    async def test_abandoning_the_iterator_stops_reading_the_source(self):
+        """A failed upload must not drain the rest of the file into memory."""
+        consumed = 0
+
+        def counted():
+            nonlocal consumed
+            for value in self.LINES:
+                consumed += 1
+                yield value
+
+        batches = aiter_batches(counted(), target_bytes=200)
+        await batches.__anext__()
+        await batches.aclose()
+
+        # Enough for the first batch and its lookahead, nowhere near the file.
+        assert consumed < len(self.LINES)

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -204,6 +204,24 @@ class TestAsyncBatching:
         assert consumed < len(self.LINES)
 
     @pytest.mark.asyncio
+    async def test_abandoning_the_iterator_closes_an_async_source(self):
+        closed = False
+
+        async def source():
+            nonlocal closed
+            try:
+                for value in self.LINES:
+                    yield value
+            finally:
+                closed = True
+
+        batches = aiter_batches(source(), target_bytes=200)
+        await batches.__anext__()
+        await batches.aclose()
+
+        assert closed
+
+    @pytest.mark.asyncio
     async def test_cancellation_waits_for_sync_source_before_closing_iterator(self):
         """Cancellation must not close a generator still running in a worker."""
         started = threading.Event()

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -167,6 +167,23 @@ class TestAsyncBatching:
         assert actual == expected
 
     @pytest.mark.asyncio
+    async def test_sync_source_iterator_is_created_off_the_event_loop(self):
+        loop_thread = threading.get_ident()
+        iterator_thread = None
+        lines = self.LINES
+
+        class Source:
+            def __iter__(self):
+                nonlocal iterator_thread
+                iterator_thread = threading.get_ident()
+                return iter(lines)
+
+        await collect(Source(), target_bytes=200)
+
+        assert iterator_thread is not None
+        assert iterator_thread != loop_thread
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("as_async", [False, True])
     async def test_blank_lines_skipped_and_line_numbers_follow_the_source(self, as_async):
         lines = [b"\n", line('{"id":"a"}'), b"   \n", line('{"id":"b"}')]
@@ -227,6 +244,51 @@ class TestAsyncBatching:
 
         # Enough for the first batch and its lookahead, nowhere near the file.
         assert consumed < len(self.LINES)
+
+    @pytest.mark.asyncio
+    async def test_abandoning_the_iterator_closes_a_retained_sync_source(self):
+        closed = False
+
+        def source():
+            nonlocal closed
+            try:
+                yield from self.LINES
+            finally:
+                closed = True
+
+        retained_source = source()
+        batches = aiter_batches(retained_source, target_bytes=200)
+        await batches.__anext__()
+        await batches.aclose()
+
+        assert closed
+
+    @pytest.mark.asyncio
+    async def test_source_error_closes_a_retained_sync_source(self):
+        closed = False
+
+        class FailingSource:
+            def __init__(self):
+                self.first = True
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self.first:
+                    self.first = False
+                    return line("{}")
+                raise RuntimeError("source failed")
+
+            def close(self):
+                nonlocal closed
+                closed = True
+
+        retained_source = FailingSource()
+        with pytest.raises(RuntimeError, match="source failed"):
+            await collect(retained_source)
+
+        assert closed
 
     @pytest.mark.asyncio
     async def test_abandoning_the_iterator_closes_an_async_source(self):

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -184,50 +184,6 @@ class TestAsyncBatching:
         assert iterator_thread != loop_thread
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("as_async", [False, True])
-    async def test_blank_lines_skipped_and_line_numbers_follow_the_source(self, as_async):
-        lines = [b"\n", line('{"id":"a"}'), b"   \n", line('{"id":"b"}')]
-        source = alines(lines) if as_async else lines
-        [batch] = await collect(source, target_bytes=1024)
-        assert batch.data == b'{"id":"a"}\n{"id":"b"}\n'
-        # Numbering counts the blank lines it skipped, as the sync path does.
-        assert batch.first_line_number == 2
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("as_async", [False, True])
-    async def test_closes_at_max_lines(self, as_async):
-        lines = [line(f'{{"i":{i}}}') for i in range(5)]
-        source = alines(lines) if as_async else lines
-        batches = await collect(source, target_bytes=1024, max_lines=2)
-        assert [b.num_lines for b in batches] == [2, 2, 1]
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("as_async", [False, True])
-    async def test_oversized_line_rejected_locally(self, as_async):
-        lines = [line('{"i":1}'), line('{"pad":"' + "x" * 64 + '"}')]
-        source = alines(lines) if as_async else lines
-        with pytest.raises(TraceTooLargeError) as exc_info:
-            await collect(source, max_line_bytes=32)
-        assert exc_info.value.line_number == 2
-
-    @pytest.mark.asyncio
-    async def test_async_line_checks_do_not_strip_or_copy_input(self):
-        guard = TestLineValidation.NoStripBytes
-        record = guard(b'{"id":"a"}\n')
-        source = alines([record, guard(b" \t\r\n")])
-
-        [batch] = await collect(source, max_line_bytes=len(record) - 1)
-
-        assert batch.data == record
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("as_async", [False, True])
-    async def test_target_above_request_cap_rejected(self, as_async):
-        source = alines([line("{}")]) if as_async else [line("{}")]
-        with pytest.raises(ValueError):
-            await collect(source, target_bytes=MAX_BATCH_BYTES + 1)
-
-    @pytest.mark.asyncio
     async def test_abandoning_the_iterator_stops_reading_the_source(self):
         """A failed upload must not drain the rest of the file into memory."""
         consumed = 0

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -82,6 +82,13 @@ class TestChunkClosing:
 
 
 class TestLineValidation:
+    class NoStripBytes(bytes):
+        def strip(self, *args, **kwargs):
+            raise AssertionError("batching must not copy a line with strip()")
+
+        def rstrip(self, *args, **kwargs):
+            raise AssertionError("batching must not copy a line with rstrip()")
+
     def test_oversized_line_rejected_locally(self):
         big = line('{"pad":"' + "x" * 64 + '"}')
         with pytest.raises(TraceTooLargeError) as exc_info:
@@ -112,6 +119,14 @@ class TestLineValidation:
         [batch] = iter_batches(lines)
         assert batch.num_lines == 2
         assert batch.data == b'{"id":"a"}\n{"id":"b"}\n'
+
+    def test_line_checks_do_not_strip_or_copy_input(self):
+        record = self.NoStripBytes(b'{"id":"a"}\n')
+        blank = self.NoStripBytes(b" \t\r\n")
+
+        [batch] = iter_batches([record, blank], max_line_bytes=len(record) - 1)
+
+        assert batch.data == record
 
 
 class TestFileReading:
@@ -177,6 +192,16 @@ class TestAsyncBatching:
         with pytest.raises(TraceTooLargeError) as exc_info:
             await collect(source, max_line_bytes=32)
         assert exc_info.value.line_number == 2
+
+    @pytest.mark.asyncio
+    async def test_async_line_checks_do_not_strip_or_copy_input(self):
+        guard = TestLineValidation.NoStripBytes
+        record = guard(b'{"id":"a"}\n')
+        source = alines([record, guard(b" \t\r\n")])
+
+        [batch] = await collect(source, max_line_bytes=len(record) - 1)
+
+        assert batch.data == record
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("as_async", [False, True])

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -282,3 +282,48 @@ class TestAsyncBatching:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert closed.is_set()
+
+    @pytest.mark.asyncio
+    async def test_repeated_cancellation_waits_for_async_source_cleanup(self):
+        close_started = asyncio.Event()
+        release_close = asyncio.Event()
+        closed = False
+
+        class SlowSource:
+            def __init__(self):
+                self.first = True
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.first:
+                    self.first = False
+                    return line("{}")
+                await asyncio.Event().wait()
+
+            async def aclose(self):
+                nonlocal closed
+                close_started.set()
+                await release_close.wait()
+                closed = True
+
+        batches = aiter_batches(SlowSource())
+        task = asyncio.create_task(batches.__anext__())
+        await asyncio.sleep(0)
+
+        task.cancel()
+        await close_started.wait()
+
+        # A second cancellation must not interrupt a source that is still
+        # releasing its files, connections or producer tasks.
+        task.cancel()
+        await asyncio.sleep(0.01)
+        assert not task.done()
+        assert not closed
+
+        release_close.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert closed

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -309,6 +309,35 @@ class TestAsyncBatching:
         assert closed
 
     @pytest.mark.asyncio
+    async def test_async_source_close_may_return_a_future(self):
+        closed = False
+
+        class FutureClosingSource:
+            def __init__(self):
+                self.first = True
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.first:
+                    self.first = False
+                    return line("{}")
+                raise StopAsyncIteration
+
+            def aclose(self):
+                nonlocal closed
+                closed = True
+                future = asyncio.get_running_loop().create_future()
+                future.set_result(None)
+                return future
+
+        [batch] = await collect(FutureClosingSource())
+
+        assert batch.data == line("{}")
+        assert closed
+
+    @pytest.mark.asyncio
     async def test_repeated_cancellation_waits_for_sync_source_cleanup(self):
         """Cancellation must not abandon a generator running in a worker."""
         started = threading.Event()

--- a/packages/prime-traces/tests/test_batching.py
+++ b/packages/prime-traces/tests/test_batching.py
@@ -247,8 +247,8 @@ class TestAsyncBatching:
         assert closed
 
     @pytest.mark.asyncio
-    async def test_cancellation_waits_for_sync_source_before_closing_iterator(self):
-        """Cancellation must not close a generator still running in a worker."""
+    async def test_repeated_cancellation_waits_for_sync_source_cleanup(self):
+        """Cancellation must not abandon a generator running in a worker."""
         started = threading.Event()
         release = threading.Event()
         closed = threading.Event()
@@ -269,6 +269,14 @@ class TestAsyncBatching:
         # Let cancellation enter aiter_batches while next_batch still owns the
         # synchronous generator, reproducing the old close-while-running race.
         await asyncio.sleep(0)
+
+        # A second cancellation must not detach the close worker while it is
+        # waiting for next_batch to release the iterator lock.
+        task.cancel()
+        await asyncio.sleep(0.01)
+        assert not task.done()
+        assert not closed.is_set()
+
         release.set()
 
         with pytest.raises(asyncio.CancelledError):

--- a/packages/prime-traces/tests/test_reads.py
+++ b/packages/prime-traces/tests/test_reads.py
@@ -1,5 +1,14 @@
 import httpx
 import pytest
+from _samples import (
+    EMPTY_AGGREGATE,
+    ENCODED_EPISODE_PATH,
+    ENCODED_TRACE_PATH,
+    EPISODE,
+    RESERVED_EPISODE_ID,
+    RESERVED_TRACE_ID,
+    SUMMARY,
+)
 
 from prime_traces import (
     AmbiguousDeleteError,
@@ -11,33 +20,6 @@ from prime_traces import (
     TransportError,
     UnauthorizedError,
 )
-
-# The pinned summary shape — mirrors the service's `TraceSummary`
-# (prime-traces/src/traces/models.py in the platform repo), including the
-# null-for-unrecorded convention.
-SUMMARY = {
-    "trace_id": "8d3f1a2b",
-    "upload_id": "5ee85e41",
-    "episode_id": None,
-    "created_at": "2026-07-20T18:02:11.482Z",
-    "ingested_at": "2026-07-20T18:06:02.117Z",
-    "run_id": "run_9f3k2m",
-    "environment_id": "terminal-bench-2",
-    "model": {"provider": "prime", "id": "deepseek-v4-flash"},
-    "task_id": "tb2-0187",
-    "agent_name": "solver",
-    "score": {"reward": 0.85, "outcome": "done"},
-    "execution": {"has_error": False, "is_truncated": False},
-    "duration_ms": 215537,
-    "total_tokens": 84213,
-    "size_bytes": 417284,
-    "context": {"source": "hosted_eval"},
-}
-
-RESERVED_TRACE_ID = "trace?with#reserved%chars and space"
-ENCODED_TRACE_PATH = b"/api/v1/traces/trace%3Fwith%23reserved%25chars%20and%20space"
-RESERVED_EPISODE_ID = "episode?with#reserved%chars and space"
-ENCODED_EPISODE_PATH = b"/api/v1/episodes/episode%3Fwith%23reserved%25chars%20and%20space"
 
 
 class TestList:
@@ -560,34 +542,12 @@ class TestStreamToFile:
 
 
 class TestEpisodes:
-    # Mirrors the service's `EpisodeSummary` (prime-traces/src/episodes/
-    # models.py in the platform repo): episode-owned fields, nested `error`.
-    EPISODE = {
-        "episode_id": "ep-1",
-        "upload_id": "5ee85e41",
-        "schema_version": 1,
-        "created_at": "2026-07-20T18:02:11.482Z",
-        "ingested_at": "2026-07-20T18:06:02.117Z",
-        "run_id": "run_9f3k2m",
-        "environment_id": "terminal-bench-2",
-        "outcome": "done",
-        "has_error": False,
-        "error": {"type": None, "message": None},
-    }
-    EMPTY_AGGREGATE = {
-        "trace_count": 0,
-        "total_tokens": 0,
-        "total_duration_ms": 0,
-        "any_trace_error": False,
-        "agent_names": [],
-    }
-
     def test_list_episodes_filters_and_envelope(self, make_client):
         captured = {}
 
         def handler(request: httpx.Request) -> httpx.Response:
             captured["params"] = dict(request.url.params)
-            return httpx.Response(200, json={"items": [self.EPISODE], "next_cursor": None})
+            return httpx.Response(200, json={"items": [EPISODE], "next_cursor": None})
 
         page = make_client(handler).list_episodes(
             run_id="run_9f3k2m",
@@ -610,7 +570,7 @@ class TestEpisodes:
         # The episode row's own error stays visible alongside the aggregate:
         # an environment-hook failure with every member trace green.
         detail = {
-            **self.EPISODE,
+            **EPISODE,
             "has_error": True,
             "error": {"type": "SetupError", "message": "setup hook failed"},
             "traces": {
@@ -639,9 +599,9 @@ class TestEpisodes:
             return httpx.Response(
                 200,
                 json={
-                    **self.EPISODE,
+                    **EPISODE,
                     "episode_id": RESERVED_EPISODE_ID,
-                    "traces": self.EMPTY_AGGREGATE,
+                    "traces": EMPTY_AGGREGATE,
                 },
             )
 
@@ -658,7 +618,7 @@ class TestEpisodes:
             assert request.url.raw_path == b"/api/v1/episodes/" + encoded
             return httpx.Response(
                 200,
-                json={**self.EPISODE, "episode_id": episode_id, "traces": self.EMPTY_AGGREGATE},
+                json={**EPISODE, "episode_id": episode_id, "traces": EMPTY_AGGREGATE},
             )
 
         assert make_client(handler).get_episode(episode_id).episode_id == episode_id

--- a/uv.lock
+++ b/uv.lock
@@ -1495,6 +1495,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -1503,6 +1504,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.1" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large new async surface duplicates upload/delete/retry semantics where cancellation and ambiguous-delete behavior must stay correct; mistakes could leak files, connections, or mishandle deletes.
> 
> **Overview**
> Adds **`AsyncTracesClient`** and **`AsyncTracesAPIClient`** as async counterparts to the existing sync traces clients, with upload, list/iter, raw download, delete, and episode APIs exposed on the event loop.
> 
> **Shared transport logic** is consolidated in **`BaseTracesAPIClient`** (headers, multipart uploads, delete ambiguity via **`is_ambiguous_delete_failure`**) so sync and async HTTP stay aligned. Record JSONL encoding is centralized in **`_encode_record`** for identical idempotency keys across surfaces.
> 
> **`aiter_batches`** mirrors **`iter_batches`** for sync and async line sources, moving batching/hash work off the loop via worker threads while preserving deterministic batch boundaries. Batching avoids copying lines on blank/size checks via **`_is_blank_line`** / **`_line_content_size`**.
> 
> Async paths add **cancellation-safe** cleanup (shielded **`to_thread`**, partial download files, iterator **`aclose`**) and **`pytest-asyncio`** coverage plus README updates for closed beta and async usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0f6a314a862834c6bced98358fbe9d5bf3c3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->