### PR TITLE
fix: bump gh-action-pypi-publish to v1.14.2 (metadata 2.5)

### DIFF
--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -73,6 +73,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-evals/dist

--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -124,7 +124,7 @@ jobs:
       # Publish to PyPI via Trusted Publishing (OIDC)
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime/dist
 

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -73,6 +73,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-sandboxes/dist

--- a/.github/workflows/release-traces.yml
+++ b/.github/workflows/release-traces.yml
@@ -73,6 +73,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-traces/dist

--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -73,6 +73,6 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-tunnel/dist


### PR DESCRIPTION
## Problem

`prime-traces` 0.0.2 was merged and its release workflow reported success, but nothing was published to PyPI. [Run 32193556204](https://github.com/PrimeIntellect-ai/prime/actions/runs/32193556204) attempt 1 failed at the publish step:

```
Checking prime_traces-0.0.2-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling 1.32.0 (uploaded 2026-08-11) emits `Metadata-Version: 2.5`. The workspace `exclude-newer = "7 days"` cooldown held builds on hatchling 1.31.0 (metadata 2.4) until 2026-08-18 05:03 UTC, so `prime-sandboxes` 0.2.37 published fine on Aug 17 and `prime-traces` 0.0.2 was the first release past the cooldown.

The pinned publisher can't read that metadata:

| Action | twine | packaging |
| --- | --- | --- |
| v1.14.0 (current pin) | 6.1.0 | 25.0 |
| v1.14.2 | 7.0.0 | 26.2 |

This is not traces-specific — the next release of any package here hits the same error.

## Change

Bump the pin from `cef2210` (v1.14.0) to `dc37677` (v1.14.2) in all five release workflows. SHA verified against the `v1.14.2` tag; its `requirements/runtime.txt` pins twine 7.0.0 / packaging 26.2.

## Merge effects

Each release workflow lists its own file in `on.push.paths`, so merging this triggers all five. Four no-op on existing tags (`prime-sandboxes-v0.2.37`, `prime-evals-v0.2.3`, `prime-tunnel-v0.1.10`, `v0.6.24`).

`Release prime-traces` is the exception, and its behavior depends on a stale tag: attempt 1 created and pushed `prime-traces-v0.0.2` **before** the publish step failed, so the tag exists while PyPI does not have the release.

- **Delete `prime-traces-v0.0.2` before merging** → this merge builds, re-tags, and publishes 0.0.2.
- **Leave the tag** → the run skips every step and reports green again, publishing nothing. You can then publish via `workflow_dispatch` with `force_release=true`.

```bash
git push origin :refs/tags/prime-traces-v0.0.2
```

No GitHub Release is attached to that tag, so deleting it is safe.

## Follow-up (not in this PR)

All five workflows create the git tag *before* publishing, so a failed publish leaves a tag that turns every subsequent re-run into a silent green no-op — exactly what masked this failure. Moving `Create tag` after `Publish to PyPI` would fix that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change on release workflows; no application runtime code, though failed publishes could still leave stale tags until follow-up workflow fixes.
> 
> **Overview**
> Bumps the pinned **PyPI publish** GitHub Action from **v1.14.0** to **v1.14.2** in all five package release workflows (`release-prime`, `release-evals`, `release-sandboxes`, `release-traces`, `release-tunnel`).
> 
> The older action’s twine/packaging stack rejects wheels built with **Metadata-Version 2.5** (e.g. from newer hatchling), which caused publish steps to fail while tags could still be created. v1.14.2 brings twine 7.0.0 / packaging 26.2 so those builds can upload.
> 
> Merging will re-run these workflows because each workflow watches its own YAML path; most runs should no-op on existing tags unless **`prime-traces-v0.0.2`** is removed so 0.0.2 can be published again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3cf845877585d27263d10a3b30d39e8549622a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->