### PR TITLE
improvement: batch sandbox status polling

### DIFF
--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -162,7 +162,7 @@ for i in range(5):
     ))
     sandbox_ids.append(sandbox.id)
 
-# Wait for all to be ready
+# Wait for up to 100 sandboxes with one batched lifecycle-status request per poll
 statuses = sandbox_client.bulk_wait_for_creation(sandbox_ids)
 
 # Delete by IDs or labels
@@ -219,6 +219,11 @@ job = sandbox_client.start_background_job(
 )
 print(f"Job started: {job.job_id}")
 
+# VM sandboxes can check up to 100 SDK-started jobs at once. Results preserve
+# input order; completed jobs include the same bounded stdout/stderr tails as
+# get_background_job().
+statuses = sandbox_client.get_background_jobs([job])
+
 # Poll for completion
 import time
 while True:
@@ -233,6 +238,9 @@ while True:
 # Download results
 sandbox_client.download_file(sandbox.id, "/app/model.pt", "./model.pt")
 ```
+
+`get_background_jobs` is VM-only. Container sandboxes retain the existing
+`get_background_job` polling behavior.
 
 #### Async version
 

--- a/packages/prime-sandboxes/README.md
+++ b/packages/prime-sandboxes/README.md
@@ -219,9 +219,9 @@ job = sandbox_client.start_background_job(
 )
 print(f"Job started: {job.job_id}")
 
-# VM sandboxes can check up to 100 SDK-started jobs at once. Results preserve
-# input order; completed jobs include the same bounded stdout/stderr tails as
-# get_background_job().
+# VM sandboxes can check up to 100 SDK-started jobs across sandboxes with one
+# platform request. Results preserve input order; completed jobs include the
+# same bounded stdout/stderr tails as get_background_job().
 statuses = sandbox_client.get_background_jobs([job])
 
 # Poll for completion

--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -14,6 +14,7 @@ from .core import (
     UnauthorizedError,
 )
 from .exceptions import (
+    BatchStatusUnsupportedError,
     CommandTimeoutError,
     DownloadTimeoutError,
     SandboxFileNotFoundError,
@@ -29,6 +30,7 @@ from .models import (
     AdvancedConfigs,
     BackgroundJob,
     BackgroundJobStatus,
+    BatchSandboxStatusResponse,
     BuildImageRequest,
     BuildImageResponse,
     BulkDeleteSandboxRequest,
@@ -59,6 +61,8 @@ from .models import (
     SandboxEgressPolicy,
     SandboxListResponse,
     SandboxStatus,
+    SandboxStatusLookupError,
+    SandboxStatusSnapshot,
     SSHSession,
     StartCommand,
     TeamImageOwner,
@@ -108,6 +112,9 @@ __all__ = [
     "AdvancedConfigs",
     "BackgroundJob",
     "BackgroundJobStatus",
+    "BatchSandboxStatusResponse",
+    "SandboxStatusSnapshot",
+    "SandboxStatusLookupError",
     "BuildImageRequest",
     "BuildImageResponse",
     "BulkImageTransferResponse",
@@ -132,6 +139,7 @@ __all__ = [
     "SSHSession",
     # Exceptions
     "APIError",
+    "BatchStatusUnsupportedError",
     "UnauthorizedError",
     "PaymentRequiredError",
     "SandboxFileNotFoundError",

--- a/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
@@ -19,6 +19,12 @@ class SandboxFileTooLargeError(APIError):
     pass
 
 
+class BatchStatusUnsupportedError(APIError):
+    """Raised when a required platform or VM batch-status endpoint is unavailable."""
+
+    pass
+
+
 class SandboxNotRunningError(RuntimeError):
     """Raised when an operation requires a RUNNING sandbox but it is not running."""
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/exceptions.py
@@ -20,7 +20,7 @@ class SandboxFileTooLargeError(APIError):
 
 
 class BatchStatusUnsupportedError(APIError):
-    """Raised when a required platform or VM batch-status endpoint is unavailable."""
+    """Raised when batch status is unsupported for the requested sandbox runtime."""
 
     pass
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -711,15 +711,33 @@ class BackgroundJobStatus(BaseModel):
     stderr_truncated: bool = False
 
 
-class BackgroundJobRuntimeStatus(BaseModel):
-    """Runtime-only completion state returned by a VM batch lookup."""
+class BackgroundJobStatusSnapshot(BaseModel):
+    """Completion state returned by a platform VM background-job lookup."""
 
+    sandbox_id: str
     job_id: str
     completed: bool
     exit_code: Optional[int] = None
 
 
-class BatchBackgroundJobRuntimeStatusResponse(BaseModel):
-    """Ordered runtime-only completion states for VM background jobs."""
+class BackgroundJobStatusLookupError(BaseModel):
+    """Per-job error returned by a platform VM background-job lookup."""
 
-    jobs: List[BackgroundJobRuntimeStatus]
+    sandbox_id: str
+    job_id: str
+    code: Literal[
+        "NOT_FOUND",
+        "FORBIDDEN",
+        "MANAGED",
+        "NOT_VM",
+        "NOT_RUNNING",
+        "RUNTIME_ERROR",
+    ]
+    message: str
+
+
+class BatchBackgroundJobStatusResponse(BaseModel):
+    """Ordered results from a platform VM background-job lookup."""
+
+    statuses: List[BackgroundJobStatusSnapshot]
+    errors: List[BackgroundJobStatusLookupError]

--- a/packages/prime-sandboxes/src/prime_sandboxes/models.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/models.py
@@ -191,6 +191,31 @@ class SandboxListResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class SandboxStatusSnapshot(BaseModel):
+    """Lightweight sandbox lifecycle state returned by a batch status lookup."""
+
+    sandbox_id: str
+    status: SandboxStatus
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    pending_image_build_id: Optional[str] = None
+
+
+class SandboxStatusLookupError(BaseModel):
+    """Per-sandbox error returned by a batch status lookup."""
+
+    sandbox_id: str
+    code: Literal["NOT_FOUND", "FORBIDDEN", "MANAGED"]
+    message: str
+
+
+class BatchSandboxStatusResponse(BaseModel):
+    """Ordered results from a batch sandbox lifecycle status lookup."""
+
+    statuses: List[SandboxStatusSnapshot]
+    errors: List[SandboxStatusLookupError]
+
+
 class CreateSandboxRequest(BaseModel):
     """Create sandbox request model"""
 
@@ -684,3 +709,17 @@ class BackgroundJobStatus(BaseModel):
     stderr: Optional[str] = None
     stdout_truncated: bool = False
     stderr_truncated: bool = False
+
+
+class BackgroundJobRuntimeStatus(BaseModel):
+    """Runtime-only completion state returned by a VM batch lookup."""
+
+    job_id: str
+    completed: bool
+    exit_code: Optional[int] = None
+
+
+class BatchBackgroundJobRuntimeStatusResponse(BaseModel):
+    """Ordered runtime-only completion states for VM background jobs."""
+
+    jobs: List[BackgroundJobRuntimeStatus]

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -12,6 +12,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import Future
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import (
     Any,
@@ -117,6 +118,13 @@ _BatchKey = TypeVar("_BatchKey", bound=Hashable)
 _BatchValue = TypeVar("_BatchValue")
 
 
+@dataclass(frozen=True)
+class _BatchItemError:
+    """An error for one key in an otherwise successful transport batch."""
+
+    error: Exception
+
+
 @functools.lru_cache(maxsize=1)
 def _ca_bundle() -> bytes:
     with open(certifi.where(), "rb") as ca_file:
@@ -207,7 +215,7 @@ class _SyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
 
     def __init__(
         self,
-        fetch: Callable[[List[_BatchKey]], Dict[_BatchKey, _BatchValue]],
+        fetch: Callable[[List[_BatchKey]], Dict[_BatchKey, _BatchValue | _BatchItemError]],
     ) -> None:
         self._fetch = fetch
         self._lock = threading.Lock()
@@ -253,8 +261,13 @@ class _SyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
                     for waiter in key_waiters:
                         waiter.set_exception(exc)
                     continue
+                result = results[key]
+                if isinstance(result, _BatchItemError):
+                    for waiter in key_waiters:
+                        waiter.set_exception(result.error)
+                    continue
                 for waiter in key_waiters:
-                    waiter.set_result(results[key])
+                    waiter.set_result(result)
 
 
 class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
@@ -262,7 +275,10 @@ class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
 
     def __init__(
         self,
-        fetch: Callable[[List[_BatchKey]], Awaitable[Dict[_BatchKey, _BatchValue]]],
+        fetch: Callable[
+            [List[_BatchKey]],
+            Awaitable[Dict[_BatchKey, _BatchValue | _BatchItemError]],
+        ],
     ) -> None:
         self._fetch = fetch
         self._pending: Dict[_BatchKey, List[asyncio.Future[_BatchValue]]] = {}
@@ -299,9 +315,15 @@ class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
                             if not waiter.done():
                                 waiter.set_exception(exc)
                         continue
+                    result = results[key]
+                    if isinstance(result, _BatchItemError):
+                        for waiter in key_waiters:
+                            if not waiter.done():
+                                waiter.set_exception(result.error)
+                        continue
                     for waiter in key_waiters:
                         if not waiter.done():
-                            waiter.set_result(results[key])
+                            waiter.set_result(result)
         finally:
             self._dispatch_task = None
             if self._pending:
@@ -780,7 +802,7 @@ class AsyncSandboxAuthCache:
             await self._save_cache()
 
 
-def _is_waiting_for_image_build(sandbox: Sandbox) -> bool:
+def _is_waiting_for_image_build(sandbox: Sandbox | SandboxStatusSnapshot) -> bool:
     return sandbox.status == "PENDING" and bool(getattr(sandbox, "pending_image_build_id", None))
 
 
@@ -1032,19 +1054,32 @@ class SandboxClient:
         self._sandbox_status_batch_supported = True
         return BatchSandboxStatusResponse.model_validate(response)
 
-    def _fetch_sandbox_statuses(self, sandbox_ids: List[str]) -> Dict[str, SandboxStatusSnapshot]:
+    def _fetch_sandbox_statuses(
+        self, sandbox_ids: List[str]
+    ) -> Dict[str, SandboxStatusSnapshot | _BatchItemError]:
         """Fetch one coalesced lifecycle batch for concurrent waiters."""
         try:
             response = self.get_sandbox_statuses(sandbox_ids)
         except BatchStatusUnsupportedError:
-            return {
-                sandbox_id: _sandbox_to_status_snapshot(self.get(sandbox_id))
-                for sandbox_id in sandbox_ids
-            }
-        if response.errors:
-            details = ", ".join(f"{error.sandbox_id}={error.code}" for error in response.errors)
-            raise APIError(f"Batch sandbox status lookup failed: {details}")
-        return {snapshot.sandbox_id: snapshot for snapshot in response.statuses}
+            results: Dict[str, SandboxStatusSnapshot | _BatchItemError] = {}
+            for sandbox_id in sandbox_ids:
+                try:
+                    results[sandbox_id] = _sandbox_to_status_snapshot(self.get(sandbox_id))
+                except Exception as exc:
+                    results[sandbox_id] = _BatchItemError(exc)
+            return results
+
+        results: Dict[str, SandboxStatusSnapshot | _BatchItemError] = {
+            snapshot.sandbox_id: snapshot for snapshot in response.statuses
+        }
+        for error in response.errors:
+            results[error.sandbox_id] = _BatchItemError(
+                APIError(
+                    f"Sandbox status lookup failed for {error.sandbox_id}: "
+                    f"{error.code}: {error.message}"
+                )
+            )
+        return results
 
     def delete(self, sandbox_id: str) -> Dict[str, Any]:
         """Delete a sandbox"""
@@ -1444,20 +1479,14 @@ class SandboxClient:
             stderr_truncated=stderr_truncated,
         )
 
-    def get_background_jobs(
+    def _request_background_job_status_batch(
         self,
         jobs: List[BackgroundJob],
         timeout: Optional[int] = None,
-    ) -> List[BackgroundJobStatus]:
-        """Get ordered status for up to 100 jobs across VM sandboxes.
-
-        One platform request checks all canonical exit-code files. Output is
-        fetched with the existing bounded-tail behavior once a job completes.
-        Container sandboxes intentionally continue to use get_background_job().
-        """
-        _validate_background_job_batch(jobs)
+    ) -> Optional[BatchBackgroundJobStatusResponse]:
+        """Return one raw platform batch, or None when the endpoint is unavailable."""
         if self._background_job_status_batch_supported is False:
-            return self._get_background_jobs_legacy(jobs, timeout)
+            return None
         try:
             response = self.client.request(
                 "POST",
@@ -1471,10 +1500,26 @@ class SandboxClient:
         except APIError as exc:
             if "HTTP 404" in str(exc) or "HTTP 405" in str(exc):
                 self._background_job_status_batch_supported = False
-                return self._get_background_jobs_legacy(jobs, timeout)
+                return None
             raise
         self._background_job_status_batch_supported = True
-        body = BatchBackgroundJobStatusResponse.model_validate(response)
+        return BatchBackgroundJobStatusResponse.model_validate(response)
+
+    def get_background_jobs(
+        self,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int] = None,
+    ) -> List[BackgroundJobStatus]:
+        """Get ordered status for up to 100 jobs across VM sandboxes.
+
+        One platform request checks all canonical exit-code files. Output is
+        fetched with the existing bounded-tail behavior once a job completes.
+        Container sandboxes intentionally continue to use get_background_job().
+        """
+        _validate_background_job_batch(jobs)
+        body = self._request_background_job_status_batch(jobs, timeout)
+        if body is None:
+            return self._get_background_jobs_legacy(jobs, timeout)
         if body.errors:
             details = "; ".join(
                 f"{error.sandbox_id}/{error.job_id}: {error.message}" for error in body.errors
@@ -1554,11 +1599,57 @@ class SandboxClient:
 
     def _fetch_background_job_statuses(
         self, keys: List[tuple[str, str]]
-    ) -> Dict[tuple[str, str], BackgroundJobStatus]:
+    ) -> Dict[tuple[str, str], BackgroundJobStatus | _BatchItemError]:
         """Fetch one coalesced VM job batch for concurrent run waiters."""
         jobs = [_canonical_background_job(sandbox_id, job_id) for sandbox_id, job_id in keys]
-        statuses = self.get_background_jobs(jobs)
-        return {(job.sandbox_id, job.job_id): status for job, status in zip(jobs, statuses)}
+        body = self._request_background_job_status_batch(jobs)
+        if body is None:
+            results: Dict[tuple[str, str], BackgroundJobStatus | _BatchItemError] = {}
+            for job in jobs:
+                key = (job.sandbox_id, job.job_id)
+                try:
+                    results[key] = self._get_background_jobs_legacy([job], None)[0]
+                except Exception as exc:
+                    results[key] = _BatchItemError(exc)
+            return results
+
+        results: Dict[tuple[str, str], BackgroundJobStatus | _BatchItemError] = {}
+        for error in body.errors:
+            key = (error.sandbox_id, error.job_id)
+            details = f"{error.sandbox_id}/{error.job_id}: {error.message}"
+            exc = (
+                BatchStatusUnsupportedError(details)
+                if error.code == "NOT_VM"
+                else APIError(f"Background job batch status failed: {details}")
+            )
+            results[key] = _BatchItemError(exc)
+
+        runtime_statuses = {(status.sandbox_id, status.job_id): status for status in body.statuses}
+        for job in jobs:
+            key = (job.sandbox_id, job.job_id)
+            if key in results:
+                continue
+            runtime_status = runtime_statuses.get(key)
+            if runtime_status is None:
+                continue
+            if not runtime_status.completed:
+                results[key] = BackgroundJobStatus(job_id=job.job_id, completed=False)
+                continue
+            if runtime_status.exit_code is None:
+                results[key] = _BatchItemError(
+                    APIError(f"Completed VM background job {job.job_id} omitted exit_code")
+                )
+                continue
+            try:
+                results[key] = self._get_completed_background_job_output(
+                    job.sandbox_id,
+                    job,
+                    runtime_status.exit_code,
+                    None,
+                )
+            except Exception as exc:
+                results[key] = _BatchItemError(exc)
+        return results
 
     def run_background_job(
         self,
@@ -1702,9 +1793,15 @@ class SandboxClient:
             try:
                 response = self.get_sandbox_statuses(sandbox_ids)
             except BatchStatusUnsupportedError:
-                snapshots = self._fetch_sandbox_statuses(sandbox_ids)
+                outcomes = self._fetch_sandbox_statuses(sandbox_ids)
+                snapshots = []
+                for sandbox_id in sandbox_ids:
+                    outcome = outcomes[sandbox_id]
+                    if isinstance(outcome, _BatchItemError):
+                        raise outcome.error
+                    snapshots.append(outcome)
                 response = BatchSandboxStatusResponse(
-                    statuses=[snapshots[sandbox_id] for sandbox_id in sandbox_ids],
+                    statuses=snapshots,
                     errors=[],
                 )
             except Exception as exc:
@@ -2325,17 +2422,34 @@ class AsyncSandboxClient:
 
     async def _fetch_sandbox_statuses(
         self, sandbox_ids: List[str]
-    ) -> Dict[str, SandboxStatusSnapshot]:
+    ) -> Dict[str, SandboxStatusSnapshot | _BatchItemError]:
         """Fetch one coalesced lifecycle batch for concurrent waiters."""
         try:
             response = await self.get_sandbox_statuses(sandbox_ids)
         except BatchStatusUnsupportedError:
-            sandboxes = await asyncio.gather(*(self.get(sandbox_id) for sandbox_id in sandbox_ids))
-            return {sandbox.id: _sandbox_to_status_snapshot(sandbox) for sandbox in sandboxes}
-        if response.errors:
-            details = ", ".join(f"{error.sandbox_id}={error.code}" for error in response.errors)
-            raise APIError(f"Batch sandbox status lookup failed: {details}")
-        return {snapshot.sandbox_id: snapshot for snapshot in response.statuses}
+            sandboxes = await asyncio.gather(
+                *(self.get(sandbox_id) for sandbox_id in sandbox_ids),
+                return_exceptions=True,
+            )
+            results: Dict[str, SandboxStatusSnapshot | _BatchItemError] = {}
+            for sandbox_id, sandbox in zip(sandbox_ids, sandboxes):
+                if isinstance(sandbox, Exception):
+                    results[sandbox_id] = _BatchItemError(sandbox)
+                else:
+                    results[sandbox_id] = _sandbox_to_status_snapshot(sandbox)
+            return results
+
+        results: Dict[str, SandboxStatusSnapshot | _BatchItemError] = {
+            snapshot.sandbox_id: snapshot for snapshot in response.statuses
+        }
+        for error in response.errors:
+            results[error.sandbox_id] = _BatchItemError(
+                APIError(
+                    f"Sandbox status lookup failed for {error.sandbox_id}: "
+                    f"{error.code}: {error.message}"
+                )
+            )
+        return results
 
     async def delete(self, sandbox_id: str) -> Dict[str, Any]:
         """Delete a sandbox"""
@@ -2846,15 +2960,14 @@ class AsyncSandboxClient:
             stderr_truncated=stderr_truncated,
         )
 
-    async def get_background_jobs(
+    async def _request_background_job_status_batch(
         self,
         jobs: List[BackgroundJob],
         timeout: Optional[int] = None,
-    ) -> List[BackgroundJobStatus]:
-        """Get ordered status for up to 100 jobs across VM sandboxes."""
-        _validate_background_job_batch(jobs)
+    ) -> Optional[BatchBackgroundJobStatusResponse]:
+        """Return one raw platform batch, or None when the endpoint is unavailable."""
         if self._background_job_status_batch_supported is False:
-            return await self._get_background_jobs_legacy(jobs, timeout)
+            return None
         try:
             response = await self.client.request(
                 "POST",
@@ -2868,10 +2981,21 @@ class AsyncSandboxClient:
         except APIError as exc:
             if "HTTP 404" in str(exc) or "HTTP 405" in str(exc):
                 self._background_job_status_batch_supported = False
-                return await self._get_background_jobs_legacy(jobs, timeout)
+                return None
             raise
         self._background_job_status_batch_supported = True
-        body = BatchBackgroundJobStatusResponse.model_validate(response)
+        return BatchBackgroundJobStatusResponse.model_validate(response)
+
+    async def get_background_jobs(
+        self,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int] = None,
+    ) -> List[BackgroundJobStatus]:
+        """Get ordered status for up to 100 jobs across VM sandboxes."""
+        _validate_background_job_batch(jobs)
+        body = await self._request_background_job_status_batch(jobs, timeout)
+        if body is None:
+            return await self._get_background_jobs_legacy(jobs, timeout)
         if body.errors:
             details = "; ".join(
                 f"{error.sandbox_id}/{error.job_id}: {error.message}" for error in body.errors
@@ -2954,11 +3078,64 @@ class AsyncSandboxClient:
 
     async def _fetch_background_job_statuses(
         self, keys: List[tuple[str, str]]
-    ) -> Dict[tuple[str, str], BackgroundJobStatus]:
+    ) -> Dict[tuple[str, str], BackgroundJobStatus | _BatchItemError]:
         """Fetch one coalesced VM job batch for concurrent run waiters."""
         jobs = [_canonical_background_job(sandbox_id, job_id) for sandbox_id, job_id in keys]
-        statuses = await self.get_background_jobs(jobs)
-        return {(job.sandbox_id, job.job_id): status for job, status in zip(jobs, statuses)}
+        body = await self._request_background_job_status_batch(jobs)
+        if body is None:
+
+            async def get_legacy_status(
+                job: BackgroundJob,
+            ) -> BackgroundJobStatus | _BatchItemError:
+                try:
+                    return (await self._get_background_jobs_legacy([job], None))[0]
+                except Exception as exc:
+                    return _BatchItemError(exc)
+
+            statuses = await asyncio.gather(*(get_legacy_status(job) for job in jobs))
+            return {(job.sandbox_id, job.job_id): status for job, status in zip(jobs, statuses)}
+
+        results: Dict[tuple[str, str], BackgroundJobStatus | _BatchItemError] = {}
+        for error in body.errors:
+            key = (error.sandbox_id, error.job_id)
+            details = f"{error.sandbox_id}/{error.job_id}: {error.message}"
+            exc = (
+                BatchStatusUnsupportedError(details)
+                if error.code == "NOT_VM"
+                else APIError(f"Background job batch status failed: {details}")
+            )
+            results[key] = _BatchItemError(exc)
+
+        runtime_statuses = {(status.sandbox_id, status.job_id): status for status in body.statuses}
+
+        async def build_status(job: BackgroundJob) -> BackgroundJobStatus | _BatchItemError | None:
+            key = (job.sandbox_id, job.job_id)
+            if key in results:
+                return None
+            runtime_status = runtime_statuses.get(key)
+            if runtime_status is None:
+                return None
+            if not runtime_status.completed:
+                return BackgroundJobStatus(job_id=job.job_id, completed=False)
+            if runtime_status.exit_code is None:
+                return _BatchItemError(
+                    APIError(f"Completed VM background job {job.job_id} omitted exit_code")
+                )
+            try:
+                return await self._get_completed_background_job_output(
+                    job.sandbox_id,
+                    job,
+                    runtime_status.exit_code,
+                    None,
+                )
+            except Exception as exc:
+                return _BatchItemError(exc)
+
+        statuses = await asyncio.gather(*(build_status(job) for job in jobs))
+        for job, status in zip(jobs, statuses):
+            if status is not None:
+                results[(job.sandbox_id, job.job_id)] = status
+        return results
 
     async def run_background_job(
         self,
@@ -3103,9 +3280,15 @@ class AsyncSandboxClient:
             try:
                 response = await self.get_sandbox_statuses(sandbox_ids)
             except BatchStatusUnsupportedError:
-                snapshots = await self._fetch_sandbox_statuses(sandbox_ids)
+                outcomes = await self._fetch_sandbox_statuses(sandbox_ids)
+                snapshots = []
+                for sandbox_id in sandbox_ids:
+                    outcome = outcomes[sandbox_id]
+                    if isinstance(outcome, _BatchItemError):
+                        raise outcome.error
+                    snapshots.append(outcome)
                 response = BatchSandboxStatusResponse(
-                    statuses=[snapshots[sandbox_id] for sandbox_id in sandbox_ids],
+                    statuses=snapshots,
                     errors=[],
                 )
             except Exception as exc:

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -60,9 +60,8 @@ from .exceptions import (
 )
 from .models import (
     BackgroundJob,
-    BackgroundJobRuntimeStatus,
     BackgroundJobStatus,
-    BatchBackgroundJobRuntimeStatusResponse,
+    BatchBackgroundJobStatusResponse,
     BatchSandboxStatusResponse,
     BulkDeleteSandboxRequest,
     BulkDeleteSandboxResponse,
@@ -185,9 +184,9 @@ AUTH_REFRESH_MARGIN_SECONDS = 60
 # Max bytes of stdout/stderr returned per background-job status check
 JOB_OUTPUT_TAIL_BYTES = 10 * 1024 * 1024
 
-# Both the platform and VM runtime batch-status contracts cap one request at 100
-# identifiers. Concurrent single-item waits are collected briefly so callers
-# share a request without adding a persistent worker to the client lifecycle.
+# Platform batch-status contracts cap one request at 100 identifiers. Concurrent
+# single-item waits are collected briefly so callers share a request without
+# adding a persistent worker to the client lifecycle.
 MAX_STATUS_BATCH_SIZE = 100
 STATUS_BATCH_WINDOW_SECONDS = 0.025
 
@@ -415,7 +414,7 @@ def _validate_unique_batch_values(values: List[str], field_name: str) -> None:
 
 
 def _canonical_background_job(sandbox_id: str, job_id: str) -> BackgroundJob:
-    """Build the canonical SDK background-job handle for a VM runtime lookup."""
+    """Build the canonical SDK background-job handle for a VM batch lookup."""
     return BackgroundJob(
         job_id=job_id,
         sandbox_id=sandbox_id,
@@ -426,7 +425,7 @@ def _canonical_background_job(sandbox_id: str, job_id: str) -> BackgroundJob:
 
 
 def _validate_background_job_batch(jobs: List[BackgroundJob]) -> None:
-    """Validate VM runtime batching is limited to canonical SDK job handles."""
+    """Validate VM batching is limited to canonical SDK job handles."""
     if not jobs or len(jobs) > MAX_STATUS_BATCH_SIZE:
         raise ValueError(f"jobs must contain between 1 and {MAX_STATUS_BATCH_SIZE} entries")
 
@@ -829,21 +828,6 @@ class SandboxClient:
         """Make a POST request to the gateway with retry on connection errors only."""
         with httpx.Client(timeout=timeout) as client:
             return client.post(url, json=json, files=files, params=params, headers=headers)
-
-    @staticmethod
-    @_read_file_retry
-    def _gateway_idempotent_post(
-        url: str,
-        headers: Dict[str, str],
-        timeout: float,
-        json: Dict[str, Any],
-    ) -> httpx.Response:
-        """Make an idempotent gateway POST with transient retries."""
-        with httpx.Client(timeout=timeout) as client:
-            response = client.post(url, json=json, headers=headers)
-        if response.status_code == 408 or response.status_code in RETRYABLE_5XX_STATUSES:
-            response.raise_for_status()
-        return response
 
     @staticmethod
     @_gateway_retry
@@ -1440,28 +1424,38 @@ class SandboxClient:
         jobs: List[BackgroundJob],
         timeout: Optional[int] = None,
     ) -> List[BackgroundJobStatus]:
-        """Get ordered status for up to 100 background jobs in VM sandboxes.
+        """Get ordered status for up to 100 jobs across VM sandboxes.
 
-        The runtime batch call reads only canonical exit-code files. Output is
+        One platform request checks all canonical exit-code files. Output is
         fetched with the existing bounded-tail behavior once a job completes.
         Container sandboxes intentionally continue to use get_background_job().
         """
         _validate_background_job_batch(jobs)
-        jobs_by_sandbox: Dict[str, List[BackgroundJob]] = {}
-        for job in jobs:
-            jobs_by_sandbox.setdefault(job.sandbox_id, []).append(job)
-
-        runtime_statuses: Dict[tuple[str, str], BackgroundJobRuntimeStatus] = {}
-        for sandbox_id, sandbox_jobs in jobs_by_sandbox.items():
-            self._auth_cache.get_or_refresh(sandbox_id)
-            if not self._auth_cache.is_vm(sandbox_id):
+        try:
+            response = self.client.request(
+                "POST",
+                "/sandbox/background-jobs/status:batchGet",
+                json={
+                    "jobs": [{"sandbox_id": job.sandbox_id, "job_id": job.job_id} for job in jobs]
+                },
+                timeout=timeout if timeout is not None else 30,
+                idempotent_post=True,
+            )
+        except APIError as exc:
+            if "HTTP 404" in str(exc):
                 raise BatchStatusUnsupportedError(
-                    "Batched background job status is only supported for VM sandboxes."
-                )
-            for status in self._get_background_job_runtime_statuses(
-                sandbox_id, sandbox_jobs, timeout
-            ):
-                runtime_statuses[(sandbox_id, status.job_id)] = status
+                    "The platform does not support batch background job status lookups."
+                ) from exc
+            raise
+        body = BatchBackgroundJobStatusResponse.model_validate(response)
+        if body.errors:
+            details = "; ".join(
+                f"{error.sandbox_id}/{error.job_id}: {error.message}" for error in body.errors
+            )
+            if any(error.code == "NOT_VM" for error in body.errors):
+                raise BatchStatusUnsupportedError(details)
+            raise APIError(f"Background job batch status failed: {details}")
+        runtime_statuses = {(status.sandbox_id, status.job_id): status for status in body.statuses}
 
         results = []
         for job in jobs:
@@ -1482,50 +1476,6 @@ class SandboxClient:
                 )
             )
         return results
-
-    def _get_background_job_runtime_statuses(
-        self,
-        sandbox_id: str,
-        jobs: List[BackgroundJob],
-        timeout: Optional[int],
-    ) -> List[BackgroundJobRuntimeStatus]:
-        """Call the VM sandboxd batch completion endpoint."""
-        effective_timeout = timeout if timeout is not None else 30
-        reauthed = False
-        for _ in range(MAX_GATEWAY_ATTEMPTS):
-            auth = self._auth_cache.get_or_refresh(sandbox_id)
-            gateway_url = auth["gateway_url"].rstrip("/")
-            url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/background-jobs/status"
-            headers = {"Authorization": f"Bearer {auth['token']}"}
-            try:
-                response = self._gateway_idempotent_post(
-                    url,
-                    headers=headers,
-                    timeout=effective_timeout,
-                    json={"job_ids": [job.job_id for job in jobs]},
-                )
-                response.raise_for_status()
-                body = BatchBackgroundJobRuntimeStatusResponse.model_validate(response.json())
-                return body.jobs
-            except httpx.TimeoutException as exc:
-                raise APIError(
-                    f"VM background job status timed out after {effective_timeout}s"
-                ) from exc
-            except httpx.HTTPStatusError as exc:
-                status_code = exc.response.status_code
-                if status_code == 401 and self._should_retry_401(sandbox_id, reauthed):
-                    reauthed = True
-                    continue
-                if status_code == 404:
-                    raise BatchStatusUnsupportedError(
-                        "This VM sandbox does not support batched background job status."
-                    ) from exc
-                raise APIError(
-                    f"VM background job status failed: HTTP {status_code}: {exc.response.text}"
-                ) from exc
-            except httpx.RequestError as exc:
-                raise APIError(f"VM background job status request failed: {exc}") from exc
-        raise APIError("VM background job status failed after retries")
 
     def _get_completed_background_job_output(
         self,
@@ -2135,21 +2085,6 @@ class AsyncSandboxClient:
         return await gateway_client.post(
             url, json=json, files=files, params=params, headers=headers, timeout=timeout
         )
-
-    @_read_file_retry
-    async def _gateway_idempotent_post(
-        self,
-        url: str,
-        headers: Dict[str, str],
-        timeout: float,
-        json: Dict[str, Any],
-    ) -> httpx.Response:
-        """Make an idempotent gateway POST with transient retries."""
-        gateway_client = self._get_gateway_client()
-        response = await gateway_client.post(url, json=json, headers=headers, timeout=timeout)
-        if response.status_code == 408 or response.status_code in RETRYABLE_5XX_STATUSES:
-            response.raise_for_status()
-        return response
 
     @_gateway_retry
     async def _gateway_get(
@@ -2857,36 +2792,33 @@ class AsyncSandboxClient:
         jobs: List[BackgroundJob],
         timeout: Optional[int] = None,
     ) -> List[BackgroundJobStatus]:
-        """Get ordered status for up to 100 background jobs in VM sandboxes."""
+        """Get ordered status for up to 100 jobs across VM sandboxes."""
         _validate_background_job_batch(jobs)
-        jobs_by_sandbox: Dict[str, List[BackgroundJob]] = {}
-        for job in jobs:
-            jobs_by_sandbox.setdefault(job.sandbox_id, []).append(job)
-
-        async def fetch_sandbox_jobs(
-            sandbox_id: str, sandbox_jobs: List[BackgroundJob]
-        ) -> tuple[str, List[BackgroundJobRuntimeStatus]]:
-            await self._auth_cache.get_or_refresh(sandbox_id)
-            if not await self._auth_cache.is_vm(sandbox_id):
+        try:
+            response = await self.client.request(
+                "POST",
+                "/sandbox/background-jobs/status:batchGet",
+                json={
+                    "jobs": [{"sandbox_id": job.sandbox_id, "job_id": job.job_id} for job in jobs]
+                },
+                timeout=timeout if timeout is not None else 30,
+                idempotent_post=True,
+            )
+        except APIError as exc:
+            if "HTTP 404" in str(exc):
                 raise BatchStatusUnsupportedError(
-                    "Batched background job status is only supported for VM sandboxes."
-                )
-            statuses = await self._get_background_job_runtime_statuses(
-                sandbox_id, sandbox_jobs, timeout
+                    "The platform does not support batch background job status lookups."
+                ) from exc
+            raise
+        body = BatchBackgroundJobStatusResponse.model_validate(response)
+        if body.errors:
+            details = "; ".join(
+                f"{error.sandbox_id}/{error.job_id}: {error.message}" for error in body.errors
             )
-            return sandbox_id, statuses
-
-        grouped_statuses = await asyncio.gather(
-            *(
-                fetch_sandbox_jobs(sandbox_id, sandbox_jobs)
-                for sandbox_id, sandbox_jobs in jobs_by_sandbox.items()
-            )
-        )
-        runtime_statuses = {
-            (sandbox_id, status.job_id): status
-            for sandbox_id, statuses in grouped_statuses
-            for status in statuses
-        }
+            if any(error.code == "NOT_VM" for error in body.errors):
+                raise BatchStatusUnsupportedError(details)
+            raise APIError(f"Background job batch status failed: {details}")
+        runtime_statuses = {(status.sandbox_id, status.job_id): status for status in body.statuses}
 
         async def build_status(job: BackgroundJob) -> BackgroundJobStatus:
             runtime_status = runtime_statuses.get((job.sandbox_id, job.job_id))
@@ -2904,50 +2836,6 @@ class AsyncSandboxClient:
             )
 
         return list(await asyncio.gather(*(build_status(job) for job in jobs)))
-
-    async def _get_background_job_runtime_statuses(
-        self,
-        sandbox_id: str,
-        jobs: List[BackgroundJob],
-        timeout: Optional[int],
-    ) -> List[BackgroundJobRuntimeStatus]:
-        """Call the VM sandboxd batch completion endpoint."""
-        effective_timeout = timeout if timeout is not None else 30
-        reauthed = False
-        for _ in range(MAX_GATEWAY_ATTEMPTS):
-            auth = await self._auth_cache.get_or_refresh(sandbox_id)
-            gateway_url = auth["gateway_url"].rstrip("/")
-            url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/background-jobs/status"
-            headers = {"Authorization": f"Bearer {auth['token']}"}
-            try:
-                response = await self._gateway_idempotent_post(
-                    url,
-                    headers=headers,
-                    timeout=effective_timeout,
-                    json={"job_ids": [job.job_id for job in jobs]},
-                )
-                response.raise_for_status()
-                body = BatchBackgroundJobRuntimeStatusResponse.model_validate(response.json())
-                return body.jobs
-            except httpx.TimeoutException as exc:
-                raise APIError(
-                    f"VM background job status timed out after {effective_timeout}s"
-                ) from exc
-            except httpx.HTTPStatusError as exc:
-                status_code = exc.response.status_code
-                if status_code == 401 and await self._should_retry_401(sandbox_id, reauthed):
-                    reauthed = True
-                    continue
-                if status_code == 404:
-                    raise BatchStatusUnsupportedError(
-                        "This VM sandbox does not support batched background job status."
-                    ) from exc
-                raise APIError(
-                    f"VM background job status failed: HTTP {status_code}: {exc.response.text}"
-                ) from exc
-            except httpx.RequestError as exc:
-                raise APIError(f"VM background job status request failed: {exc}") from exc
-        raise APIError("VM background job status failed after retries")
 
     async def _get_completed_background_job_output(
         self,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -443,6 +443,17 @@ def _validate_background_job_batch(jobs: List[BackgroundJob]) -> None:
         raise ValueError("jobs must be unique")
 
 
+def _sandbox_to_status_snapshot(sandbox: Sandbox) -> SandboxStatusSnapshot:
+    """Convert a legacy full-sandbox lookup into the lightweight batch shape."""
+    return SandboxStatusSnapshot(
+        sandbox_id=sandbox.id,
+        status=sandbox.status,
+        error_type=sandbox.error_type,
+        error_message=sandbox.error_message,
+        pending_image_build_id=sandbox.pending_image_build_id,
+    )
+
+
 def _build_terminated_message(command: str, ctx: dict) -> str:
     """Build helpful error message for terminated sandbox."""
     cmd_preview = command[:50] + "..." if len(command) > 50 else command
@@ -814,6 +825,8 @@ class SandboxClient:
         self._background_job_status_batcher = _SyncRequestBatcher(
             self._fetch_background_job_statuses
         )
+        self._sandbox_status_batch_supported: Optional[bool] = None
+        self._background_job_status_batch_supported: Optional[bool] = None
 
     @staticmethod
     @_gateway_post_retry
@@ -998,6 +1011,10 @@ class SandboxClient:
     def get_sandbox_statuses(self, sandbox_ids: List[str]) -> BatchSandboxStatusResponse:
         """Get lightweight lifecycle state for up to 100 sandboxes."""
         _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
+        if self._sandbox_status_batch_supported is False:
+            raise BatchStatusUnsupportedError(
+                "The platform does not support batch sandbox status lookups."
+            )
         try:
             response = self.client.request(
                 "POST",
@@ -1006,16 +1023,24 @@ class SandboxClient:
                 idempotent_post=True,
             )
         except APIError as exc:
-            if "HTTP 404" in str(exc):
+            if "HTTP 404" in str(exc) or "HTTP 405" in str(exc):
+                self._sandbox_status_batch_supported = False
                 raise BatchStatusUnsupportedError(
                     "The platform does not support batch sandbox status lookups."
                 ) from exc
             raise
+        self._sandbox_status_batch_supported = True
         return BatchSandboxStatusResponse.model_validate(response)
 
     def _fetch_sandbox_statuses(self, sandbox_ids: List[str]) -> Dict[str, SandboxStatusSnapshot]:
         """Fetch one coalesced lifecycle batch for concurrent waiters."""
-        response = self.get_sandbox_statuses(sandbox_ids)
+        try:
+            response = self.get_sandbox_statuses(sandbox_ids)
+        except BatchStatusUnsupportedError:
+            return {
+                sandbox_id: _sandbox_to_status_snapshot(self.get(sandbox_id))
+                for sandbox_id in sandbox_ids
+            }
         if response.errors:
             details = ", ".join(f"{error.sandbox_id}={error.code}" for error in response.errors)
             raise APIError(f"Batch sandbox status lookup failed: {details}")
@@ -1431,6 +1456,8 @@ class SandboxClient:
         Container sandboxes intentionally continue to use get_background_job().
         """
         _validate_background_job_batch(jobs)
+        if self._background_job_status_batch_supported is False:
+            return self._get_background_jobs_legacy(jobs, timeout)
         try:
             response = self.client.request(
                 "POST",
@@ -1442,11 +1469,11 @@ class SandboxClient:
                 idempotent_post=True,
             )
         except APIError as exc:
-            if "HTTP 404" in str(exc):
-                raise BatchStatusUnsupportedError(
-                    "The platform does not support batch background job status lookups."
-                ) from exc
+            if "HTTP 404" in str(exc) or "HTTP 405" in str(exc):
+                self._background_job_status_batch_supported = False
+                return self._get_background_jobs_legacy(jobs, timeout)
             raise
+        self._background_job_status_batch_supported = True
         body = BatchBackgroundJobStatusResponse.model_validate(response)
         if body.errors:
             details = "; ".join(
@@ -1476,6 +1503,20 @@ class SandboxClient:
                 )
             )
         return results
+
+    def _get_background_jobs_legacy(
+        self,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int],
+    ) -> List[BackgroundJobStatus]:
+        """Use VM-only per-job reads when the platform batch API is unavailable."""
+        for sandbox_id in dict.fromkeys(job.sandbox_id for job in jobs):
+            self._auth_cache.get_or_refresh(sandbox_id)
+            if not self._auth_cache.is_vm(sandbox_id):
+                raise BatchStatusUnsupportedError(
+                    "Batched background job status is only supported for VM sandboxes."
+                )
+        return [self.get_background_job(job.sandbox_id, job, timeout=timeout) for job in jobs]
 
     def _get_completed_background_job_output(
         self,
@@ -1660,6 +1701,12 @@ class SandboxClient:
         while attempt < max_attempts:
             try:
                 response = self.get_sandbox_statuses(sandbox_ids)
+            except BatchStatusUnsupportedError:
+                snapshots = self._fetch_sandbox_statuses(sandbox_ids)
+                response = BatchSandboxStatusResponse(
+                    statuses=[snapshots[sandbox_id] for sandbox_id in sandbox_ids],
+                    errors=[],
+                )
             except Exception as exc:
                 if "429" in str(exc) or "Too Many Requests" in str(exc):
                     time.sleep(min(2**attempt, 60))
@@ -2053,6 +2100,8 @@ class AsyncSandboxClient:
         self._background_job_status_batcher = _AsyncRequestBatcher(
             self._fetch_background_job_statuses
         )
+        self._sandbox_status_batch_supported: Optional[bool] = None
+        self._background_job_status_batch_supported: Optional[bool] = None
 
     def _get_gateway_client(self) -> httpx.AsyncClient:
         """Get or create the shared gateway client for connection pooling
@@ -2253,6 +2302,10 @@ class AsyncSandboxClient:
     async def get_sandbox_statuses(self, sandbox_ids: List[str]) -> BatchSandboxStatusResponse:
         """Get lightweight lifecycle state for up to 100 sandboxes."""
         _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
+        if self._sandbox_status_batch_supported is False:
+            raise BatchStatusUnsupportedError(
+                "The platform does not support batch sandbox status lookups."
+            )
         try:
             response = await self.client.request(
                 "POST",
@@ -2261,18 +2314,24 @@ class AsyncSandboxClient:
                 idempotent_post=True,
             )
         except APIError as exc:
-            if "HTTP 404" in str(exc):
+            if "HTTP 404" in str(exc) or "HTTP 405" in str(exc):
+                self._sandbox_status_batch_supported = False
                 raise BatchStatusUnsupportedError(
                     "The platform does not support batch sandbox status lookups."
                 ) from exc
             raise
+        self._sandbox_status_batch_supported = True
         return BatchSandboxStatusResponse.model_validate(response)
 
     async def _fetch_sandbox_statuses(
         self, sandbox_ids: List[str]
     ) -> Dict[str, SandboxStatusSnapshot]:
         """Fetch one coalesced lifecycle batch for concurrent waiters."""
-        response = await self.get_sandbox_statuses(sandbox_ids)
+        try:
+            response = await self.get_sandbox_statuses(sandbox_ids)
+        except BatchStatusUnsupportedError:
+            sandboxes = await asyncio.gather(*(self.get(sandbox_id) for sandbox_id in sandbox_ids))
+            return {sandbox.id: _sandbox_to_status_snapshot(sandbox) for sandbox in sandboxes}
         if response.errors:
             details = ", ".join(f"{error.sandbox_id}={error.code}" for error in response.errors)
             raise APIError(f"Batch sandbox status lookup failed: {details}")
@@ -2794,6 +2853,8 @@ class AsyncSandboxClient:
     ) -> List[BackgroundJobStatus]:
         """Get ordered status for up to 100 jobs across VM sandboxes."""
         _validate_background_job_batch(jobs)
+        if self._background_job_status_batch_supported is False:
+            return await self._get_background_jobs_legacy(jobs, timeout)
         try:
             response = await self.client.request(
                 "POST",
@@ -2805,11 +2866,11 @@ class AsyncSandboxClient:
                 idempotent_post=True,
             )
         except APIError as exc:
-            if "HTTP 404" in str(exc):
-                raise BatchStatusUnsupportedError(
-                    "The platform does not support batch background job status lookups."
-                ) from exc
+            if "HTTP 404" in str(exc) or "HTTP 405" in str(exc):
+                self._background_job_status_batch_supported = False
+                return await self._get_background_jobs_legacy(jobs, timeout)
             raise
+        self._background_job_status_batch_supported = True
         body = BatchBackgroundJobStatusResponse.model_validate(response)
         if body.errors:
             details = "; ".join(
@@ -2836,6 +2897,24 @@ class AsyncSandboxClient:
             )
 
         return list(await asyncio.gather(*(build_status(job) for job in jobs)))
+
+    async def _get_background_jobs_legacy(
+        self,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int],
+    ) -> List[BackgroundJobStatus]:
+        """Use VM-only per-job reads when the platform batch API is unavailable."""
+        for sandbox_id in dict.fromkeys(job.sandbox_id for job in jobs):
+            await self._auth_cache.get_or_refresh(sandbox_id)
+            if not await self._auth_cache.is_vm(sandbox_id):
+                raise BatchStatusUnsupportedError(
+                    "Batched background job status is only supported for VM sandboxes."
+                )
+        return list(
+            await asyncio.gather(
+                *(self.get_background_job(job.sandbox_id, job, timeout=timeout) for job in jobs)
+            )
+        )
 
     async def _get_completed_background_job_output(
         self,
@@ -3023,6 +3102,12 @@ class AsyncSandboxClient:
         while attempt < max_attempts:
             try:
                 response = await self.get_sandbox_statuses(sandbox_ids)
+            except BatchStatusUnsupportedError:
+                snapshots = await self._fetch_sandbox_statuses(sandbox_ids)
+                response = BatchSandboxStatusResponse(
+                    statuses=[snapshots[sandbox_id] for sandbox_id in sandbox_ids],
+                    errors=[],
+                )
             except Exception as exc:
                 if "429" in str(exc) or "Too Many Requests" in str(exc):
                     await asyncio.sleep(min(2**attempt, 60))

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -11,8 +11,21 @@ import sys
 import threading
 import time
 import uuid
+from concurrent.futures import Future
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Literal, NoReturn, Optional, TypeVar
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Generic,
+    Hashable,
+    List,
+    Literal,
+    NoReturn,
+    Optional,
+    TypeVar,
+)
 
 import aiofiles
 import certifi
@@ -34,6 +47,7 @@ from tenacity import (
 
 from .core import APIClient, APIError, AsyncAPIClient
 from .exceptions import (
+    BatchStatusUnsupportedError,
     CommandTimeoutError,
     DownloadTimeoutError,
     SandboxFileNotFoundError,
@@ -46,7 +60,10 @@ from .exceptions import (
 )
 from .models import (
     BackgroundJob,
+    BackgroundJobRuntimeStatus,
     BackgroundJobStatus,
+    BatchBackgroundJobRuntimeStatusResponse,
+    BatchSandboxStatusResponse,
     BulkDeleteSandboxRequest,
     BulkDeleteSandboxResponse,
     CommandResponse,
@@ -62,6 +79,7 @@ from .models import (
     Sandbox,
     SandboxListResponse,
     SandboxLogsResponse,
+    SandboxStatusSnapshot,
     SSHSession,
     validate_egress_lists,
 )
@@ -96,6 +114,8 @@ _PROCESS_SIGNAL_TIMEOUT_MS = 10_000
 
 _RequestMessage = TypeVar("_RequestMessage", bound=Message)
 _ResponseMessage = TypeVar("_ResponseMessage", bound=Message)
+_BatchKey = TypeVar("_BatchKey", bound=Hashable)
+_BatchValue = TypeVar("_BatchValue")
 
 
 @functools.lru_cache(maxsize=1)
@@ -165,6 +185,12 @@ AUTH_REFRESH_MARGIN_SECONDS = 60
 # Max bytes of stdout/stderr returned per background-job status check
 JOB_OUTPUT_TAIL_BYTES = 10 * 1024 * 1024
 
+# Both the platform and VM runtime batch-status contracts cap one request at 100
+# identifiers. Concurrent single-item waits are collected briefly so callers
+# share a request without adding a persistent worker to the client lifecycle.
+MAX_STATUS_BATCH_SIZE = 100
+STATUS_BATCH_WINDOW_SECONDS = 0.025
+
 # Creation status-poll pacing. Sandbox creation is polled with exponential
 # backoff plus jitter rather than at a fixed interval
 CREATION_POLL_INITIAL_DELAY = 1.0
@@ -175,6 +201,112 @@ CREATION_POLL_JITTER = 0.25
 # Legacy fixed schedule (1s for the first 5 polls, then 2s) that `max_attempts`
 # used to describe. Retained only to derive the same wall-clock budget.
 _LEGACY_FAST_POLLS = 5
+
+
+class _SyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
+    """Coalesce concurrent sync lookups into bounded calls."""
+
+    def __init__(
+        self,
+        fetch: Callable[[List[_BatchKey]], Dict[_BatchKey, _BatchValue]],
+    ) -> None:
+        self._fetch = fetch
+        self._lock = threading.Lock()
+        self._pending: Dict[_BatchKey, List[Future[_BatchValue]]] = {}
+        self._dispatching = False
+
+    def get(self, key: _BatchKey) -> _BatchValue:
+        """Return one result, sharing a batch with concurrent callers."""
+        future: Future[_BatchValue] = Future()
+        with self._lock:
+            self._pending.setdefault(key, []).append(future)
+            leader = not self._dispatching
+            if leader:
+                self._dispatching = True
+
+        if leader:
+            time.sleep(STATUS_BATCH_WINDOW_SECONDS)
+            self._dispatch()
+
+        return future.result()
+
+    def _dispatch(self) -> None:
+        """Drain all currently pending lookups in bounded chunks."""
+        while True:
+            with self._lock:
+                keys = list(self._pending)[:MAX_STATUS_BATCH_SIZE]
+                if not keys:
+                    self._dispatching = False
+                    return
+                waiters = {key: self._pending.pop(key) for key in keys}
+
+            try:
+                results = self._fetch(keys)
+            except Exception as exc:
+                for key_waiters in waiters.values():
+                    for waiter in key_waiters:
+                        waiter.set_exception(exc)
+                continue
+
+            for key, key_waiters in waiters.items():
+                if key not in results:
+                    exc = APIError(f"Batch status response omitted {key!r}")
+                    for waiter in key_waiters:
+                        waiter.set_exception(exc)
+                    continue
+                for waiter in key_waiters:
+                    waiter.set_result(results[key])
+
+
+class _AsyncRequestBatcher(Generic[_BatchKey, _BatchValue]):
+    """Coalesce concurrent async lookups into bounded calls."""
+
+    def __init__(
+        self,
+        fetch: Callable[[List[_BatchKey]], Awaitable[Dict[_BatchKey, _BatchValue]]],
+    ) -> None:
+        self._fetch = fetch
+        self._pending: Dict[_BatchKey, List[asyncio.Future[_BatchValue]]] = {}
+        self._dispatch_task: Optional[asyncio.Task[None]] = None
+
+    async def get(self, key: _BatchKey) -> _BatchValue:
+        """Return one result, sharing a batch with concurrent callers."""
+        future = asyncio.get_running_loop().create_future()
+        self._pending.setdefault(key, []).append(future)
+        if self._dispatch_task is None:
+            self._dispatch_task = asyncio.create_task(self._dispatch())
+        return await future
+
+    async def _dispatch(self) -> None:
+        """Drain all currently pending lookups in bounded chunks."""
+        await asyncio.sleep(STATUS_BATCH_WINDOW_SECONDS)
+        try:
+            while self._pending:
+                keys = list(self._pending)[:MAX_STATUS_BATCH_SIZE]
+                waiters = {key: self._pending.pop(key) for key in keys}
+                try:
+                    results = await self._fetch(keys)
+                except Exception as exc:
+                    for key_waiters in waiters.values():
+                        for waiter in key_waiters:
+                            if not waiter.done():
+                                waiter.set_exception(exc)
+                    continue
+
+                for key, key_waiters in waiters.items():
+                    if key not in results:
+                        exc = APIError(f"Batch status response omitted {key!r}")
+                        for waiter in key_waiters:
+                            if not waiter.done():
+                                waiter.set_exception(exc)
+                        continue
+                    for waiter in key_waiters:
+                        if not waiter.done():
+                            waiter.set_result(results[key])
+        finally:
+            self._dispatch_task = None
+            if self._pending:
+                self._dispatch_task = asyncio.create_task(self._dispatch())
 
 
 def _creation_poll_delay(poll_index: int) -> float:
@@ -272,6 +404,44 @@ def _validate_env_key(key: str) -> str:
     if not _ENV_VAR_PATTERN.fullmatch(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     return key
+
+
+def _validate_unique_batch_values(values: List[str], field_name: str) -> None:
+    """Validate the shared bounded, non-empty, unique batch contract."""
+    if not values or len(values) > MAX_STATUS_BATCH_SIZE:
+        raise ValueError(f"{field_name} must contain between 1 and {MAX_STATUS_BATCH_SIZE} entries")
+    if len(values) != len(set(values)):
+        raise ValueError(f"{field_name} must be unique")
+
+
+def _canonical_background_job(sandbox_id: str, job_id: str) -> BackgroundJob:
+    """Build the canonical SDK background-job handle for a VM runtime lookup."""
+    return BackgroundJob(
+        job_id=job_id,
+        sandbox_id=sandbox_id,
+        stdout_log_file=f"/tmp/job_{job_id}.stdout.log",
+        stderr_log_file=f"/tmp/job_{job_id}.stderr.log",
+        exit_file=f"/tmp/job_{job_id}.exit",
+    )
+
+
+def _validate_background_job_batch(jobs: List[BackgroundJob]) -> None:
+    """Validate VM runtime batching is limited to canonical SDK job handles."""
+    if not jobs or len(jobs) > MAX_STATUS_BATCH_SIZE:
+        raise ValueError(f"jobs must contain between 1 and {MAX_STATUS_BATCH_SIZE} entries")
+
+    keys = []
+    for job in jobs:
+        if not re.fullmatch(r"[0-9A-Fa-f]{8}", job.job_id):
+            raise ValueError(f"Invalid background job ID: {job.job_id}")
+        if job != _canonical_background_job(job.sandbox_id, job.job_id):
+            raise ValueError(
+                "Batch status requires an unmodified BackgroundJob returned by "
+                "start_background_job()."
+            )
+        keys.append((job.sandbox_id, job.job_id))
+    if len(keys) != len(set(keys)):
+        raise ValueError("jobs must be unique")
 
 
 def _build_terminated_message(command: str, ctx: dict) -> str:
@@ -641,6 +811,10 @@ class SandboxClient:
             self.client.config.config_dir / "sandbox_auth_cache.json",
             self.client,
         )
+        self._sandbox_status_batcher = _SyncRequestBatcher(self._fetch_sandbox_statuses)
+        self._background_job_status_batcher = _SyncRequestBatcher(
+            self._fetch_background_job_statuses
+        )
 
     @staticmethod
     @_gateway_post_retry
@@ -655,6 +829,21 @@ class SandboxClient:
         """Make a POST request to the gateway with retry on connection errors only."""
         with httpx.Client(timeout=timeout) as client:
             return client.post(url, json=json, files=files, params=params, headers=headers)
+
+    @staticmethod
+    @_read_file_retry
+    def _gateway_idempotent_post(
+        url: str,
+        headers: Dict[str, str],
+        timeout: float,
+        json: Dict[str, Any],
+    ) -> httpx.Response:
+        """Make an idempotent gateway POST with transient retries."""
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(url, json=json, headers=headers)
+        if response.status_code == 408 or response.status_code in RETRYABLE_5XX_STATUSES:
+            response.raise_for_status()
+        return response
 
     @staticmethod
     @_gateway_retry
@@ -821,6 +1010,32 @@ class SandboxClient:
         """Get a specific sandbox"""
         response = self.client.request("GET", f"/sandbox/{sandbox_id}")
         return Sandbox.model_validate(response)
+
+    def get_sandbox_statuses(self, sandbox_ids: List[str]) -> BatchSandboxStatusResponse:
+        """Get lightweight lifecycle state for up to 100 sandboxes."""
+        _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
+        try:
+            response = self.client.request(
+                "POST",
+                "/sandbox/status:batchGet",
+                json={"sandbox_ids": sandbox_ids},
+                idempotent_post=True,
+            )
+        except APIError as exc:
+            if "HTTP 404" in str(exc):
+                raise BatchStatusUnsupportedError(
+                    "The platform does not support batch sandbox status lookups."
+                ) from exc
+            raise
+        return BatchSandboxStatusResponse.model_validate(response)
+
+    def _fetch_sandbox_statuses(self, sandbox_ids: List[str]) -> Dict[str, SandboxStatusSnapshot]:
+        """Fetch one coalesced lifecycle batch for concurrent waiters."""
+        response = self.get_sandbox_statuses(sandbox_ids)
+        if response.errors:
+            details = ", ".join(f"{error.sandbox_id}={error.code}" for error in response.errors)
+            raise APIError(f"Batch sandbox status lookup failed: {details}")
+        return {snapshot.sandbox_id: snapshot for snapshot in response.statuses}
 
     def delete(self, sandbox_id: str) -> Dict[str, Any]:
         """Delete a sandbox"""
@@ -1220,6 +1435,140 @@ class SandboxClient:
             stderr_truncated=stderr_truncated,
         )
 
+    def get_background_jobs(
+        self,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int] = None,
+    ) -> List[BackgroundJobStatus]:
+        """Get ordered status for up to 100 background jobs in VM sandboxes.
+
+        The runtime batch call reads only canonical exit-code files. Output is
+        fetched with the existing bounded-tail behavior once a job completes.
+        Container sandboxes intentionally continue to use get_background_job().
+        """
+        _validate_background_job_batch(jobs)
+        jobs_by_sandbox: Dict[str, List[BackgroundJob]] = {}
+        for job in jobs:
+            jobs_by_sandbox.setdefault(job.sandbox_id, []).append(job)
+
+        runtime_statuses: Dict[tuple[str, str], BackgroundJobRuntimeStatus] = {}
+        for sandbox_id, sandbox_jobs in jobs_by_sandbox.items():
+            self._auth_cache.get_or_refresh(sandbox_id)
+            if not self._auth_cache.is_vm(sandbox_id):
+                raise BatchStatusUnsupportedError(
+                    "Batched background job status is only supported for VM sandboxes."
+                )
+            for status in self._get_background_job_runtime_statuses(
+                sandbox_id, sandbox_jobs, timeout
+            ):
+                runtime_statuses[(sandbox_id, status.job_id)] = status
+
+        results = []
+        for job in jobs:
+            runtime_status = runtime_statuses.get((job.sandbox_id, job.job_id))
+            if runtime_status is None:
+                raise APIError(f"VM batch status response omitted job {job.job_id}")
+            if not runtime_status.completed:
+                results.append(BackgroundJobStatus(job_id=job.job_id, completed=False))
+                continue
+            if runtime_status.exit_code is None:
+                raise APIError(f"Completed VM background job {job.job_id} omitted exit_code")
+            results.append(
+                self._get_completed_background_job_output(
+                    job.sandbox_id,
+                    job,
+                    runtime_status.exit_code,
+                    timeout,
+                )
+            )
+        return results
+
+    def _get_background_job_runtime_statuses(
+        self,
+        sandbox_id: str,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int],
+    ) -> List[BackgroundJobRuntimeStatus]:
+        """Call the VM sandboxd batch completion endpoint."""
+        effective_timeout = timeout if timeout is not None else 30
+        reauthed = False
+        for _ in range(MAX_GATEWAY_ATTEMPTS):
+            auth = self._auth_cache.get_or_refresh(sandbox_id)
+            gateway_url = auth["gateway_url"].rstrip("/")
+            url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/background-jobs/status"
+            headers = {"Authorization": f"Bearer {auth['token']}"}
+            try:
+                response = self._gateway_idempotent_post(
+                    url,
+                    headers=headers,
+                    timeout=effective_timeout,
+                    json={"job_ids": [job.job_id for job in jobs]},
+                )
+                response.raise_for_status()
+                body = BatchBackgroundJobRuntimeStatusResponse.model_validate(response.json())
+                return body.jobs
+            except httpx.TimeoutException as exc:
+                raise APIError(
+                    f"VM background job status timed out after {effective_timeout}s"
+                ) from exc
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code == 401 and self._should_retry_401(sandbox_id, reauthed):
+                    reauthed = True
+                    continue
+                if status_code == 404:
+                    raise BatchStatusUnsupportedError(
+                        "This VM sandbox does not support batched background job status."
+                    ) from exc
+                raise APIError(
+                    f"VM background job status failed: HTTP {status_code}: {exc.response.text}"
+                ) from exc
+            except httpx.RequestError as exc:
+                raise APIError(f"VM background job status request failed: {exc}") from exc
+        raise APIError("VM background job status failed after retries")
+
+    def _get_completed_background_job_output(
+        self,
+        sandbox_id: str,
+        job: BackgroundJob,
+        exit_code: int,
+        timeout: Optional[int],
+    ) -> BackgroundJobStatus:
+        """Read bounded stdout and stderr tails for one completed job."""
+
+        def read_output_tail(path: str) -> tuple[str, bool]:
+            try:
+                response = self.read_file(
+                    sandbox_id,
+                    path,
+                    timeout=timeout,
+                    offset=-JOB_OUTPUT_TAIL_BYTES,
+                    length=JOB_OUTPUT_TAIL_BYTES,
+                )
+                return response.content, bool(response.truncated)
+            except SandboxFileNotFoundError:
+                return "", False
+
+        stdout, stdout_truncated = read_output_tail(job.stdout_log_file)
+        stderr, stderr_truncated = read_output_tail(job.stderr_log_file)
+        return BackgroundJobStatus(
+            job_id=job.job_id,
+            completed=True,
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+        )
+
+    def _fetch_background_job_statuses(
+        self, keys: List[tuple[str, str]]
+    ) -> Dict[tuple[str, str], BackgroundJobStatus]:
+        """Fetch one coalesced VM job batch for concurrent run waiters."""
+        jobs = [_canonical_background_job(sandbox_id, job_id) for sandbox_id, job_id in keys]
+        statuses = self.get_background_jobs(jobs)
+        return {(job.sandbox_id, job.job_id): status for job, status in zip(jobs, statuses)}
+
     def run_background_job(
         self,
         sandbox_id: str,
@@ -1250,9 +1599,13 @@ class SandboxClient:
             CommandTimeoutError: If command doesn't complete within timeout
         """
         job = self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
+        use_batch_status = self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            status = self.get_background_job(sandbox_id, job)
+            if use_batch_status:
+                status = self._background_job_status_batcher.get((sandbox_id, job.job_id))
+            else:
+                status = self.get_background_job(sandbox_id, job)
             if status.completed:
                 return status
             time.sleep(poll_interval)
@@ -1288,7 +1641,7 @@ class SandboxClient:
         poll_index = 0
         reachability_phase = False
         while time.monotonic() < deadline:
-            sandbox = self.get(sandbox_id)
+            sandbox = self._sandbox_status_batcher.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if not reachability_phase:
                     reachability_phase = True
@@ -1310,7 +1663,7 @@ class SandboxClient:
                     "error_type": sandbox.error_type,
                     "error_message": sandbox.error_message,
                 }
-                _raise_not_running_error(sandbox.id, ctx)
+                _raise_not_running_error(sandbox.sandbox_id, ctx)
             elif _is_waiting_for_image_build(sandbox):
                 # The platform is building the VM image for this sandbox; it
                 # starts on its own once the build completes. This phase runs on
@@ -1343,46 +1696,43 @@ class SandboxClient:
         max_attempts: int = 60,
         image_build_timeout_seconds: int = 3000,
     ) -> Dict[str, str]:
-        """Wait for multiple sandboxes to be running using list endpoint to avoid rate limits.
+        """Wait for up to 100 sandboxes using the batch lifecycle endpoint.
 
         Sandboxes PENDING on an automatic VM image build (first use of an
         image) are waited on a separate slower budget bounded by
         image_build_timeout_seconds instead of consuming max_attempts.
         """
-        sandbox_id_set = set(sandbox_ids)
-        final_statuses = {}
+        _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
+        final_statuses: Dict[str, str] = {}
         image_build_deadline: Optional[float] = None
 
         attempt = 0
         while attempt < max_attempts:
+            try:
+                response = self.get_sandbox_statuses(sandbox_ids)
+            except Exception as exc:
+                if "429" in str(exc) or "Too Many Requests" in str(exc):
+                    time.sleep(min(2**attempt, 60))
+                    continue
+                raise
+
+            if response.errors:
+                failures = [(error.sandbox_id, error.code) for error in response.errors]
+                raise RuntimeError(f"Sandboxes unavailable: {failures}")
+
             total_running = 0
             all_failed = []
             total_image_build_waiting = 0
-            page = 1
-
-            while True:
-                try:
-                    list_response = self.list(per_page=100, page=page)
-                except Exception as e:
-                    if "429" in str(e) or "Too Many Requests" in str(e):
-                        wait_time = min(2**attempt, 60)
-                        time.sleep(wait_time)
-                        continue
-                    raise
-
-                running_count, failed_sandboxes, page_statuses, image_build_waiting = (
-                    _check_sandbox_statuses(list_response.sandboxes, sandbox_id_set)
-                )
-
-                total_running += running_count
-                all_failed.extend(failed_sandboxes)
-                final_statuses.update(page_statuses)
-                total_image_build_waiting += image_build_waiting
-
-                if len(final_statuses) == len(sandbox_ids) or not list_response.has_next:
-                    break
-
-                page += 1
+            for snapshot in response.statuses:
+                status_value = snapshot.status.value
+                if status_value == "RUNNING":
+                    total_running += 1
+                    final_statuses[snapshot.sandbox_id] = status_value
+                elif status_value in ["ERROR", "TERMINATED", "TIMEOUT"]:
+                    all_failed.append((snapshot.sandbox_id, status_value))
+                    final_statuses[snapshot.sandbox_id] = status_value
+                elif _is_waiting_for_image_build(snapshot):
+                    total_image_build_waiting += 1
 
             if all_failed:
                 raise RuntimeError(f"Sandboxes failed: {all_failed}")
@@ -1413,7 +1763,7 @@ class SandboxClient:
             sleep_time = 1 if attempt <= 5 else 2
             time.sleep(sleep_time)
 
-        for sandbox_id in sandbox_id_set:
+        for sandbox_id in sandbox_ids:
             if sandbox_id not in final_statuses:
                 final_statuses[sandbox_id] = "TIMEOUT"
 
@@ -1749,6 +2099,10 @@ class AsyncSandboxClient:
         # Shared httpx client for gateway operations (upload/download/execute)
         # Initialized lazily to allow connection pooling and reuse
         self._gateway_client: Optional[httpx.AsyncClient] = None
+        self._sandbox_status_batcher = _AsyncRequestBatcher(self._fetch_sandbox_statuses)
+        self._background_job_status_batcher = _AsyncRequestBatcher(
+            self._fetch_background_job_statuses
+        )
 
     def _get_gateway_client(self) -> httpx.AsyncClient:
         """Get or create the shared gateway client for connection pooling
@@ -1781,6 +2135,21 @@ class AsyncSandboxClient:
         return await gateway_client.post(
             url, json=json, files=files, params=params, headers=headers, timeout=timeout
         )
+
+    @_read_file_retry
+    async def _gateway_idempotent_post(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        timeout: float,
+        json: Dict[str, Any],
+    ) -> httpx.Response:
+        """Make an idempotent gateway POST with transient retries."""
+        gateway_client = self._get_gateway_client()
+        response = await gateway_client.post(url, json=json, headers=headers, timeout=timeout)
+        if response.status_code == 408 or response.status_code in RETRYABLE_5XX_STATUSES:
+            response.raise_for_status()
+        return response
 
     @_gateway_retry
     async def _gateway_get(
@@ -1945,6 +2314,34 @@ class AsyncSandboxClient:
         """Get a specific sandbox"""
         response = await self.client.request("GET", f"/sandbox/{sandbox_id}")
         return Sandbox.model_validate(response)
+
+    async def get_sandbox_statuses(self, sandbox_ids: List[str]) -> BatchSandboxStatusResponse:
+        """Get lightweight lifecycle state for up to 100 sandboxes."""
+        _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
+        try:
+            response = await self.client.request(
+                "POST",
+                "/sandbox/status:batchGet",
+                json={"sandbox_ids": sandbox_ids},
+                idempotent_post=True,
+            )
+        except APIError as exc:
+            if "HTTP 404" in str(exc):
+                raise BatchStatusUnsupportedError(
+                    "The platform does not support batch sandbox status lookups."
+                ) from exc
+            raise
+        return BatchSandboxStatusResponse.model_validate(response)
+
+    async def _fetch_sandbox_statuses(
+        self, sandbox_ids: List[str]
+    ) -> Dict[str, SandboxStatusSnapshot]:
+        """Fetch one coalesced lifecycle batch for concurrent waiters."""
+        response = await self.get_sandbox_statuses(sandbox_ids)
+        if response.errors:
+            details = ", ".join(f"{error.sandbox_id}={error.code}" for error in response.errors)
+            raise APIError(f"Batch sandbox status lookup failed: {details}")
+        return {snapshot.sandbox_id: snapshot for snapshot in response.statuses}
 
     async def delete(self, sandbox_id: str) -> Dict[str, Any]:
         """Delete a sandbox"""
@@ -2455,6 +2852,147 @@ class AsyncSandboxClient:
             stderr_truncated=stderr_truncated,
         )
 
+    async def get_background_jobs(
+        self,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int] = None,
+    ) -> List[BackgroundJobStatus]:
+        """Get ordered status for up to 100 background jobs in VM sandboxes."""
+        _validate_background_job_batch(jobs)
+        jobs_by_sandbox: Dict[str, List[BackgroundJob]] = {}
+        for job in jobs:
+            jobs_by_sandbox.setdefault(job.sandbox_id, []).append(job)
+
+        async def fetch_sandbox_jobs(
+            sandbox_id: str, sandbox_jobs: List[BackgroundJob]
+        ) -> tuple[str, List[BackgroundJobRuntimeStatus]]:
+            await self._auth_cache.get_or_refresh(sandbox_id)
+            if not await self._auth_cache.is_vm(sandbox_id):
+                raise BatchStatusUnsupportedError(
+                    "Batched background job status is only supported for VM sandboxes."
+                )
+            statuses = await self._get_background_job_runtime_statuses(
+                sandbox_id, sandbox_jobs, timeout
+            )
+            return sandbox_id, statuses
+
+        grouped_statuses = await asyncio.gather(
+            *(
+                fetch_sandbox_jobs(sandbox_id, sandbox_jobs)
+                for sandbox_id, sandbox_jobs in jobs_by_sandbox.items()
+            )
+        )
+        runtime_statuses = {
+            (sandbox_id, status.job_id): status
+            for sandbox_id, statuses in grouped_statuses
+            for status in statuses
+        }
+
+        async def build_status(job: BackgroundJob) -> BackgroundJobStatus:
+            runtime_status = runtime_statuses.get((job.sandbox_id, job.job_id))
+            if runtime_status is None:
+                raise APIError(f"VM batch status response omitted job {job.job_id}")
+            if not runtime_status.completed:
+                return BackgroundJobStatus(job_id=job.job_id, completed=False)
+            if runtime_status.exit_code is None:
+                raise APIError(f"Completed VM background job {job.job_id} omitted exit_code")
+            return await self._get_completed_background_job_output(
+                job.sandbox_id,
+                job,
+                runtime_status.exit_code,
+                timeout,
+            )
+
+        return list(await asyncio.gather(*(build_status(job) for job in jobs)))
+
+    async def _get_background_job_runtime_statuses(
+        self,
+        sandbox_id: str,
+        jobs: List[BackgroundJob],
+        timeout: Optional[int],
+    ) -> List[BackgroundJobRuntimeStatus]:
+        """Call the VM sandboxd batch completion endpoint."""
+        effective_timeout = timeout if timeout is not None else 30
+        reauthed = False
+        for _ in range(MAX_GATEWAY_ATTEMPTS):
+            auth = await self._auth_cache.get_or_refresh(sandbox_id)
+            gateway_url = auth["gateway_url"].rstrip("/")
+            url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/background-jobs/status"
+            headers = {"Authorization": f"Bearer {auth['token']}"}
+            try:
+                response = await self._gateway_idempotent_post(
+                    url,
+                    headers=headers,
+                    timeout=effective_timeout,
+                    json={"job_ids": [job.job_id for job in jobs]},
+                )
+                response.raise_for_status()
+                body = BatchBackgroundJobRuntimeStatusResponse.model_validate(response.json())
+                return body.jobs
+            except httpx.TimeoutException as exc:
+                raise APIError(
+                    f"VM background job status timed out after {effective_timeout}s"
+                ) from exc
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                if status_code == 401 and await self._should_retry_401(sandbox_id, reauthed):
+                    reauthed = True
+                    continue
+                if status_code == 404:
+                    raise BatchStatusUnsupportedError(
+                        "This VM sandbox does not support batched background job status."
+                    ) from exc
+                raise APIError(
+                    f"VM background job status failed: HTTP {status_code}: {exc.response.text}"
+                ) from exc
+            except httpx.RequestError as exc:
+                raise APIError(f"VM background job status request failed: {exc}") from exc
+        raise APIError("VM background job status failed after retries")
+
+    async def _get_completed_background_job_output(
+        self,
+        sandbox_id: str,
+        job: BackgroundJob,
+        exit_code: int,
+        timeout: Optional[int],
+    ) -> BackgroundJobStatus:
+        """Read bounded stdout and stderr tails for one completed job."""
+
+        async def read_output_tail(path: str) -> tuple[str, bool]:
+            try:
+                response = await self.read_file(
+                    sandbox_id,
+                    path,
+                    timeout=timeout,
+                    offset=-JOB_OUTPUT_TAIL_BYTES,
+                    length=JOB_OUTPUT_TAIL_BYTES,
+                )
+                return response.content, bool(response.truncated)
+            except SandboxFileNotFoundError:
+                return "", False
+
+        stdout, stderr = await asyncio.gather(
+            read_output_tail(job.stdout_log_file),
+            read_output_tail(job.stderr_log_file),
+        )
+        return BackgroundJobStatus(
+            job_id=job.job_id,
+            completed=True,
+            exit_code=exit_code,
+            stdout=stdout[0],
+            stderr=stderr[0],
+            stdout_truncated=stdout[1],
+            stderr_truncated=stderr[1],
+        )
+
+    async def _fetch_background_job_statuses(
+        self, keys: List[tuple[str, str]]
+    ) -> Dict[tuple[str, str], BackgroundJobStatus]:
+        """Fetch one coalesced VM job batch for concurrent run waiters."""
+        jobs = [_canonical_background_job(sandbox_id, job_id) for sandbox_id, job_id in keys]
+        statuses = await self.get_background_jobs(jobs)
+        return {(job.sandbox_id, job.job_id): status for job, status in zip(jobs, statuses)}
+
     async def run_background_job(
         self,
         sandbox_id: str,
@@ -2485,9 +3023,13 @@ class AsyncSandboxClient:
             CommandTimeoutError: If command doesn't complete within timeout
         """
         job = await self.start_background_job(sandbox_id, command, working_dir=working_dir, env=env)
+        use_batch_status = await self._auth_cache.is_vm(sandbox_id)
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            status = await self.get_background_job(sandbox_id, job)
+            if use_batch_status:
+                status = await self._background_job_status_batcher.get((sandbox_id, job.job_id))
+            else:
+                status = await self.get_background_job(sandbox_id, job)
             if status.completed:
                 return status
             await asyncio.sleep(poll_interval)
@@ -2523,7 +3065,7 @@ class AsyncSandboxClient:
         poll_index = 0
         reachability_phase = False
         while time.monotonic() < deadline:
-            sandbox = await self.get(sandbox_id)
+            sandbox = await self._sandbox_status_batcher.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if not reachability_phase:
                     reachability_phase = True
@@ -2545,7 +3087,7 @@ class AsyncSandboxClient:
                     "error_type": sandbox.error_type,
                     "error_message": sandbox.error_message,
                 }
-                _raise_not_running_error(sandbox.id, ctx)
+                _raise_not_running_error(sandbox.sandbox_id, ctx)
             elif _is_waiting_for_image_build(sandbox):
                 # The platform is building the VM image for this sandbox; it
                 # starts on its own once the build completes. This phase runs on
@@ -2578,47 +3120,44 @@ class AsyncSandboxClient:
         max_attempts: int = 60,
         image_build_timeout_seconds: int = 3000,
     ) -> Dict[str, str]:
-        """Wait for multiple sandboxes to be running using list endpoint.
+        """Wait for up to 100 sandboxes using the batch lifecycle endpoint.
 
         Sandboxes PENDING on an automatic VM image build (first use of an
         image) are waited on a separate slower budget bounded by
         image_build_timeout_seconds instead of consuming max_attempts.
         """
 
-        sandbox_id_set = set(sandbox_ids)
-        final_statuses = {}
+        _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
+        final_statuses: Dict[str, str] = {}
         image_build_deadline: Optional[float] = None
 
         attempt = 0
         while attempt < max_attempts:
+            try:
+                response = await self.get_sandbox_statuses(sandbox_ids)
+            except Exception as exc:
+                if "429" in str(exc) or "Too Many Requests" in str(exc):
+                    await asyncio.sleep(min(2**attempt, 60))
+                    continue
+                raise
+
+            if response.errors:
+                failures = [(error.sandbox_id, error.code) for error in response.errors]
+                raise RuntimeError(f"Sandboxes unavailable: {failures}")
+
             total_running = 0
             all_failed = []
             total_image_build_waiting = 0
-            page = 1
-
-            while True:
-                try:
-                    list_response = await self.list(per_page=100, page=page)
-                except Exception as e:
-                    if "429" in str(e) or "Too Many Requests" in str(e):
-                        wait_time = min(2**attempt, 60)
-                        await asyncio.sleep(wait_time)
-                        continue
-                    raise
-
-                running_count, failed_sandboxes, page_statuses, image_build_waiting = (
-                    _check_sandbox_statuses(list_response.sandboxes, sandbox_id_set)
-                )
-
-                total_running += running_count
-                all_failed.extend(failed_sandboxes)
-                final_statuses.update(page_statuses)
-                total_image_build_waiting += image_build_waiting
-
-                if len(final_statuses) == len(sandbox_ids) or not list_response.has_next:
-                    break
-
-                page += 1
+            for snapshot in response.statuses:
+                status_value = snapshot.status.value
+                if status_value == "RUNNING":
+                    total_running += 1
+                    final_statuses[snapshot.sandbox_id] = status_value
+                elif status_value in ["ERROR", "TERMINATED", "TIMEOUT"]:
+                    all_failed.append((snapshot.sandbox_id, status_value))
+                    final_statuses[snapshot.sandbox_id] = status_value
+                elif _is_waiting_for_image_build(snapshot):
+                    total_image_build_waiting += 1
 
             if all_failed:
                 raise RuntimeError(f"Sandboxes failed: {all_failed}")
@@ -2649,7 +3188,7 @@ class AsyncSandboxClient:
             sleep_time = 1 if attempt <= 5 else 2
             await asyncio.sleep(sleep_time)
 
-        for sandbox_id in sandbox_id_set:
+        for sandbox_id in sandbox_ids:
             if sandbox_id not in final_statuses:
                 final_statuses[sandbox_id] = "TIMEOUT"
 

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -806,34 +806,6 @@ def _is_waiting_for_image_build(sandbox: Sandbox | SandboxStatusSnapshot) -> boo
     return sandbox.status == "PENDING" and bool(getattr(sandbox, "pending_image_build_id", None))
 
 
-def _check_sandbox_statuses(
-    sandboxes: List[Sandbox], target_ids: set
-) -> tuple[int, List[tuple], Dict[str, str], int]:
-    """Helper function to check sandbox statuses
-
-    Returns:
-        tuple of (running_count, failed_sandboxes, final_statuses,
-        image_build_waiting_count)
-    """
-    running_count = 0
-    failed_sandboxes = []
-    final_statuses = {}
-    image_build_waiting = 0
-
-    for sandbox in sandboxes:
-        if sandbox.id in target_ids:
-            if sandbox.status == "RUNNING":
-                running_count += 1
-                final_statuses[sandbox.id] = sandbox.status
-            elif sandbox.status in ["ERROR", "TERMINATED", "TIMEOUT"]:
-                failed_sandboxes.append((sandbox.id, sandbox.status))
-                final_statuses[sandbox.id] = sandbox.status
-            elif _is_waiting_for_image_build(sandbox):
-                image_build_waiting += 1
-
-    return running_count, failed_sandboxes, final_statuses, image_build_waiting
-
-
 class SandboxClient:
     """Client for sandbox API operations"""
 

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -24,8 +24,9 @@ def _job(sandbox_id: str, job_id: str) -> BackgroundJob:
 
 
 class _SyncPlatformClient:
-    def __init__(self) -> None:
+    def __init__(self, error_sandbox_id: Optional[str] = None) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.error_sandbox_id = error_sandbox_id
 
     def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         self.calls.append((method, path, kwargs))
@@ -40,14 +41,26 @@ class _SyncPlatformClient:
                     "pending_image_build_id": None,
                 }
                 for sandbox_id in sandbox_ids
+                if sandbox_id != self.error_sandbox_id
             ],
-            "errors": [],
+            "errors": (
+                [
+                    {
+                        "sandbox_id": self.error_sandbox_id,
+                        "code": "NOT_FOUND",
+                        "message": "Sandbox not found",
+                    }
+                ]
+                if self.error_sandbox_id in sandbox_ids
+                else []
+            ),
         }
 
 
 class _AsyncPlatformClient:
-    def __init__(self) -> None:
+    def __init__(self, error_sandbox_id: Optional[str] = None) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.error_sandbox_id = error_sandbox_id
 
     async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         self.calls.append((method, path, kwargs))
@@ -62,8 +75,19 @@ class _AsyncPlatformClient:
                     "pending_image_build_id": None,
                 }
                 for sandbox_id in sandbox_ids
+                if sandbox_id != self.error_sandbox_id
             ],
-            "errors": [],
+            "errors": (
+                [
+                    {
+                        "sandbox_id": self.error_sandbox_id,
+                        "code": "NOT_FOUND",
+                        "message": "Sandbox not found",
+                    }
+                ]
+                if self.error_sandbox_id in sandbox_ids
+                else []
+            ),
         }
 
     async def aclose(self) -> None:
@@ -71,9 +95,14 @@ class _AsyncPlatformClient:
 
 
 class _SyncBackgroundJobPlatformClient:
-    def __init__(self, reject_as_container: bool = False) -> None:
+    def __init__(
+        self,
+        reject_as_container: bool = False,
+        error_job_id: Optional[str] = None,
+    ) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
         self.reject_as_container = reject_as_container
+        self.error_job_id = error_job_id
 
     def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         self.calls.append((method, path, kwargs))
@@ -99,22 +128,50 @@ class _SyncBackgroundJobPlatformClient:
                     "exit_code": 7 if job["job_id"] == "feedface" else None,
                 }
                 for job in jobs
+                if job["job_id"] != self.error_job_id
             ],
-            "errors": [],
+            "errors": (
+                [
+                    {
+                        **next(job for job in jobs if job["job_id"] == self.error_job_id),
+                        "code": "RUNTIME_ERROR",
+                        "message": "Runtime lookup failed",
+                    }
+                ]
+                if any(job["job_id"] == self.error_job_id for job in jobs)
+                else []
+            ),
         }
 
 
 class _AsyncBackgroundJobPlatformClient:
-    def __init__(self) -> None:
+    def __init__(self, error_job_id: Optional[str] = None) -> None:
         self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.error_job_id = error_job_id
 
     async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
         self.calls.append((method, path, kwargs))
         return {
             "statuses": [
-                {**job, "completed": False, "exit_code": None} for job in kwargs["json"]["jobs"]
+                {**job, "completed": False, "exit_code": None}
+                for job in kwargs["json"]["jobs"]
+                if job["job_id"] != self.error_job_id
             ],
-            "errors": [],
+            "errors": (
+                [
+                    {
+                        **next(
+                            job
+                            for job in kwargs["json"]["jobs"]
+                            if job["job_id"] == self.error_job_id
+                        ),
+                        "code": "RUNTIME_ERROR",
+                        "message": "Runtime lookup failed",
+                    }
+                ]
+                if any(job["job_id"] == self.error_job_id for job in kwargs["json"]["jobs"])
+                else []
+            ),
         }
 
     async def aclose(self) -> None:
@@ -173,6 +230,24 @@ def test_concurrent_sync_creation_waits_share_one_platform_batch() -> None:
     assert kwargs["idempotent_post"] is True
 
 
+def test_sync_creation_batch_errors_only_fail_the_matching_waiter() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncPlatformClient(error_sandbox_id="sandbox-b")
+    cast(Any, client).client = platform
+    cast(Any, client)._is_sandbox_reachable = lambda _sandbox_id: True
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        running = executor.submit(client.wait_for_creation, "sandbox-a")
+        missing = executor.submit(client.wait_for_creation, "sandbox-b")
+
+        assert running.result() is None
+        with pytest.raises(APIError, match="sandbox-b: NOT_FOUND"):
+            missing.result()
+
+    assert len(platform.calls) == 1
+
+
 @pytest.mark.asyncio
 async def test_concurrent_async_creation_waits_share_one_platform_batch() -> None:
     client = AsyncSandboxClient(api_key="test-key")
@@ -194,6 +269,32 @@ async def test_concurrent_async_creation_waits_share_one_platform_batch() -> Non
 
     assert len(platform.calls) == 1
     assert set(platform.calls[0][2]["json"]["sandbox_ids"]) == {"sandbox-a", "sandbox-b"}
+
+
+@pytest.mark.asyncio
+async def test_async_creation_batch_errors_only_fail_the_matching_waiter() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncPlatformClient(error_sandbox_id="sandbox-b")
+    cast(Any, client).client = platform
+
+    async def reachable(_sandbox_id: str) -> bool:
+        return True
+
+    cast(Any, client)._is_sandbox_reachable = reachable
+    try:
+        results = await asyncio.gather(
+            client.wait_for_creation("sandbox-a"),
+            client.wait_for_creation("sandbox-b"),
+            return_exceptions=True,
+        )
+    finally:
+        await client.aclose()
+
+    assert results[0] is None
+    assert isinstance(results[1], APIError)
+    assert "sandbox-b: NOT_FOUND" in str(results[1])
+    assert len(platform.calls) == 1
 
 
 def test_sync_creation_batch_capability_falls_back_once_per_client() -> None:
@@ -337,6 +438,29 @@ def test_concurrent_sync_background_waiters_share_one_platform_batch() -> None:
     }
 
 
+def test_sync_background_batch_errors_only_fail_the_matching_waiter() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncBackgroundJobPlatformClient(error_job_id="cafebabe")
+    cast(Any, client).client = platform
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        running = executor.submit(
+            cast(Any, client)._background_job_status_batcher.get,
+            ("sandbox-a", "deadbeef"),
+        )
+        failed = executor.submit(
+            cast(Any, client)._background_job_status_batcher.get,
+            ("sandbox-b", "cafebabe"),
+        )
+
+        assert not running.result().completed
+        with pytest.raises(APIError, match="sandbox-b/cafebabe"):
+            failed.result()
+
+    assert len(platform.calls) == 1
+
+
 @pytest.mark.asyncio
 async def test_async_get_background_jobs_uses_one_platform_batch() -> None:
     client = AsyncSandboxClient(api_key="test-key")
@@ -382,3 +506,25 @@ async def test_concurrent_async_background_waiters_share_one_platform_batch() ->
         ("sandbox-a", "deadbeef"),
         ("sandbox-b", "cafebabe"),
     }
+
+
+@pytest.mark.asyncio
+async def test_async_background_batch_errors_only_fail_the_matching_waiter() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncBackgroundJobPlatformClient(error_job_id="cafebabe")
+    cast(Any, client).client = platform
+    try:
+        results = await asyncio.gather(
+            cast(Any, client)._background_job_status_batcher.get(("sandbox-a", "deadbeef")),
+            cast(Any, client)._background_job_status_batcher.get(("sandbox-b", "cafebabe")),
+            return_exceptions=True,
+        )
+    finally:
+        await client.aclose()
+
+    assert isinstance(results[0], BackgroundJobStatus)
+    assert not results[0].completed
+    assert isinstance(results[1], APIError)
+    assert "sandbox-b/cafebabe" in str(results[1])
+    assert len(platform.calls) == 1

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -1,27 +1,15 @@
-"""Focused tests for platform and VM runtime batch status calls."""
+"""Focused tests for platform lifecycle and VM background-job batch calls."""
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, cast
 
-import httpx
 import pytest
 
 from prime_sandboxes import BatchStatusUnsupportedError
 from prime_sandboxes.core.client import APIClient
 from prime_sandboxes.models import BackgroundJob, ReadFileResponse
 from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
-
-
-def _auth_payload() -> dict[str, Any]:
-    return {
-        "gateway_url": "https://gateway.example.com",
-        "user_ns": "ns",
-        "job_id": "runtime",
-        "token": "token",
-        "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat(),
-    }
 
 
 def _job(sandbox_id: str, job_id: str) -> BackgroundJob:
@@ -81,31 +69,54 @@ class _AsyncPlatformClient:
         return None
 
 
-class _SyncAuthCache:
-    def __init__(self, is_vm: bool = True) -> None:
-        self._is_vm = is_vm
+class _SyncBackgroundJobPlatformClient:
+    def __init__(self, reject_as_container: bool = False) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.reject_as_container = reject_as_container
 
-    def get_or_refresh(self, _sandbox_id: str) -> dict[str, Any]:
-        return _auth_payload()
+    def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((method, path, kwargs))
+        jobs = kwargs["json"]["jobs"]
+        if self.reject_as_container:
+            return {
+                "statuses": [],
+                "errors": [
+                    {
+                        **jobs[0],
+                        "code": "NOT_VM",
+                        "message": (
+                            "Batched background job status is only supported for VM sandboxes"
+                        ),
+                    }
+                ],
+            }
+        return {
+            "statuses": [
+                {
+                    **job,
+                    "completed": job["job_id"] == "feedface",
+                    "exit_code": 7 if job["job_id"] == "feedface" else None,
+                }
+                for job in jobs
+            ],
+            "errors": [],
+        }
 
-    def is_vm(self, _sandbox_id: str) -> bool:
-        return self._is_vm
 
-    def invalidate(self, _sandbox_id: str) -> None:
-        return None
+class _AsyncBackgroundJobPlatformClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
 
+    async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((method, path, kwargs))
+        return {
+            "statuses": [
+                {**job, "completed": False, "exit_code": None} for job in kwargs["json"]["jobs"]
+            ],
+            "errors": [],
+        }
 
-class _AsyncAuthCache:
-    def __init__(self, is_vm: bool = True) -> None:
-        self._is_vm = is_vm
-
-    async def get_or_refresh(self, _sandbox_id: str) -> dict[str, Any]:
-        return _auth_payload()
-
-    async def is_vm(self, _sandbox_id: str) -> bool:
-        return self._is_vm
-
-    async def invalidate(self, _sandbox_id: str) -> None:
+    async def aclose(self) -> None:
         return None
 
 
@@ -155,28 +166,11 @@ async def test_concurrent_async_creation_waits_share_one_platform_batch() -> Non
     assert set(platform.calls[0][2]["json"]["sandbox_ids"]) == {"sandbox-a", "sandbox-b"}
 
 
-def test_sync_get_background_jobs_uses_one_vm_runtime_batch_and_reads_completed_output() -> None:
+def test_sync_get_background_jobs_uses_one_platform_batch_across_vm_sandboxes() -> None:
     client = SandboxClient(APIClient(api_key="test-key"))
-    cast(Any, client)._auth_cache = _SyncAuthCache()
-    calls: list[dict[str, Any]] = []
-
-    def post(
-        url: str,
-        headers: dict[str, str],
-        timeout: float,
-        json: dict[str, Any],
-    ) -> httpx.Response:
-        calls.append({"url": url, "headers": headers, "timeout": timeout, "json": json})
-        return httpx.Response(
-            200,
-            json={
-                "jobs": [
-                    {"job_id": "deadbeef", "completed": False},
-                    {"job_id": "feedface", "completed": True, "exit_code": 7},
-                ]
-            },
-            request=httpx.Request("POST", url),
-        )
+    client.client.client.close()
+    platform = _SyncBackgroundJobPlatformClient()
+    cast(Any, client).client = platform
 
     def read_file(
         _sandbox_id: str,
@@ -188,14 +182,23 @@ def test_sync_get_background_jobs_uses_one_vm_runtime_batch_and_reads_completed_
         content = "stdout" if path.endswith("stdout.log") else "stderr"
         return ReadFileResponse(content=content, size=len(content), truncated=False)
 
-    cast(Any, client)._gateway_idempotent_post = post
     cast(Any, client).read_file = read_file
-    jobs = [_job("sandbox-vm", "deadbeef"), _job("sandbox-vm", "feedface")]
+    jobs = [_job("sandbox-a", "deadbeef"), _job("sandbox-b", "feedface")]
 
     statuses = client.get_background_jobs(jobs, timeout=12)
 
-    assert calls[0]["json"] == {"job_ids": ["deadbeef", "feedface"]}
-    assert calls[0]["timeout"] == 12
+    assert len(platform.calls) == 1
+    method, path, kwargs = platform.calls[0]
+    assert method == "POST"
+    assert path == "/sandbox/background-jobs/status:batchGet"
+    assert kwargs["json"] == {
+        "jobs": [
+            {"sandbox_id": "sandbox-a", "job_id": "deadbeef"},
+            {"sandbox_id": "sandbox-b", "job_id": "feedface"},
+        ]
+    }
+    assert kwargs["timeout"] == 12
+    assert kwargs["idempotent_post"] is True
     assert not statuses[0].completed
     assert statuses[1].completed
     assert statuses[1].exit_code == 7
@@ -205,37 +208,82 @@ def test_sync_get_background_jobs_uses_one_vm_runtime_batch_and_reads_completed_
 
 def test_sync_get_background_jobs_rejects_container_sandboxes() -> None:
     client = SandboxClient(APIClient(api_key="test-key"))
-    cast(Any, client)._auth_cache = _SyncAuthCache(is_vm=False)
+    client.client.client.close()
+    cast(Any, client).client = _SyncBackgroundJobPlatformClient(reject_as_container=True)
 
     with pytest.raises(BatchStatusUnsupportedError, match="only supported for VM"):
         client.get_background_jobs([_job("sandbox-container", "deadbeef")])
 
 
+def test_concurrent_sync_background_waiters_share_one_platform_batch() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncBackgroundJobPlatformClient()
+    cast(Any, client).client = platform
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(
+                cast(Any, client)._background_job_status_batcher.get,
+                key,
+            )
+            for key in [
+                ("sandbox-a", "deadbeef"),
+                ("sandbox-b", "cafebabe"),
+            ]
+        ]
+        for future in futures:
+            assert not future.result().completed
+
+    assert len(platform.calls) == 1
+    assert {(job["sandbox_id"], job["job_id"]) for job in platform.calls[0][2]["json"]["jobs"]} == {
+        ("sandbox-a", "deadbeef"),
+        ("sandbox-b", "cafebabe"),
+    }
+
+
 @pytest.mark.asyncio
-async def test_async_get_background_jobs_uses_vm_runtime_batch() -> None:
+async def test_async_get_background_jobs_uses_one_platform_batch() -> None:
     client = AsyncSandboxClient(api_key="test-key")
     await client.client.aclose()
-    cast(Any, client)._auth_cache = _AsyncAuthCache()
-    calls: list[dict[str, Any]] = []
-
-    async def post(
-        url: str,
-        headers: dict[str, str],
-        timeout: float,
-        json: dict[str, Any],
-    ) -> httpx.Response:
-        calls.append({"url": url, "headers": headers, "timeout": timeout, "json": json})
-        return httpx.Response(
-            200,
-            json={"jobs": [{"job_id": "deadbeef", "completed": False}]},
-            request=httpx.Request("POST", url),
-        )
-
-    cast(Any, client)._gateway_idempotent_post = post
+    platform = _AsyncBackgroundJobPlatformClient()
+    cast(Any, client).client = platform
     try:
-        statuses = await client.get_background_jobs([_job("sandbox-vm", "deadbeef")])
+        statuses = await client.get_background_jobs(
+            [_job("sandbox-a", "deadbeef"), _job("sandbox-b", "feedface")]
+        )
     finally:
         await client.aclose()
 
-    assert calls[0]["json"] == {"job_ids": ["deadbeef"]}
+    assert len(platform.calls) == 1
+    assert platform.calls[0][1] == "/sandbox/background-jobs/status:batchGet"
+    assert platform.calls[0][2]["json"] == {
+        "jobs": [
+            {"sandbox_id": "sandbox-a", "job_id": "deadbeef"},
+            {"sandbox_id": "sandbox-b", "job_id": "feedface"},
+        ]
+    }
     assert not statuses[0].completed
+    assert not statuses[1].completed
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_background_waiters_share_one_platform_batch() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncBackgroundJobPlatformClient()
+    cast(Any, client).client = platform
+    try:
+        statuses = await asyncio.gather(
+            cast(Any, client)._background_job_status_batcher.get(("sandbox-a", "deadbeef")),
+            cast(Any, client)._background_job_status_batcher.get(("sandbox-b", "cafebabe")),
+        )
+    finally:
+        await client.aclose()
+
+    assert all(not status.completed for status in statuses)
+    assert len(platform.calls) == 1
+    assert {(job["sandbox_id"], job["job_id"]) for job in platform.calls[0][2]["json"]["jobs"]} == {
+        ("sandbox-a", "deadbeef"),
+        ("sandbox-b", "cafebabe"),
+    }

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -1,0 +1,241 @@
+"""Focused tests for platform and VM runtime batch status calls."""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional, cast
+
+import httpx
+import pytest
+
+from prime_sandboxes import BatchStatusUnsupportedError
+from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.models import BackgroundJob, ReadFileResponse
+from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
+
+
+def _auth_payload() -> dict[str, Any]:
+    return {
+        "gateway_url": "https://gateway.example.com",
+        "user_ns": "ns",
+        "job_id": "runtime",
+        "token": "token",
+        "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat(),
+    }
+
+
+def _job(sandbox_id: str, job_id: str) -> BackgroundJob:
+    return BackgroundJob(
+        job_id=job_id,
+        sandbox_id=sandbox_id,
+        stdout_log_file=f"/tmp/job_{job_id}.stdout.log",
+        stderr_log_file=f"/tmp/job_{job_id}.stderr.log",
+        exit_file=f"/tmp/job_{job_id}.exit",
+    )
+
+
+class _SyncPlatformClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((method, path, kwargs))
+        sandbox_ids = kwargs["json"]["sandbox_ids"]
+        return {
+            "statuses": [
+                {
+                    "sandbox_id": sandbox_id,
+                    "status": "RUNNING",
+                    "error_type": None,
+                    "error_message": None,
+                    "pending_image_build_id": None,
+                }
+                for sandbox_id in sandbox_ids
+            ],
+            "errors": [],
+        }
+
+
+class _AsyncPlatformClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append((method, path, kwargs))
+        sandbox_ids = kwargs["json"]["sandbox_ids"]
+        return {
+            "statuses": [
+                {
+                    "sandbox_id": sandbox_id,
+                    "status": "RUNNING",
+                    "error_type": None,
+                    "error_message": None,
+                    "pending_image_build_id": None,
+                }
+                for sandbox_id in sandbox_ids
+            ],
+            "errors": [],
+        }
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _SyncAuthCache:
+    def __init__(self, is_vm: bool = True) -> None:
+        self._is_vm = is_vm
+
+    def get_or_refresh(self, _sandbox_id: str) -> dict[str, Any]:
+        return _auth_payload()
+
+    def is_vm(self, _sandbox_id: str) -> bool:
+        return self._is_vm
+
+    def invalidate(self, _sandbox_id: str) -> None:
+        return None
+
+
+class _AsyncAuthCache:
+    def __init__(self, is_vm: bool = True) -> None:
+        self._is_vm = is_vm
+
+    async def get_or_refresh(self, _sandbox_id: str) -> dict[str, Any]:
+        return _auth_payload()
+
+    async def is_vm(self, _sandbox_id: str) -> bool:
+        return self._is_vm
+
+    async def invalidate(self, _sandbox_id: str) -> None:
+        return None
+
+
+def test_concurrent_sync_creation_waits_share_one_platform_batch() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncPlatformClient()
+    cast(Any, client).client = platform
+    cast(Any, client)._is_sandbox_reachable = lambda _sandbox_id: True
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(client.wait_for_creation, sandbox_id)
+            for sandbox_id in ["sandbox-a", "sandbox-b"]
+        ]
+        for future in futures:
+            future.result()
+
+    assert len(platform.calls) == 1
+    method, path, kwargs = platform.calls[0]
+    assert method == "POST"
+    assert path == "/sandbox/status:batchGet"
+    assert set(kwargs["json"]["sandbox_ids"]) == {"sandbox-a", "sandbox-b"}
+    assert kwargs["idempotent_post"] is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_creation_waits_share_one_platform_batch() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncPlatformClient()
+    cast(Any, client).client = platform
+
+    async def reachable(_sandbox_id: str) -> bool:
+        return True
+
+    cast(Any, client)._is_sandbox_reachable = reachable
+    try:
+        await asyncio.gather(
+            client.wait_for_creation("sandbox-a"),
+            client.wait_for_creation("sandbox-b"),
+        )
+    finally:
+        await client.aclose()
+
+    assert len(platform.calls) == 1
+    assert set(platform.calls[0][2]["json"]["sandbox_ids"]) == {"sandbox-a", "sandbox-b"}
+
+
+def test_sync_get_background_jobs_uses_one_vm_runtime_batch_and_reads_completed_output() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    cast(Any, client)._auth_cache = _SyncAuthCache()
+    calls: list[dict[str, Any]] = []
+
+    def post(
+        url: str,
+        headers: dict[str, str],
+        timeout: float,
+        json: dict[str, Any],
+    ) -> httpx.Response:
+        calls.append({"url": url, "headers": headers, "timeout": timeout, "json": json})
+        return httpx.Response(
+            200,
+            json={
+                "jobs": [
+                    {"job_id": "deadbeef", "completed": False},
+                    {"job_id": "feedface", "completed": True, "exit_code": 7},
+                ]
+            },
+            request=httpx.Request("POST", url),
+        )
+
+    def read_file(
+        _sandbox_id: str,
+        path: str,
+        timeout: Optional[int] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+    ) -> ReadFileResponse:
+        content = "stdout" if path.endswith("stdout.log") else "stderr"
+        return ReadFileResponse(content=content, size=len(content), truncated=False)
+
+    cast(Any, client)._gateway_idempotent_post = post
+    cast(Any, client).read_file = read_file
+    jobs = [_job("sandbox-vm", "deadbeef"), _job("sandbox-vm", "feedface")]
+
+    statuses = client.get_background_jobs(jobs, timeout=12)
+
+    assert calls[0]["json"] == {"job_ids": ["deadbeef", "feedface"]}
+    assert calls[0]["timeout"] == 12
+    assert not statuses[0].completed
+    assert statuses[1].completed
+    assert statuses[1].exit_code == 7
+    assert statuses[1].stdout == "stdout"
+    assert statuses[1].stderr == "stderr"
+
+
+def test_sync_get_background_jobs_rejects_container_sandboxes() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    cast(Any, client)._auth_cache = _SyncAuthCache(is_vm=False)
+
+    with pytest.raises(BatchStatusUnsupportedError, match="only supported for VM"):
+        client.get_background_jobs([_job("sandbox-container", "deadbeef")])
+
+
+@pytest.mark.asyncio
+async def test_async_get_background_jobs_uses_vm_runtime_batch() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    cast(Any, client)._auth_cache = _AsyncAuthCache()
+    calls: list[dict[str, Any]] = []
+
+    async def post(
+        url: str,
+        headers: dict[str, str],
+        timeout: float,
+        json: dict[str, Any],
+    ) -> httpx.Response:
+        calls.append({"url": url, "headers": headers, "timeout": timeout, "json": json})
+        return httpx.Response(
+            200,
+            json={"jobs": [{"job_id": "deadbeef", "completed": False}]},
+            request=httpx.Request("POST", url),
+        )
+
+    cast(Any, client)._gateway_idempotent_post = post
+    try:
+        statuses = await client.get_background_jobs([_job("sandbox-vm", "deadbeef")])
+    finally:
+        await client.aclose()
+
+    assert calls[0]["json"] == {"job_ids": ["deadbeef"]}
+    assert not statuses[0].completed

--- a/packages/prime-sandboxes/tests/test_batch_status.py
+++ b/packages/prime-sandboxes/tests/test_batch_status.py
@@ -2,13 +2,14 @@
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from typing import Any, Optional, cast
 
 import pytest
 
 from prime_sandboxes import BatchStatusUnsupportedError
-from prime_sandboxes.core.client import APIClient
-from prime_sandboxes.models import BackgroundJob, ReadFileResponse
+from prime_sandboxes.core.client import APIClient, APIError
+from prime_sandboxes.models import BackgroundJob, BackgroundJobStatus, ReadFileResponse
 from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
 
 
@@ -120,6 +121,35 @@ class _AsyncBackgroundJobPlatformClient:
         return None
 
 
+class _SyncUnsupportedPlatformClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def request(self, _method: str, _path: str, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        raise APIError("HTTP 405: Method Not Allowed")
+
+
+class _AsyncUnsupportedPlatformClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def request(self, _method: str, _path: str, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        raise APIError("HTTP 405: Method Not Allowed")
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _SyncVMAuthCache:
+    def get_or_refresh(self, _sandbox_id: str) -> dict[str, Any]:
+        return {}
+
+    def is_vm(self, _sandbox_id: str) -> bool:
+        return True
+
+
 def test_concurrent_sync_creation_waits_share_one_platform_batch() -> None:
     client = SandboxClient(APIClient(api_key="test-key"))
     client.client.client.close()
@@ -164,6 +194,53 @@ async def test_concurrent_async_creation_waits_share_one_platform_batch() -> Non
 
     assert len(platform.calls) == 1
     assert set(platform.calls[0][2]["json"]["sandbox_ids"]) == {"sandbox-a", "sandbox-b"}
+
+
+def test_sync_creation_batch_capability_falls_back_once_per_client() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncUnsupportedPlatformClient()
+    cast(Any, client).client = platform
+    cast(Any, client).get = lambda sandbox_id: SimpleNamespace(
+        id=sandbox_id,
+        status="RUNNING",
+        error_type=None,
+        error_message=None,
+        pending_image_build_id=None,
+    )
+
+    for _ in range(2):
+        statuses = cast(Any, client)._fetch_sandbox_statuses(["sandbox-a"])
+        assert statuses["sandbox-a"].status == "RUNNING"
+
+    assert platform.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_async_creation_batch_capability_falls_back_once_per_client() -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+    await client.client.aclose()
+    platform = _AsyncUnsupportedPlatformClient()
+    cast(Any, client).client = platform
+
+    async def get_sandbox(sandbox_id: str):
+        return SimpleNamespace(
+            id=sandbox_id,
+            status="RUNNING",
+            error_type=None,
+            error_message=None,
+            pending_image_build_id=None,
+        )
+
+    cast(Any, client).get = get_sandbox
+    try:
+        for _ in range(2):
+            statuses = await cast(Any, client)._fetch_sandbox_statuses(["sandbox-a"])
+            assert statuses["sandbox-a"].status == "RUNNING"
+    finally:
+        await client.aclose()
+
+    assert platform.calls == 1
 
 
 def test_sync_get_background_jobs_uses_one_platform_batch_across_vm_sandboxes() -> None:
@@ -213,6 +290,24 @@ def test_sync_get_background_jobs_rejects_container_sandboxes() -> None:
 
     with pytest.raises(BatchStatusUnsupportedError, match="only supported for VM"):
         client.get_background_jobs([_job("sandbox-container", "deadbeef")])
+
+
+def test_sync_background_batch_capability_falls_back_once_per_client() -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client.client.client.close()
+    platform = _SyncUnsupportedPlatformClient()
+    cast(Any, client).client = platform
+    cast(Any, client)._auth_cache = _SyncVMAuthCache()
+    cast(Any, client).get_background_job = lambda _sandbox_id, job, timeout=None: (
+        BackgroundJobStatus(job_id=job.job_id, completed=False)
+    )
+    jobs = [_job("sandbox-a", "deadbeef"), _job("sandbox-b", "cafebabe")]
+
+    for _ in range(2):
+        statuses = client.get_background_jobs(jobs)
+        assert all(not status.completed for status in statuses)
+
+    assert platform.calls == 1
 
 
 def test_concurrent_sync_background_waiters_share_one_platform_batch() -> None:


### PR DESCRIPTION
## Summary

- add sync and async platform lifecycle batch-status methods for up to 100 sandboxes
- keep one lifecycle coordinator and one background-job coordinator per SDK client, coalescing concurrent waits into bounded batches
- replace bulk creation polling through the list endpoint with targeted lifecycle batch requests
- add sync and async VM-only `get_background_jobs` methods that send one platform request across many sandboxes
- have VM `run_background_job` polling use the shared coordinator while preserving completed-job output tails and timeout behavior
- keep container background-job polling unchanged
- cache platform batch capability per client and use legacy polling when an older deployment returns 404/405

## Testing

- Ruff format and lint checks
- 10 focused batch-status tests, including sync and async cross-sandbox coordinator coalescing and one-time capability fallback
- 176-test offline SDK regression run covering background jobs, retries, transports, egress, models, images, gateway errors, and VM guards

## Dependency and rollout

PrimeIntellect-ai/platform#4412 enables the reduced-request path. The SDK remains compatible before deployment by caching an unsupported response and using legacy polling for that client; no VM image rollout or existing-sandbox drain is required because the platform endpoint fans out through the existing VM `/read-file` API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core creation-wait and background-job polling paths for sync and async clients, but behavior is guarded by capability detection, legacy fallbacks, and a focused test suite for coalescing and errors.
> 
> **Overview**
> Adds **platform batch status APIs** and routes high-volume polling through them so many sandboxes or jobs share bounded HTTP calls instead of list pagination or per-id `get` loops.
> 
> **Lifecycle:** New `get_sandbox_statuses` (sync/async) calls `POST /sandbox/status:batchGet` for up to 100 unique sandbox IDs. `wait_for_creation`, `bulk_wait_for_creation`, and concurrent creation waiters use per-client **request batchers** (short coalescing window, max 100 keys) so overlapping polls merge into one batch. `bulk_wait_for_creation` no longer walks the sandbox list API.
> 
> **VM background jobs:** New `get_background_jobs` batches up to 100 canonical `BackgroundJob` handles via `POST /sandbox/background-jobs/status:batchGet`; completed jobs still load bounded stdout/stderr tails like `get_background_job`. VM `run_background_job` polling uses the shared job batcher; container sandboxes keep per-job polling.
> 
> **Compatibility:** Per-client flags remember when batch endpoints return 404/405 and fall back to legacy per-sandbox `get` or per-job reads without re-probing. New models (`SandboxStatusSnapshot`, batch response types) and `BatchStatusUnsupportedError` are exported; README documents the new flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e660c046364ce46f9d2ed62d5f2506965412dddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->