### PR TITLE
pin sandbox tests to containers

### DIFF
--- a/packages/prime-sandboxes/tests/test_cmd_timeout.py
+++ b/packages/prime-sandboxes/tests/test_cmd_timeout.py
@@ -17,6 +17,7 @@ def test_command_timeout():
             CreateSandboxRequest(
                 name="test-sandbox",
                 docker_image="python:3.11-slim",
+                vm=False,
                 cpu_cores=1,
                 memory_gb=2,
                 timeout_minutes=60,

--- a/packages/prime-sandboxes/tests/test_command_execution.py
+++ b/packages/prime-sandboxes/tests/test_command_execution.py
@@ -18,6 +18,7 @@ def shared_sandbox(sandbox_client):
             CreateSandboxRequest(
                 name="test-cmd-exec",
                 docker_image="python:3.11-slim",
+                vm=False,
                 cpu_cores=1,
                 memory_gb=2,
                 timeout_minutes=60,

--- a/packages/prime-sandboxes/tests/test_file_operations.py
+++ b/packages/prime-sandboxes/tests/test_file_operations.py
@@ -18,6 +18,7 @@ def shared_sandbox(sandbox_client):
             CreateSandboxRequest(
                 name="test-file-ops",
                 docker_image="python:3.11-slim",
+                vm=False,
                 cpu_cores=1,
                 memory_gb=2,
                 timeout_minutes=60,

--- a/packages/prime-sandboxes/tests/test_sandbox_operations.py
+++ b/packages/prime-sandboxes/tests/test_sandbox_operations.py
@@ -12,6 +12,7 @@ def test_create_sandbox_with_custom_config(sandbox_client):
             CreateSandboxRequest(
                 name="test-custom-config",
                 docker_image="python:3.11-slim",
+                vm=False,
                 cpu_cores=2,
                 memory_gb=4,
                 disk_size_gb=10,
@@ -49,6 +50,7 @@ def test_get_sandbox(sandbox_client):
             CreateSandboxRequest(
                 name="test-get-sandbox",
                 docker_image="python:3.11-slim",
+                vm=False,
             )
         )
         print(f"✓ Created sandbox: {sandbox.id}")
@@ -81,6 +83,7 @@ def test_list_sandboxes(sandbox_client):
             CreateSandboxRequest(
                 name="test-list-sandbox",
                 docker_image="python:3.11-slim",
+                vm=False,
                 labels=["test-list"],
             )
         )
@@ -124,6 +127,7 @@ def test_list_sandboxes_with_label_filter(sandbox_client, unique_id):
             CreateSandboxRequest(
                 name=f"test-label-filter-{unique_id}",
                 docker_image="python:3.11-slim",
+                vm=False,
                 labels=[test_label],
             )
         )
@@ -162,6 +166,7 @@ def test_delete_sandbox(sandbox_client):
         CreateSandboxRequest(
             name="test-delete",
             docker_image="python:3.11-slim",
+            vm=False,
         )
     )
     sandbox_id = sandbox.id
@@ -194,6 +199,7 @@ def test_bulk_delete_by_ids(sandbox_client):
                 CreateSandboxRequest(
                     name=f"test-bulk-delete-{i}",
                     docker_image="python:3.11-slim",
+                    vm=False,
                 )
             )
             sandboxes.append(sandbox)
@@ -233,6 +239,7 @@ def test_bulk_delete_by_labels(sandbox_client, unique_id):
                 CreateSandboxRequest(
                     name=f"test-bulk-delete-label-{unique_id}-{i}",
                     docker_image="python:3.11-slim",
+                    vm=False,
                     labels=[test_label],
                 )
             )
@@ -267,6 +274,7 @@ def test_get_logs(sandbox_client):
             CreateSandboxRequest(
                 name="test-logs",
                 docker_image="python:3.11-slim",
+                vm=False,
             )
         )
         print(f"✓ Created sandbox: {sandbox.id}")
@@ -303,6 +311,7 @@ def test_wait_for_creation(sandbox_client):
             CreateSandboxRequest(
                 name="test-wait",
                 docker_image="python:3.11-slim",
+                vm=False,
             )
         )
         print(f"✓ Created sandbox: {sandbox.id}")
@@ -341,6 +350,7 @@ def test_sandbox_lifecycle(sandbox_client):
             CreateSandboxRequest(
                 name="test-lifecycle",
                 docker_image="python:3.11-slim",
+                vm=False,
                 labels=["lifecycle-test"],
             )
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only request flags; no production or SDK behavior changes.
> 
> **Overview**
> Integration tests that create sandboxes now pass **`vm=False`** on every `CreateSandboxRequest` in `test_cmd_timeout.py`, `test_command_execution.py`, `test_file_operations.py`, and `test_sandbox_operations.py`.
> 
> Omitting `vm` follows the **platform default** runtime (documented as VM-backed in public beta). These suites assume **container** behavior—shell commands, file I/O, and similar paths—so they are pinned to containers instead of picking up VM defaults over time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1366116b5a179e2c89e48f6e57d539a7ef664a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->