### PR TITLE
improvement: create release tags only after a successful PyPI publish

### DIFF
--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -46,6 +46,12 @@ jobs:
             echo "Tag $TAG does not exist"
           fi
 
+      # A forced release must build the tagged source, not whatever the
+      # dispatch ref currently points at
+      - name: Check out existing tag
+        if: steps.check_tag.outputs.exists == 'true' && inputs.force_release == 'true'
+        run: git checkout --detach "prime-evals-v${{ steps.version.outputs.version }}"
+
       - name: Set up Python
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -62,6 +62,13 @@ jobs:
         run: |
           uv build --out-dir dist
 
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: packages/prime-evals/dist
+          skip-existing: true
+
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -70,9 +77,3 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-
-      - name: Publish to PyPI
-        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: packages/prime-evals/dist

--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -67,7 +67,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-evals/dist
-          skip-existing: true
+          skip-existing: ${{ inputs.force_release == 'true' }}
 
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -67,7 +67,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-sandboxes/dist
-          skip-existing: true
+          skip-existing: ${{ inputs.force_release == 'true' }}
 
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -46,6 +46,12 @@ jobs:
             echo "Tag $TAG does not exist"
           fi
 
+      # A forced release must build the tagged source, not whatever the
+      # dispatch ref currently points at
+      - name: Check out existing tag
+        if: steps.check_tag.outputs.exists == 'true' && inputs.force_release == 'true'
+        run: git checkout --detach "prime-sandboxes-v${{ steps.version.outputs.version }}"
+
       - name: Set up Python
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/release-sandboxes.yml
+++ b/.github/workflows/release-sandboxes.yml
@@ -62,6 +62,13 @@ jobs:
         run: |
           uv build --out-dir dist
 
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: packages/prime-sandboxes/dist
+          skip-existing: true
+
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -70,9 +77,3 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-
-      - name: Publish to PyPI
-        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: packages/prime-sandboxes/dist

--- a/.github/workflows/release-traces.yml
+++ b/.github/workflows/release-traces.yml
@@ -46,6 +46,12 @@ jobs:
             echo "Tag $TAG does not exist"
           fi
 
+      # A forced release must build the tagged source, not whatever the
+      # dispatch ref currently points at
+      - name: Check out existing tag
+        if: steps.check_tag.outputs.exists == 'true' && inputs.force_release == 'true'
+        run: git checkout --detach "prime-traces-v${{ steps.version.outputs.version }}"
+
       - name: Set up Python
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/release-traces.yml
+++ b/.github/workflows/release-traces.yml
@@ -67,7 +67,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-traces/dist
-          skip-existing: true
+          skip-existing: ${{ inputs.force_release == 'true' }}
 
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'

--- a/.github/workflows/release-traces.yml
+++ b/.github/workflows/release-traces.yml
@@ -62,6 +62,13 @@ jobs:
         run: |
           uv build --out-dir dist
 
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: packages/prime-traces/dist
+          skip-existing: true
+
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -70,9 +77,3 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-
-      - name: Publish to PyPI
-        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: packages/prime-traces/dist

--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -62,6 +62,13 @@ jobs:
         run: |
           uv build --out-dir dist
 
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: packages/prime-tunnel/dist
+          skip-existing: true
+
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
         run: |
@@ -70,9 +77,3 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-
-      - name: Publish to PyPI
-        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: packages/prime-tunnel/dist

--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -46,6 +46,12 @@ jobs:
             echo "Tag $TAG does not exist"
           fi
 
+      # A forced release must build the tagged source, not whatever the
+      # dispatch ref currently points at
+      - name: Check out existing tag
+        if: steps.check_tag.outputs.exists == 'true' && inputs.force_release == 'true'
+        run: git checkout --detach "prime-tunnel-v${{ steps.version.outputs.version }}"
+
       - name: Set up Python
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
         uses: actions/setup-python@v6

--- a/.github/workflows/release-tunnel.yml
+++ b/.github/workflows/release-tunnel.yml
@@ -67,7 +67,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime-tunnel/dist
-          skip-existing: true
+          skip-existing: ${{ inputs.force_release == 'true' }}
 
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'


### PR DESCRIPTION
Follow-up to #849. Merge that one first — it is the fix that unblocks the `prime-traces` 0.0.2 release. This PR addresses the reason that failure went unnoticed.

## Problem

All four SDK release workflows create the git tag *before* publishing:

```
Build package  →  Create tag  →  Publish to PyPI
```

`Create tag` pushes the tag, then `Publish to PyPI` runs. If the publish fails, the tag survives. Every subsequent run then trips the `Check for existing tag` guard, skips build, tag, and publish, and exits **green** having shipped nothing.

That is exactly what happened to `prime-traces` 0.0.2: attempt 1 tagged, then failed to publish; the re-run skipped every step and reported success, so the release looked done while PyPI had no 0.0.2. A green run is currently not evidence that anything shipped.

## Change

Swap the order so the tag records a publish that actually happened:

```
Build package  →  Publish to PyPI  →  Create tag
```

