### PR TITLE
release: cli 0.6.25 + sandbox 0.2.38

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -74,7 +74,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.37"
+__version__ = "0.2.38"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/pyproject.toml
+++ b/packages/prime/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Prime Intellect", email = "contact@primeintellect.ai" }
 ]
 dependencies = [
-    "prime-sandboxes>=0.2.37",
+    "prime-sandboxes>=0.2.38",
     "prime-evals>=0.2.3",
     "prime-traces>=0.0.1",
     "prime-tunnel>=0.1.9",

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.24"
+__version__ = "0.6.25"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

- release `prime-sandboxes` 0.2.38 with batched VM sandbox lifecycle and background-job polling from #852
- release Prime CLI 0.6.25
- require `prime-sandboxes>=0.2.38` from the CLI package

## Testing

- `uv lock --check`
- `uv run pytest packages/prime-sandboxes/tests/test_batch_status.py` (14 passed)
- verified workspace versions: Prime CLI 0.6.25, prime-sandboxes 0.2.38
- Ruff and pre-commit hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime logic changes—only version strings and a dependency minimum bump.
> 
> **Overview**
> **Version-only release** that ships **`prime-sandboxes` 0.2.38** and **`prime` CLI 0.6.25**. The diff only bumps `__version__` in `prime_sandboxes` and `prime_cli`, and raises the CLI dependency to **`prime-sandboxes>=0.2.38`**.
> 
> The **0.2.38** sandbox package (from #852, not in this diff) adds batched VM sandbox lifecycle and background-job polling APIs. This PR wires consumers to that release via semver pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab1cd3470b99f1ad90dcab8bc391e9452f5f918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->