### PR TITLE
improvement: publish before tagging in release-prime, add force_release

### DIFF
--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -81,6 +81,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      # A forced release must build the tagged source, not whatever the
+      # dispatch ref currently points at
+      - name: Check out existing tag
+        if: steps.check_tag.outputs.exists == 'true' && inputs.force_release == 'true'
+        run: git checkout --detach "v${{ steps.version.outputs.version }}"
+
       # Setup Python for build
       - name: Set up Python
         if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'

--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -13,6 +13,10 @@ on:
         description: 'Tag to create release from (e.g. v1.2.3)'
         required: false
         type: string
+      force_release:
+        description: 'Force release even if tag exists'
+        required: false
+        default: 'false'
 
 jobs:
   tag-and-release:
@@ -32,7 +36,7 @@ jobs:
 
       # Get version from package source on push
       - name: Get version from packages/prime/src/prime_cli/__init__.py
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.tag == ''
         id: auto_version
         run: |
           VERSION=$(grep -E "^__version__[[:space:]]*=" packages/prime/src/prime_cli/__init__.py | head -n1 | sed -E "s/^__version__[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"].*/\1/")
@@ -77,6 +81,40 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      # Setup Python for build
+      - name: Set up Python
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      # Install uv and build tools
+      - name: Install uv
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: astral-sh/setup-uv@v3
+        
+      # Build package
+      - name: Build package
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        working-directory: packages/prime
+        run: |
+          uv build --out-dir dist
+
+      - name: Upload build artifacts
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/prime/dist/*
+
+      # Publish to PyPI via Trusted Publishing (OIDC)
+      - name: Publish to PyPI
+        if: steps.check_tag.outputs.exists != 'true' || inputs.force_release == 'true'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: packages/prime/dist
+          skip-existing: true
+
       # Create new tag if it doesn't exist
       - name: Create tag
         if: steps.check_tag.outputs.exists != 'true'
@@ -86,32 +124,6 @@ jobs:
           git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
 
-      # Setup Python for build
-      - name: Set up Python
-        if: steps.check_tag.outputs.exists != 'true'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
-      # Install uv and build tools
-      - name: Install uv
-        if: steps.check_tag.outputs.exists != 'true'
-        uses: astral-sh/setup-uv@v3
-        
-      # Build package
-      - name: Build package
-        if: steps.check_tag.outputs.exists != 'true'
-        working-directory: packages/prime
-        run: |
-          uv build --out-dir dist
-
-      - name: Upload build artifacts
-        if: steps.check_tag.outputs.exists != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: packages/prime/dist/*
-
       # Create GitHub Release
       - name: Create GitHub Release
         if: steps.check_tag.outputs.exists != 'true'
@@ -120,13 +132,6 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           files: packages/prime/dist/*
           generate_release_notes: true
-
-      # Publish to PyPI via Trusted Publishing (OIDC)
-      - name: Publish to PyPI
-        if: steps.check_tag.outputs.exists != 'true'
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: packages/prime/dist
 
       - name: Notify Slack
         if: steps.check_tag.outputs.exists != 'true'
@@ -172,7 +177,7 @@ jobs:
       - name: Set release status
         id: release_status
         run: |
-          if [ "${{ steps.check_tag.outputs.exists }}" = "true" ]; then
+          if [ "${{ steps.check_tag.outputs.exists }}" = "true" ] && [ "${{ inputs.force_release }}" != "true" ]; then
             echo "created=false" >> "$GITHUB_OUTPUT"
           else
             echo "created=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-prime.yml
+++ b/.github/workflows/release-prime.yml
@@ -113,7 +113,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/prime/dist
-          skip-existing: true
+          skip-existing: ${{ inputs.force_release == 'true' }}
 
       # Create new tag if it doesn't exist
       - name: Create tag


### PR DESCRIPTION
Completes the follow-up work from #850, which deliberately left `release-prime.yml` out because it needed more than a step swap. Merge order: #849, then #850, then this.

## Problem

`release-prime.yml` had the same flaw as the SDK workflows, in a worse arrangement:

```
Create tag  →  Set up Python  →  Build  →  Create GitHub Release  →  Publish to PyPI  →  Slack
```

The tag was pushed before Python was even installed, and the GitHub Release was created before the publish. A failed publish left both behind, so every later run tripped the `Check for existing tag` guard, skipped everything, and reported success while shipping nothing — the failure mode that hid the `prime-traces` 0.0.2 failure for hours.

`softprops/action-gh-release` also creates the tag itself when `tag_name` does not exist, so the Release step was a second way to tag early. Moving only the explicit `Create tag` step would not have fixed it.

## Changes

**1. Reorder.** Now `build → publish → tag → GitHub Release → Slack`. The publish is the step most likely to fail and the only irreversible one, so nothing durable is recorded until it succeeds. `skip-existing: ${{ inputs.force_release == 'true' }}` keeps a retry clean if the tag push fails after a successful upload, while confining the skip to the explicit recovery path — unconditionally it would let the next commit touching `packages/prime` without a version bump skip the already-published filenames and then tag that newer commit, attaching its artifacts to the GitHub Release while PyPI serves the older ones. See #850 for the full reasoning.

**2. `force_release` dispatch input,** matching the SDK workflows. This matters more here than anywhere else: the `tag-delete-protection` ruleset covers `~ALL` tags with an empty bypass list, so **no one can delete a tag in this repo**, admin or not. A prematurely created tag is permanent, which makes `force_release` the only recovery path — and `release-prime.yml` was the one workflow without it. A failed CLI publish would have been unrecoverable without an admin editing the ruleset.

Build, upload, and publish now honour `exists != 'true' || force_release == 'true'`. Tag, GitHub Release, and Slack stay gated on the tag alone, so a forced re-publish never duplicates a tag or rewrites release notes.

**3. Supporting fixes so `force_release` actually works:**

- A `workflow_dispatch` with no `tag` input previously failed at `Set final version`, since `auto_version` was push-only and `manual_version` needs a tag. It now falls back to the source version, so `-f force_release=true` works on its own.
- `release_created` stays `true` on a forced publish, so the `docker-images` job still runs. It consumes the `dist` artifact, which the forced path uploads.

## Traced paths

| Scenario | Result |
| --- | --- |
| Push, new version | build → publish → tag → release → slack; docker-images runs |
| Push, tag exists | everything skipped, `created=false`, docker-images skipped |
| Publish fails | job fails with no tag and no release; next run retries normally |
| Dispatch `force_release=true`, tag exists | build + publish only; tag/release/slack skipped; docker-images runs |

Verified the file parses and the resulting step order and `if:` conditions match the table above.

## Forced releases build the tag

Same change as #850: `actions/checkout` takes the run's ref, so a forced release built the dispatch branch rather than the tag being recovered. The tag is now checked out before building, gated on `exists == 'true' && force_release == 'true'`.

Here it also settles the version skew noted below. A dispatch with an explicit `tag` input built the dispatch ref's source, so the wheel carried main's version while `docker-images` tagged the image with the requested one. Building the tag makes the wheel, the tag and the image agree.

The `docker-images` job still checks out the dispatch ref for its Dockerfile; only the artifact it packages comes from the tagged build.

## Notes

In forced mode the GitHub Release is not created, since the tag guard covers it. That is intentional — force is a publish-recovery path, not a release-recreation one — so a stuck release from before this change may need its GitHub Release added by hand.

Pre-existing and untouched: a dispatch with an explicit `tag` input still builds from the checked-out ref rather than from that tag, so the artifact version comes from the working tree either way.

## Recovery when a tag push fails after a successful publish

`skip-existing` is gated on `force_release`, so this narrow window needs one manual step. If the publish succeeds and the tag push then fails (transient — the tag ruleset does not block *creating* tags), no tag exists and PyPI holds the version:

- **An automatic re-run does not self-heal.** `skip-existing` is `false` on the push path, so the publish fails on the duplicate filename and stops before `Create tag`.
- **Recovery is one dispatch:** `gh workflow run release-prime.yml --ref main -f force_release=true`. That sets `skip-existing` to `true`, the upload skips, and `Create tag` runs.

This is deliberate. Unconditional `skip-existing` would make the automatic re-run succeed, but it would also let a later commit — one touching the package with no version bump, which is the normal rhythm here — skip the already-published filenames and tag *that* tree instead. A visible failure needing one command beats a silent mis-tag, given both branch off the same rare event.

One caveat when recovering: the tag is absent in this state, so `Check out existing tag` does not fire and the tag lands on the dispatch ref. If the branch has moved past the commit that produced the published artifact, dispatch from a ref at that commit, or check the tag afterwards.

Considered and rejected: comparing the built wheel's sha256 against PyPI's published hash before publishing, which would let the automatic re-run self-heal while still refusing to tag a different tree. It resolves the trade-off properly, but costs ~8 lines in each of five workflows and a PyPI query on the release path, and a build-backend upgrade between publish and retry (hatchling 1.31 to 1.32, exactly what happened this week) changes the hash for identical source and would fail the release. Recorded here so the option is not re-derived from scratch next time.

## Merge note

Carries the same v1.14.2 pin as #849, so neither PR can silently revert the other. They conflict on whichever merges second — the conflict is the old-position `Publish to PyPI` block versus its deletion, and the resolution is to **take the deletion**, since this branch re-adds that step with the v1.14.2 pin after `Upload build artifacts`. Taking `HEAD` would duplicate the publish step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release and PyPI publish ordering in CI; mistakes could affect shipping or recovery paths, but scope is limited to the workflow file with explicit force-only skip-existing behavior.
> 
> **Overview**
> **Reworks `release-prime.yml` so PyPI publish runs before any durable release artifacts** (git tag and GitHub Release), matching the SDK workflow fix pattern. Failed publishes no longer leave a tag that blocks retries while nothing ships to PyPI.
> 
> Adds a **`force_release` manual dispatch input** so build, artifact upload, and PyPI publish can run when the version tag already exists—needed because tags here cannot be deleted. Forced publishes use **`skip-existing`** on PyPI and **check out the existing tag** so the built package matches the tagged source. Tag creation, GitHub Release, and Slack stay gated on “tag does not exist,” so forced runs recover PyPI without duplicating tags or release notes.
> 
> **Dispatch without a `tag` input** now resolves version from package source (not only on push), and **`release_created`** stays true on forced publish so the **`docker-images`** job still runs from the uploaded `dist` artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d40995c46462cacb58e12d188c16286d20c9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->