Now a failed publish leaves no tag, and the next push or re-run retries the whole thing normally.

Also sets `skip-existing: ${{ inputs.force_release == 'true' }}` on the publish step. The reorder narrows the failure window rather than closing it: publish-succeeds-then-tag-push-fails leaves PyPI published with no tag, and a retry would otherwise fail on the already-uploaded filename.

Skipping is deliberately confined to the explicit recovery path. Unconditionally, it would make a provenance mismatch silent: in that stuck state, the next commit touching the package **without** a version bump builds a different tree, finds the filenames already on PyPI, skips the upload, and then tags that newer commit even though PyPI holds artifacts built from the older one. Package commits without a version bump are the norm here — #842 is an example — so the stuck state would mis-tag on the very next PR. Gated, a duplicate filename on the automatic path is a loud PyPI rejection that fails the job before any tag exists, and skipping only happens when a human dispatched `force_release=true`.

Applies to `release-{traces,sandboxes,evals,tunnel}.yml`, which are structurally identical. Verified all four still parse and that the resulting step order is `Build package → Publish to PyPI → Create tag`.

## Not included: release-prime.yml

`release-prime.yml` has the same flaw but a different shape — it tags at step 81 before Python is even set up, creates a GitHub Release at 116 before publishing at 125, notifies Slack, and feeds a `release_created` output into a downstream `docker-images` job. Reordering it means moving the tag, the GitHub Release, and the Slack notify past the publish and re-checking that job dependency. It also has no `force_release` input, so a failed publish there has no escape hatch at all and needs both a tag and a GitHub Release deleted to retry. That deserves its own PR.

## Forced releases build the tag

`actions/checkout` takes the run's ref, so a forced release used to build whatever the dispatch branch pointed at rather than the tag being recovered. The `prime-traces` 0.0.2 recovery already hit this: run 32195274109 built `f80c8ade` while `prime-traces-v0.0.2` points at `612f5102`. It was harmless only because the commit between them touched no traces source — the published wheel hashed identically to a build of the tagged tree.

`force_release` means "finish the release for this tag", so the tag is now checked out before building. `fetch-depth: 0` already makes it available locally, so this is a plain `git checkout --detach`, gated on `exists == 'true' && force_release == 'true'` — the normal path is untouched.

## Recovery when a tag push fails after a successful publish

`skip-existing` is gated on `force_release`, so this narrow window needs one manual step. If the publish succeeds and the tag push then fails (transient — the tag ruleset does not block *creating* tags), no tag exists and PyPI holds the version:

- **An automatic re-run does not self-heal.** `skip-existing` is `false` on the push path, so the publish fails on the duplicate filename and stops before `Create tag`.
- **Recovery is one dispatch:** `gh workflow run release-traces.yml --ref main -f force_release=true`. That sets `skip-existing` to `true`, the upload skips, and `Create tag` runs.

This is deliberate. Unconditional `skip-existing` would make the automatic re-run succeed, but it would also let a later commit — one touching the package with no version bump, which is the normal rhythm here — skip the already-published filenames and tag *that* tree instead. A visible failure needing one command beats a silent mis-tag, given both branch off the same rare event.

One caveat when recovering: the tag is absent in this state, so `Check out existing tag` does not fire and the tag lands on the dispatch ref. If the branch has moved past the commit that produced the published artifact, dispatch from a ref at that commit, or check the tag afterwards.

Considered and rejected: comparing the built wheel's sha256 against PyPI's published hash before publishing, which would let the automatic re-run self-heal while still refusing to tag a different tree. It resolves the trade-off properly, but costs ~8 lines in each of five workflows and a PyPI query on the release path, and a build-backend upgrade between publish and retry (hatchling 1.31 to 1.32, exactly what happened this week) changes the hash for identical source and would fail the release. Recorded here so the option is not re-derived from scratch next time.

## Merge note

This branch carries the same v1.14.2 pin as #849 so the two cannot silently revert each other. They still conflict on whichever merges second: the conflict is the old-position `Publish to PyPI` block versus its deletion, and the correct resolution is to **take the deletion** — this branch already re-adds that step, with the v1.14.2 pin, below `Build package`. Taking `HEAD` instead would duplicate the publish step. Simplest path is to merge #849, then rebase this branch onto main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production PyPI release ordering and retry behavior; mistakes could mis-tag or skip publishes, but scope is limited to four CI workflows with explicit force_release gating for skip-existing.
> 
> **Overview**
> **Four SDK release workflows** (`release-evals`, `release-sandboxes`, `release-traces`, `release-tunnel`) now run **Publish to PyPI** immediately after **Build package**, and only **Create tag** after a successful publish. That way a failed upload does not leave a tag that makes later runs skip build/publish and exit green without shipping.
> 
> The publish step uses **`skip-existing`** only when **`force_release`** is true, so manual recovery can finish when PyPI already has the artifacts but the tag push failed, without silently skipping uploads on normal pushes.
> 
> Each workflow also adds a **check out existing tag** step when forcing a release so the build uses the tagged source, not the dispatch ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ff4e4fa7b776fe8518386ad035155f3fcc18bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->