### PR TITLE
release: cli 0.6.24 + sandbox 0.2.37

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -70,7 +70,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.36"
+__version__ = "0.2.37"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.36",
+    "prime-sandboxes>=0.2.37",
     "prime-evals>=0.2.3",
     "prime-traces>=0.0.1",
     "prime-tunnel>=0.1.9",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.23"
+__version__ = "0.6.24"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary
- bump Prime CLI from 0.6.23 to 0.6.24
- bump prime-sandboxes SDK from 0.2.36 to 0.2.37
- require prime-sandboxes 0.2.37 from the Prime package

## Validation
- uv lock --check
- Ruff checks
- ty pre-commit check
- 71 focused CLI/SDK tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string and dependency constraint updates only; no runtime or API logic changes in this diff.
> 
> **Overview**
> **Release-only version alignment** with no functional code changes in the diff.
> 
> Bumps **`prime-sandboxes`** from `0.2.36` to `0.2.37` in `packages/prime-sandboxes/src/prime_sandboxes/__init__.py`, bumps **`prime`** CLI from `0.6.23` to `0.6.24` in `packages/prime/src/prime_cli/__init__.py`, and updates the **`prime`** package dependency in `pyproject.toml` to require `prime-sandboxes>=0.2.37`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fdf5d0c3a314d2cb73abfa72eb02ecbeebc1360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->