### PR TITLE
add kenneth as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all repository changes.
-* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper
+* @JannikSt @kcoopermiller @willccbb @burnpiro @JohannesHa @DamianB-BitFlipper @kennethnym


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Repository metadata only; no application or runtime behavior changes.
> 
> **Overview**
> Adds **@kennethnym** to the default `*` entry in `.github/CODEOWNERS`, so they are automatically requested as a reviewer on pull requests that touch the repo under the default ownership rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f37e22302bda0af4d06dde0d7790fea77e2460b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->