### PR TITLE
fix(sandboxes): use compatible Connect RPC codec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
       working-directory: packages/prime-sandboxes
       run: uv sync --all-extras
 
+    - name: Verify wheel dependency and protobuf compatibility
+      working-directory: packages/prime-sandboxes
+      run: |
+        uv build --wheel --out-dir dist
+        uv venv --python "${{ matrix.python-version }}" .wheel-venv
+        uv pip install --python .wheel-venv/bin/python dist/*.whl
+        .wheel-venv/bin/python tests/connectrpc_install_smoke.py
+
     - name: Run tests
       working-directory: packages/prime-sandboxes
       env:

--- a/packages/prime-sandboxes/pyproject.toml
+++ b/packages/prime-sandboxes/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "aiofiles>=23.0.0",
     "tenacity>=8.0.0",
-    "connect-python>=0.8.0",
+    "connectrpc>=0.11.1,<0.12",
     "protobuf>=6.31.1",
     "pyqwest>=0.6.0",
     "certifi",

--- a/packages/prime-sandboxes/src/prime_sandboxes/_connectrpc.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/_connectrpc.py
@@ -3,60 +3,25 @@
 from importlib.metadata import PackageNotFoundError, version
 
 
-def _distribution_version(name: str) -> str | None:
+def _legacy_connect_python_version() -> str | None:
     try:
-        return version(name)
+        return version("connect-python")
     except PackageNotFoundError:
         return None
 
 
-def _validate_connectrpc_runtime(
-    connectrpc_version: str | None,
-    legacy_version: str | None,
-    imported_version: str | None,
-) -> None:
-    """Reject ambiguous or partially upgraded Connect RPC installations."""
+def _reject_legacy_connect_python(legacy_version: str | None) -> None:
+    """Reject an upgrade that left the old distribution installed."""
     if legacy_version is not None:
-        current = connectrpc_version or "not installed"
         raise RuntimeError(
-            "Conflicting Connect RPC distributions are installed: "
-            f"connectrpc={current} and connect-python={legacy_version}. Both provide the "
-            "'connectrpc' Python package. Uninstall connect-python and reinstall "
-            "prime-sandboxes."
-        )
-    if connectrpc_version is None:
-        raise RuntimeError(
-            "prime-sandboxes requires connectrpc>=0.11.1,<0.12. Reinstall "
-            "prime-sandboxes to restore its RPC dependency."
-        )
-    if imported_version != connectrpc_version:
-        raise RuntimeError(
-            "The imported Connect RPC runtime does not match the installed distribution "
-            f"(imported={imported_version or 'unknown'}, installed={connectrpc_version}). "
-            "Recreate the environment to remove stale package files."
+            f"Legacy connect-python={legacy_version} is still installed. It shares the "
+            "'connectrpc' module path with the required connectrpc distribution. Uninstall "
+            "connect-python and reinstall prime-sandboxes."
         )
 
 
-_CONNECTRPC_VERSION = _distribution_version("connectrpc")
-_LEGACY_CONNECT_PYTHON_VERSION = _distribution_version("connect-python")
+_reject_legacy_connect_python(_legacy_connect_python_version())
 
-# Import only after checking the distribution metadata. The legacy and current
-# distributions both install the same module path, so importing first can load
-# an arbitrary mixture of files in a partially upgraded environment.
-if _LEGACY_CONNECT_PYTHON_VERSION is not None or _CONNECTRPC_VERSION is None:
-    _validate_connectrpc_runtime(
-        _CONNECTRPC_VERSION,
-        _LEGACY_CONNECT_PYTHON_VERSION,
-        imported_version=None,
-    )
-
-from connectrpc import __version__ as _IMPORTED_CONNECTRPC_VERSION  # noqa: E402
 from connectrpc.compat import google_protobuf_binary_codec  # noqa: E402
-
-_validate_connectrpc_runtime(
-    _CONNECTRPC_VERSION,
-    _LEGACY_CONNECT_PYTHON_VERSION,
-    _IMPORTED_CONNECTRPC_VERSION,
-)
 
 GOOGLE_PROTOBUF_BINARY_CODEC = google_protobuf_binary_codec()

--- a/packages/prime-sandboxes/src/prime_sandboxes/_connectrpc.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/_connectrpc.py
@@ -1,0 +1,62 @@
+"""Connect RPC runtime compatibility for the SDK's Google protobuf messages."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _distribution_version(name: str) -> str | None:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+def _validate_connectrpc_runtime(
+    connectrpc_version: str | None,
+    legacy_version: str | None,
+    imported_version: str | None,
+) -> None:
+    """Reject ambiguous or partially upgraded Connect RPC installations."""
+    if legacy_version is not None:
+        current = connectrpc_version or "not installed"
+        raise RuntimeError(
+            "Conflicting Connect RPC distributions are installed: "
+            f"connectrpc={current} and connect-python={legacy_version}. Both provide the "
+            "'connectrpc' Python package. Uninstall connect-python and reinstall "
+            "prime-sandboxes."
+        )
+    if connectrpc_version is None:
+        raise RuntimeError(
+            "prime-sandboxes requires connectrpc>=0.11.1,<0.12. Reinstall "
+            "prime-sandboxes to restore its RPC dependency."
+        )
+    if imported_version != connectrpc_version:
+        raise RuntimeError(
+            "The imported Connect RPC runtime does not match the installed distribution "
+            f"(imported={imported_version or 'unknown'}, installed={connectrpc_version}). "
+            "Recreate the environment to remove stale package files."
+        )
+
+
+_CONNECTRPC_VERSION = _distribution_version("connectrpc")
+_LEGACY_CONNECT_PYTHON_VERSION = _distribution_version("connect-python")
+
+# Import only after checking the distribution metadata. The legacy and current
+# distributions both install the same module path, so importing first can load
+# an arbitrary mixture of files in a partially upgraded environment.
+if _LEGACY_CONNECT_PYTHON_VERSION is not None or _CONNECTRPC_VERSION is None:
+    _validate_connectrpc_runtime(
+        _CONNECTRPC_VERSION,
+        _LEGACY_CONNECT_PYTHON_VERSION,
+        imported_version=None,
+    )
+
+from connectrpc import __version__ as _IMPORTED_CONNECTRPC_VERSION  # noqa: E402
+from connectrpc.compat import google_protobuf_binary_codec  # noqa: E402
+
+_validate_connectrpc_runtime(
+    _CONNECTRPC_VERSION,
+    _LEGACY_CONNECT_PYTHON_VERSION,
+    _IMPORTED_CONNECTRPC_VERSION,
+)
+
+GOOGLE_PROTOBUF_BINARY_CODEC = google_protobuf_binary_codec()

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -46,6 +46,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from ._connectrpc import GOOGLE_PROTOBUF_BINARY_CODEC
 from .core import APIClient, APIError, AsyncAPIClient
 from .exceptions import (
     BatchStatusUnsupportedError,
@@ -364,6 +365,64 @@ def _is_retryable_gateway_error(exc: BaseException) -> bool:
             return False
         return True
     return False
+
+
+def _exception_chain(exc: BaseException) -> List[BaseException]:
+    """Return an exception and its explicit causes without looping."""
+    chain: List[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        chain.append(current)
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def _is_retryable_reachability_error(exc: BaseException) -> bool:
+    """Retry transport readiness failures, but surface local SDK defects."""
+    chain = _exception_chain(exc)
+    if any(
+        isinstance(error, (AttributeError, ImportError, ModuleNotFoundError, TypeError))
+        for error in chain
+    ):
+        return False
+    if any(isinstance(error, SandboxNotRunningError) for error in chain):
+        return False
+
+    for error in chain:
+        if isinstance(error, CommandTimeoutError):
+            return True
+        if isinstance(error, ConnectError):
+            return error.code in {Code.ABORTED, Code.DEADLINE_EXCEEDED, Code.UNAVAILABLE}
+        if isinstance(error, httpx.HTTPStatusError):
+            status = error.response.status_code
+            return status in {408, 409} or status in RETRYABLE_5XX_STATUSES
+        if isinstance(
+            error,
+            GATEWAY_IDEMPOTENT_RETRYABLE_EXCEPTIONS + (httpx.ConnectTimeout, httpx.ReadTimeout),
+        ):
+            return True
+    return False
+
+
+def _reachability_timeout_error(
+    sandbox_id: str,
+    timeout_seconds: float,
+    last_error: BaseException | None,
+) -> SandboxNotRunningError:
+    message = (
+        f"Sandbox {sandbox_id} reached RUNNING but did not become reachable through the "
+        f"gateway within {timeout_seconds:g}s"
+    )
+    if last_error is not None:
+        message += f". Last error: {last_error.__class__.__name__}: {last_error}"
+    return SandboxNotRunningError(
+        sandbox_id,
+        status="RUNNING",
+        error_type="GATEWAY_REACHABILITY_TIMEOUT",
+        message=message,
+    )
 
 
 def _is_retryable_read_file_error(exc: BaseException) -> bool:
@@ -868,11 +927,8 @@ class SandboxClient:
 
     def _is_sandbox_reachable(self, sandbox_id: str, timeout: int = 10) -> bool:
         """Test if a sandbox is reachable by executing a simple echo command"""
-        try:
-            self.execute_command(sandbox_id, "echo 'sandbox ready'", timeout=timeout)
-            return True
-        except Exception:
-            return False
+        self.execute_command(sandbox_id, "echo 'sandbox ready'", timeout=timeout)
+        return True
 
     def _get_sandbox_error_context(self, sandbox_id: str) -> dict:
         """Fetch sandbox error context from the lightweight server endpoint."""
@@ -1173,7 +1229,11 @@ class SandboxClient:
             exit_code: Optional[int] = None
             stream_started = False
 
-            rpc_client = ConnectClientSync(base_url)
+            rpc_client = ConnectClientSync(
+                base_url,
+                codec=GOOGLE_PROTOBUF_BINARY_CODEC,
+                send_compression=None,
+            )
             try:
                 stream = rpc_client.execute_server_stream(
                     request=request,
@@ -1691,17 +1751,26 @@ class SandboxClient:
         """
         consecutive_successes = 0
         image_build_deadline: Optional[float] = None
-        deadline = time.monotonic() + _creation_timeout_seconds(max_attempts)
+        timeout_seconds = _creation_timeout_seconds(max_attempts)
+        deadline = time.monotonic() + timeout_seconds
         poll_index = 0
         reachability_phase = False
+        last_reachability_error: BaseException | None = None
         while time.monotonic() < deadline:
             sandbox = self._sandbox_status_batcher.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if not reachability_phase:
                     reachability_phase = True
-                    deadline = time.monotonic() + _creation_timeout_seconds(max_attempts)
+                    deadline = time.monotonic() + timeout_seconds
                     poll_index = 0
-                if self._is_sandbox_reachable(sandbox_id):
+                try:
+                    reachable = self._is_sandbox_reachable(sandbox_id)
+                except Exception as error:
+                    if not _is_retryable_reachability_error(error):
+                        raise
+                    last_reachability_error = error
+                    reachable = False
+                if reachable:
                     consecutive_successes += 1
                     if consecutive_successes >= stability_checks:
                         return
@@ -1727,10 +1796,11 @@ class SandboxClient:
                     image_build_deadline = time.monotonic() + image_build_timeout_seconds
                 if time.monotonic() >= image_build_deadline:
                     raise SandboxNotRunningError(
-                        sandbox_id, "Timeout waiting for the VM image build"
+                        sandbox_id,
+                        message="Timeout waiting for the VM image build",
                     )
                 time.sleep(10)
-                deadline = time.monotonic() + _creation_timeout_seconds(max_attempts)
+                deadline = time.monotonic() + timeout_seconds
                 poll_index = 0
                 continue
 
@@ -1742,7 +1812,17 @@ class SandboxClient:
                 break
             time.sleep(min(_creation_poll_delay(poll_index), remaining))
             poll_index += 1
-        raise SandboxNotRunningError(sandbox_id, "Timeout during sandbox creation")
+        if reachability_phase:
+            error = _reachability_timeout_error(
+                sandbox_id,
+                timeout_seconds,
+                last_reachability_error,
+            )
+            raise error from last_reachability_error
+        raise SandboxNotRunningError(
+            sandbox_id,
+            message=f"Sandbox did not reach RUNNING within {timeout_seconds:g}s",
+        )
 
     def bulk_wait_for_creation(
         self,
@@ -1758,6 +1838,7 @@ class SandboxClient:
         """
         _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
         final_statuses: Dict[str, str] = {}
+        last_reachability_errors: Dict[str, BaseException] = {}
         image_build_deadline: Optional[float] = None
 
         attempt = 0
@@ -1807,7 +1888,14 @@ class SandboxClient:
                 all_reachable = True
                 for sandbox_id in sandbox_ids:
                     if final_statuses.get(sandbox_id) == "RUNNING":
-                        if not self._is_sandbox_reachable(sandbox_id):
+                        try:
+                            reachable = self._is_sandbox_reachable(sandbox_id)
+                        except Exception as error:
+                            if not _is_retryable_reachability_error(error):
+                                raise
+                            last_reachability_errors[sandbox_id] = error
+                            reachable = False
+                        if not reachable:
                             all_reachable = False
                             final_statuses.pop(sandbox_id, None)
 
@@ -1833,7 +1921,16 @@ class SandboxClient:
             if sandbox_id not in final_statuses:
                 final_statuses[sandbox_id] = "TIMEOUT"
 
-        raise RuntimeError(f"Timeout waiting for sandboxes to be ready. Status: {final_statuses}")
+        detail = ""
+        if last_reachability_errors:
+            errors = {
+                sandbox_id: f"{error.__class__.__name__}: {error}"
+                for sandbox_id, error in last_reachability_errors.items()
+            }
+            detail = f" Last reachability errors: {errors}"
+        raise RuntimeError(
+            f"Timeout waiting for sandboxes to be ready. Status: {final_statuses}.{detail}"
+        )
 
     def upload_file(
         self,
@@ -2236,11 +2333,8 @@ class AsyncSandboxClient:
 
     async def _is_sandbox_reachable(self, sandbox_id: str, timeout: int = 10) -> bool:
         """Test if a sandbox is reachable by executing a simple echo command"""
-        try:
-            await self.execute_command(sandbox_id, "echo 'sandbox ready'", timeout=timeout)
-            return True
-        except Exception:
-            return False
+        await self.execute_command(sandbox_id, "echo 'sandbox ready'", timeout=timeout)
+        return True
 
     async def _get_sandbox_error_context(self, sandbox_id: str) -> dict:
         """Fetch sandbox error context from the lightweight server endpoint."""
@@ -2553,7 +2647,12 @@ class AsyncSandboxClient:
         # control RPCs reuse the same transport so they cannot starve either.
         transport = _live_process_transport()
         http_client = HTTPClient(transport=transport)
-        rpc_client = ConnectClient(base_url, http_client=http_client)
+        rpc_client = ConnectClient(
+            base_url,
+            codec=GOOGLE_PROTOBUF_BINARY_CODEC,
+            send_compression=None,
+            http_client=http_client,
+        )
         request = build_command_session_start_request(
             command,
             working_dir,
@@ -2611,7 +2710,12 @@ class AsyncSandboxClient:
             gateway_url = auth["gateway_url"].rstrip("/")
             base_url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}"
             headers = {"Authorization": f"Bearer {auth['token']}"}
-            rpc_client = ConnectClient(base_url, http_client=http_client)
+            rpc_client = ConnectClient(
+                base_url,
+                codec=GOOGLE_PROTOBUF_BINARY_CODEC,
+                send_compression=None,
+                http_client=http_client,
+            )
             try:
                 await rpc_client.execute_unary(
                     request=request,
@@ -2654,7 +2758,11 @@ class AsyncSandboxClient:
             exit_code: Optional[int] = None
             stream_started = False
 
-            rpc_client = ConnectClient(base_url)
+            rpc_client = ConnectClient(
+                base_url,
+                codec=GOOGLE_PROTOBUF_BINARY_CODEC,
+                send_compression=None,
+            )
             try:
                 stream = rpc_client.execute_server_stream(
                     request=request,
@@ -3177,17 +3285,26 @@ class AsyncSandboxClient:
         """
         consecutive_successes = 0
         image_build_deadline: Optional[float] = None
-        deadline = time.monotonic() + _creation_timeout_seconds(max_attempts)
+        timeout_seconds = _creation_timeout_seconds(max_attempts)
+        deadline = time.monotonic() + timeout_seconds
         poll_index = 0
         reachability_phase = False
+        last_reachability_error: BaseException | None = None
         while time.monotonic() < deadline:
             sandbox = await self._sandbox_status_batcher.get(sandbox_id)
             if sandbox.status == "RUNNING":
                 if not reachability_phase:
                     reachability_phase = True
-                    deadline = time.monotonic() + _creation_timeout_seconds(max_attempts)
+                    deadline = time.monotonic() + timeout_seconds
                     poll_index = 0
-                if await self._is_sandbox_reachable(sandbox_id):
+                try:
+                    reachable = await self._is_sandbox_reachable(sandbox_id)
+                except Exception as error:
+                    if not _is_retryable_reachability_error(error):
+                        raise
+                    last_reachability_error = error
+                    reachable = False
+                if reachable:
                     consecutive_successes += 1
                     if consecutive_successes >= stability_checks:
                         return
@@ -3213,10 +3330,11 @@ class AsyncSandboxClient:
                     image_build_deadline = time.monotonic() + image_build_timeout_seconds
                 if time.monotonic() >= image_build_deadline:
                     raise SandboxNotRunningError(
-                        sandbox_id, "Timeout waiting for the VM image build"
+                        sandbox_id,
+                        message="Timeout waiting for the VM image build",
                     )
                 await asyncio.sleep(10)
-                deadline = time.monotonic() + _creation_timeout_seconds(max_attempts)
+                deadline = time.monotonic() + timeout_seconds
                 poll_index = 0
                 continue
 
@@ -3228,7 +3346,17 @@ class AsyncSandboxClient:
                 break
             await asyncio.sleep(min(_creation_poll_delay(poll_index), remaining))
             poll_index += 1
-        raise SandboxNotRunningError(sandbox_id, "Timeout during sandbox creation")
+        if reachability_phase:
+            error = _reachability_timeout_error(
+                sandbox_id,
+                timeout_seconds,
+                last_reachability_error,
+            )
+            raise error from last_reachability_error
+        raise SandboxNotRunningError(
+            sandbox_id,
+            message=f"Sandbox did not reach RUNNING within {timeout_seconds:g}s",
+        )
 
     async def bulk_wait_for_creation(
         self,
@@ -3245,6 +3373,7 @@ class AsyncSandboxClient:
 
         _validate_unique_batch_values(sandbox_ids, "sandbox_ids")
         final_statuses: Dict[str, str] = {}
+        last_reachability_errors: Dict[str, BaseException] = {}
         image_build_deadline: Optional[float] = None
 
         attempt = 0
@@ -3294,7 +3423,14 @@ class AsyncSandboxClient:
                 all_reachable = True
                 for sandbox_id in sandbox_ids:
                     if final_statuses.get(sandbox_id) == "RUNNING":
-                        if not await self._is_sandbox_reachable(sandbox_id):
+                        try:
+                            reachable = await self._is_sandbox_reachable(sandbox_id)
+                        except Exception as error:
+                            if not _is_retryable_reachability_error(error):
+                                raise
+                            last_reachability_errors[sandbox_id] = error
+                            reachable = False
+                        if not reachable:
                             all_reachable = False
                             final_statuses.pop(sandbox_id, None)
 
@@ -3320,7 +3456,16 @@ class AsyncSandboxClient:
             if sandbox_id not in final_statuses:
                 final_statuses[sandbox_id] = "TIMEOUT"
 
-        raise RuntimeError(f"Timeout waiting for sandboxes to be ready. Status: {final_statuses}")
+        detail = ""
+        if last_reachability_errors:
+            errors = {
+                sandbox_id: f"{error.__class__.__name__}: {error}"
+                for sandbox_id, error in last_reachability_errors.items()
+            }
+            detail = f" Last reachability errors: {errors}"
+        raise RuntimeError(
+            f"Timeout waiting for sandboxes to be ready. Status: {final_statuses}.{detail}"
+        )
 
     async def upload_file(
         self,

--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -388,7 +388,17 @@ def _is_retryable_reachability_error(exc: BaseException) -> bool:
     ):
         return False
     if any(isinstance(error, SandboxNotRunningError) for error in chain):
-        return False
+        # A RUNNING control-plane status can briefly lead gateway registration.
+        # Command execution maps that gateway miss to SandboxNotRunningError for
+        # normal operations, but creation reachability checks must keep polling.
+        return any(
+            (isinstance(error, ConnectError) and error.code == Code.NOT_FOUND)
+            or (
+                isinstance(error, httpx.HTTPStatusError)
+                and _is_gateway_sandbox_not_found(error.response)
+            )
+            for error in chain
+        )
 
     for error in chain:
         if isinstance(error, CommandTimeoutError):

--- a/packages/prime-sandboxes/tests/connectrpc_install_smoke.py
+++ b/packages/prime-sandboxes/tests/connectrpc_install_smoke.py
@@ -1,0 +1,13 @@
+"""Smoke check run against the built prime-sandboxes wheel in a clean environment."""
+
+from importlib.metadata import version
+
+from prime_sandboxes._connectrpc import GOOGLE_PROTOBUF_BINARY_CODEC
+from prime_sandboxes.rpc_command_session import build_command_session_start_request
+
+request = build_command_session_start_request("echo ready", None, None)
+payload = GOOGLE_PROTOBUF_BINARY_CODEC.encode(request)
+decoded = GOOGLE_PROTOBUF_BINARY_CODEC.decode(payload, type(request))
+
+assert decoded == request
+assert version("connectrpc").startswith("0.11.")

--- a/packages/prime-sandboxes/tests/test_command_transport_selection.py
+++ b/packages/prime-sandboxes/tests/test_command_transport_selection.py
@@ -8,6 +8,7 @@ import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
+from prime_sandboxes._connectrpc import GOOGLE_PROTOBUF_BINARY_CODEC
 from prime_sandboxes._proto.command_session import command_session_pb2
 from prime_sandboxes.core.client import APIClient, APIError
 from prime_sandboxes.models import CommandResponse
@@ -149,14 +150,15 @@ async def test_async_execute_command_uses_rest_for_cpu():
 @pytest.mark.asyncio
 async def test_async_open_process_streams_vm_command_session(monkeypatch):
     calls = []
+    client_init_kwargs = {}
     start_kwargs = {}
     input_written = asyncio.Event()
     terminated = asyncio.Event()
 
     class _FakeConnectClient:
-        def __init__(self, address: str, http_client=None):
+        def __init__(self, address: str, **kwargs):
             self.address = address
-            self.http_client = http_client
+            client_init_kwargs.update(kwargs)
 
         def execute_server_stream(self, **kwargs):
             start_kwargs.update(kwargs)
@@ -228,6 +230,8 @@ async def test_async_open_process_streams_vm_command_session(monkeypatch):
         assert [name for name, _ in calls] == ["Start", "SendInput", "SendSignal"]
         assert calls[0][1].stdin is True
         assert start_kwargs["timeout_ms"] == 24 * 60 * 60 * 1000
+        assert client_init_kwargs["codec"] is GOOGLE_PROTOBUF_BINARY_CODEC
+        assert client_init_kwargs["send_compression"] is None
         assert calls[0][1].command.cwd == "/workspace"
         assert calls[0][1].command.envs == {"KEY": "value"}
         assert calls[1][1].session.pid == 42
@@ -298,9 +302,12 @@ def test_auth_cache_stores_vm_flag_for_reuse(tmp_path):
 
 
 def test_sync_connect_execution_collects_stdout_stderr(monkeypatch):
+    client_init_kwargs = {}
+
     class _FakeConnectClient:
-        def __init__(self, address: str):
+        def __init__(self, address: str, **kwargs):
             self.address = address
+            client_init_kwargs.update(kwargs)
 
         def execute_server_stream(self, **_kwargs):
             start_response = getattr(command_session_pb2, "StartResponse")
@@ -337,11 +344,13 @@ def test_sync_connect_execution_collects_stdout_stderr(monkeypatch):
     assert result.stdout == "hello\n"
     assert result.stderr == "warn\n"
     assert result.exit_code == 7
+    assert client_init_kwargs["codec"] is GOOGLE_PROTOBUF_BINARY_CODEC
+    assert client_init_kwargs["send_compression"] is None
 
 
 def test_sync_connect_execution_maps_deadline_to_timeout(monkeypatch):
     class _FakeConnectClient:
-        def __init__(self, _address: str):
+        def __init__(self, _address: str, **_kwargs):
             pass
 
         def execute_server_stream(self, **_kwargs):

--- a/packages/prime-sandboxes/tests/test_connectrpc_compatibility.py
+++ b/packages/prime-sandboxes/tests/test_connectrpc_compatibility.py
@@ -1,0 +1,28 @@
+"""Regression coverage for the Connect RPC package and protobuf runtime boundary."""
+
+import pytest
+
+from prime_sandboxes._connectrpc import (
+    GOOGLE_PROTOBUF_BINARY_CODEC,
+    _validate_connectrpc_runtime,
+)
+from prime_sandboxes.rpc_command_session import build_command_session_start_request
+
+
+def test_google_protobuf_command_request_round_trips() -> None:
+    request = build_command_session_start_request("echo ready", None, None)
+
+    payload = GOOGLE_PROTOBUF_BINARY_CODEC.encode(request)
+    decoded = GOOGLE_PROTOBUF_BINARY_CODEC.decode(payload, type(request))
+
+    assert decoded == request
+
+
+def test_legacy_and_current_connect_distributions_are_rejected() -> None:
+    with pytest.raises(RuntimeError, match="Both provide the 'connectrpc' Python package"):
+        _validate_connectrpc_runtime("0.11.1", "0.9.0", "0.11.1")
+
+
+def test_stale_connect_module_files_are_rejected() -> None:
+    with pytest.raises(RuntimeError, match="does not match the installed distribution"):
+        _validate_connectrpc_runtime("0.11.1", None, "0.9.0")

--- a/packages/prime-sandboxes/tests/test_connectrpc_compatibility.py
+++ b/packages/prime-sandboxes/tests/test_connectrpc_compatibility.py
@@ -4,7 +4,7 @@ import pytest
 
 from prime_sandboxes._connectrpc import (
     GOOGLE_PROTOBUF_BINARY_CODEC,
-    _validate_connectrpc_runtime,
+    _reject_legacy_connect_python,
 )
 from prime_sandboxes.rpc_command_session import build_command_session_start_request
 
@@ -18,11 +18,6 @@ def test_google_protobuf_command_request_round_trips() -> None:
     assert decoded == request
 
 
-def test_legacy_and_current_connect_distributions_are_rejected() -> None:
-    with pytest.raises(RuntimeError, match="Both provide the 'connectrpc' Python package"):
-        _validate_connectrpc_runtime("0.11.1", "0.9.0", "0.11.1")
-
-
-def test_stale_connect_module_files_are_rejected() -> None:
-    with pytest.raises(RuntimeError, match="does not match the installed distribution"):
-        _validate_connectrpc_runtime("0.11.1", None, "0.9.0")
+def test_legacy_connect_distribution_is_rejected() -> None:
+    with pytest.raises(RuntimeError, match="Legacy connect-python=0.9.0"):
+        _reject_legacy_connect_python("0.9.0")

--- a/packages/prime-sandboxes/tests/test_creation_reachability.py
+++ b/packages/prime-sandboxes/tests/test_creation_reachability.py
@@ -1,8 +1,9 @@
 """Creation waits distinguish transient reachability from local SDK failures."""
 
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Callable, cast
 
+import httpx
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -10,6 +11,7 @@ from connectrpc.errors import ConnectError
 from prime_sandboxes.core import APIError
 from prime_sandboxes.core.client import APIClient
 from prime_sandboxes.exceptions import SandboxNotRunningError
+from prime_sandboxes.models import BatchSandboxStatusResponse
 from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
 
 
@@ -33,6 +35,66 @@ def _wrapped_rpc_error(
     error = APIError(f"Connect RPC failed ({code.value}): {message}")
     error.__cause__ = rpc_error
     return error
+
+
+def _rpc_sandbox_not_found_error() -> SandboxNotRunningError:
+    cause = ConnectError(Code.NOT_FOUND, "sandbox not found")
+    error = SandboxNotRunningError(
+        "sandbox-a",
+        status="TERMINATED",
+        error_type="SANDBOX_NOT_FOUND",
+    )
+    error.__cause__ = cause
+    return error
+
+
+def _http_sandbox_not_found_error() -> SandboxNotRunningError:
+    request = httpx.Request("POST", "https://gateway.example.com/ns/job/exec")
+    response = httpx.Response(
+        502,
+        request=request,
+        json={"error": "sandbox_not_found"},
+    )
+    cause = httpx.HTTPStatusError("bad gateway", request=request, response=response)
+    error = SandboxNotRunningError(
+        "sandbox-a",
+        status="TERMINATED",
+        error_type="SANDBOX_NOT_FOUND",
+    )
+    error.__cause__ = cause
+    return error
+
+
+def _running_batch_status(sandbox_ids: list[str]) -> BatchSandboxStatusResponse:
+    return BatchSandboxStatusResponse.model_validate(
+        {
+            "statuses": [
+                {
+                    "sandbox_id": sandbox_id,
+                    "status": "RUNNING",
+                    "error_type": None,
+                    "error_message": None,
+                    "pending_image_build_id": None,
+                }
+                for sandbox_id in sandbox_ids
+            ],
+            "errors": [],
+        }
+    )
+
+
+def _reachable_after(
+    failure_factory: Callable[[], SandboxNotRunningError],
+) -> tuple[Callable[[str], bool], list[str]]:
+    calls: list[str] = []
+
+    def reachable(sandbox_id: str) -> bool:
+        calls.append(sandbox_id)
+        if len(calls) == 1:
+            raise failure_factory()
+        return True
+
+    return reachable, calls
 
 
 def test_sync_wait_surfaces_local_codec_failure_immediately(monkeypatch) -> None:
@@ -75,6 +137,33 @@ def test_sync_wait_reports_last_transient_reachability_error(monkeypatch) -> Non
     assert exc_info.value.error_type == "GATEWAY_REACHABILITY_TIMEOUT"
     assert "connection reset" in str(exc_info.value)
     assert exc_info.value.__cause__ is failure
+
+
+def test_sync_wait_retries_gateway_not_found_during_reachability(monkeypatch) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    cast(Any, client)._sandbox_status_batcher = SimpleNamespace(
+        get=lambda sandbox_id: _running_status(sandbox_id)
+    )
+    reachable, calls = _reachable_after(_rpc_sandbox_not_found_error)
+    cast(Any, client)._is_sandbox_reachable = reachable
+    monkeypatch.setattr("prime_sandboxes.sandbox._creation_poll_delay", lambda _: 0)
+
+    client.wait_for_creation("sandbox-a", max_attempts=1)
+
+    assert calls == ["sandbox-a", "sandbox-a"]
+
+
+def test_sync_bulk_wait_retries_gateway_not_found_during_reachability(monkeypatch) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    cast(Any, client).get_sandbox_statuses = _running_batch_status
+    reachable, calls = _reachable_after(_http_sandbox_not_found_error)
+    cast(Any, client)._is_sandbox_reachable = reachable
+    monkeypatch.setattr("prime_sandboxes.sandbox.time.sleep", lambda _: None)
+
+    statuses = client.bulk_wait_for_creation(["sandbox-a"], max_attempts=2)
+
+    assert statuses == {"sandbox-a": "RUNNING"}
+    assert calls == ["sandbox-a", "sandbox-a"]
 
 
 @pytest.mark.asyncio
@@ -131,3 +220,64 @@ async def test_async_wait_reports_last_transient_reachability_error(monkeypatch)
     assert exc_info.value.error_type == "GATEWAY_REACHABILITY_TIMEOUT"
     assert "connection reset" in str(exc_info.value)
     assert exc_info.value.__cause__ is failure
+
+
+@pytest.mark.asyncio
+async def test_async_wait_retries_gateway_not_found_during_reachability(monkeypatch) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+
+    async def status(sandbox_id: str) -> SimpleNamespace:
+        return _running_status(sandbox_id)
+
+    calls: list[str] = []
+
+    async def reachable(sandbox_id: str) -> bool:
+        calls.append(sandbox_id)
+        if len(calls) == 1:
+            raise _http_sandbox_not_found_error()
+        return True
+
+    cast(Any, client)._sandbox_status_batcher = SimpleNamespace(get=status)
+    cast(Any, client)._is_sandbox_reachable = reachable
+    monkeypatch.setattr("prime_sandboxes.sandbox._creation_poll_delay", lambda _: 0)
+
+    try:
+        await client.wait_for_creation("sandbox-a", max_attempts=1)
+    finally:
+        await client.aclose()
+
+    assert calls == ["sandbox-a", "sandbox-a"]
+
+
+@pytest.mark.asyncio
+async def test_async_bulk_wait_retries_gateway_not_found_during_reachability(
+    monkeypatch,
+) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+
+    async def statuses(sandbox_ids: list[str]) -> BatchSandboxStatusResponse:
+        return _running_batch_status(sandbox_ids)
+
+    calls: list[str] = []
+
+    async def reachable(sandbox_id: str) -> bool:
+        calls.append(sandbox_id)
+        if len(calls) == 1:
+            raise _rpc_sandbox_not_found_error()
+        return True
+
+    cast(Any, client).get_sandbox_statuses = statuses
+    cast(Any, client)._is_sandbox_reachable = reachable
+    monkeypatch.setattr("prime_sandboxes.sandbox.asyncio.sleep", lambda _: _async_noop())
+
+    try:
+        result = await client.bulk_wait_for_creation(["sandbox-a"], max_attempts=2)
+    finally:
+        await client.aclose()
+
+    assert result == {"sandbox-a": "RUNNING"}
+    assert calls == ["sandbox-a", "sandbox-a"]
+
+
+async def _async_noop() -> None:
+    return None

--- a/packages/prime-sandboxes/tests/test_creation_reachability.py
+++ b/packages/prime-sandboxes/tests/test_creation_reachability.py
@@ -1,0 +1,133 @@
+"""Creation waits distinguish transient reachability from local SDK failures."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+
+from prime_sandboxes.core import APIError
+from prime_sandboxes.core.client import APIClient
+from prime_sandboxes.exceptions import SandboxNotRunningError
+from prime_sandboxes.sandbox import AsyncSandboxClient, SandboxClient
+
+
+def _running_status(sandbox_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        sandbox_id=sandbox_id,
+        status="RUNNING",
+        error_type=None,
+        error_message=None,
+        pending_image_build_id=None,
+    )
+
+
+def _wrapped_rpc_error(
+    code: Code,
+    message: str,
+    cause: BaseException | None = None,
+) -> APIError:
+    rpc_error = ConnectError(code, message)
+    rpc_error.__cause__ = cause
+    error = APIError(f"Connect RPC failed ({code.value}): {message}")
+    error.__cause__ = rpc_error
+    return error
+
+
+def test_sync_wait_surfaces_local_codec_failure_immediately(monkeypatch) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    cast(Any, client)._sandbox_status_batcher = SimpleNamespace(
+        get=lambda sandbox_id: _running_status(sandbox_id)
+    )
+    failure = _wrapped_rpc_error(
+        Code.UNAVAILABLE,
+        "StartRequest has no attribute to_binary",
+        AttributeError("StartRequest has no attribute to_binary"),
+    )
+    cast(Any, client)._is_sandbox_reachable = lambda _sandbox_id: (_ for _ in ()).throw(failure)
+    monotonic = iter([0.0, 0.0, 0.0])
+    monkeypatch.setattr("prime_sandboxes.sandbox.time.monotonic", lambda: next(monotonic))
+    monkeypatch.setattr(
+        "prime_sandboxes.sandbox.time.sleep",
+        lambda _delay: pytest.fail("permanent reachability errors must not be retried"),
+    )
+
+    with pytest.raises(APIError, match="to_binary") as exc_info:
+        client.wait_for_creation("sandbox-a", max_attempts=1)
+
+    assert exc_info.value is failure
+
+
+def test_sync_wait_reports_last_transient_reachability_error(monkeypatch) -> None:
+    client = SandboxClient(APIClient(api_key="test-key"))
+    cast(Any, client)._sandbox_status_batcher = SimpleNamespace(
+        get=lambda sandbox_id: _running_status(sandbox_id)
+    )
+    failure = _wrapped_rpc_error(Code.UNAVAILABLE, "connection reset")
+    cast(Any, client)._is_sandbox_reachable = lambda _sandbox_id: (_ for _ in ()).throw(failure)
+    monotonic = iter([0.0, 0.0, 0.0, 2.0])
+    monkeypatch.setattr("prime_sandboxes.sandbox.time.monotonic", lambda: next(monotonic))
+
+    with pytest.raises(SandboxNotRunningError, match="reached RUNNING") as exc_info:
+        client.wait_for_creation("sandbox-a", max_attempts=1)
+
+    assert exc_info.value.error_type == "GATEWAY_REACHABILITY_TIMEOUT"
+    assert "connection reset" in str(exc_info.value)
+    assert exc_info.value.__cause__ is failure
+
+
+@pytest.mark.asyncio
+async def test_async_wait_surfaces_local_codec_failure_immediately(monkeypatch) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+
+    async def status(sandbox_id: str) -> SimpleNamespace:
+        return _running_status(sandbox_id)
+
+    failure = _wrapped_rpc_error(
+        Code.UNAVAILABLE,
+        "StartRequest has no attribute to_binary",
+        AttributeError("StartRequest has no attribute to_binary"),
+    )
+
+    async def unreachable(_sandbox_id: str) -> bool:
+        raise failure
+
+    cast(Any, client)._sandbox_status_batcher = SimpleNamespace(get=status)
+    cast(Any, client)._is_sandbox_reachable = unreachable
+    monkeypatch.setattr("prime_sandboxes.sandbox._creation_timeout_seconds", lambda _: 0.001)
+
+    try:
+        with pytest.raises(APIError, match="to_binary") as exc_info:
+            await client.wait_for_creation("sandbox-a", max_attempts=1)
+    finally:
+        await client.aclose()
+
+    assert exc_info.value is failure
+
+
+@pytest.mark.asyncio
+async def test_async_wait_reports_last_transient_reachability_error(monkeypatch) -> None:
+    client = AsyncSandboxClient(api_key="test-key")
+
+    async def status(sandbox_id: str) -> SimpleNamespace:
+        return _running_status(sandbox_id)
+
+    failure = _wrapped_rpc_error(Code.UNAVAILABLE, "connection reset")
+
+    async def unreachable(_sandbox_id: str) -> bool:
+        raise failure
+
+    cast(Any, client)._sandbox_status_batcher = SimpleNamespace(get=status)
+    cast(Any, client)._is_sandbox_reachable = unreachable
+    monkeypatch.setattr("prime_sandboxes.sandbox._creation_timeout_seconds", lambda _: 0.001)
+
+    try:
+        with pytest.raises(SandboxNotRunningError, match="reached RUNNING") as exc_info:
+            await client.wait_for_creation("sandbox-a", max_attempts=1)
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.error_type == "GATEWAY_REACHABILITY_TIMEOUT"
+    assert "connection reset" in str(exc_info.value)
+    assert exc_info.value.__cause__ is failure

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-12T18:00:50.512194Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -352,16 +352,16 @@ wheels = [
 ]
 
 [[package]]
-name = "connect-python"
-version = "0.8.1"
+name = "connectrpc"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf-py" },
     { name = "pyqwest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/8d/e04954dacc3c32c2f858a115b2b989ed6cccefc3835fb440bb12dcb468c2/connect_python-0.8.1.tar.gz", hash = "sha256:0d36c9cfe050661f8f167afcfff8df622805a4f348961d0d8fab630c96f0bdab", size = 39292, upload-time = "2026-01-27T05:00:02.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b5/63e14ab9d4d4cc58818562db4120a35fa7454e3035633da41bdc6b712abd/connectrpc-0.11.1.tar.gz", hash = "sha256:18277f7838847b4271ca38d40c7d2387b5a2ea6a29f240689c19e1ec84aaff66", size = 46222, upload-time = "2026-07-15T06:33:31.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/e4/e36a6d0450493e2b940086ebe94394381803b2b09c97e8f8e34230bcaa99/connect_python-0.8.1-py3-none-any.whl", hash = "sha256:bfe31fb3d90c2a6715fc2996fa4bd5c98dfdccd81e47ac232c9d03aadd666be1", size = 54902, upload-time = "2026-01-27T05:00:01.18Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ac/aa647675812cd075f2cb9acb00d62f4f2cbcbc6736049a62342b7371ce5b/connectrpc-0.11.1-py3-none-any.whl", hash = "sha256:8a52e2e92a485fa9681c1101a79a5ebeb31807e3ea3d5aabd41f484a6398bc7b", size = 64991, upload-time = "2026-07-15T06:33:29.396Z" },
 ]
 
 [[package]]
@@ -1451,7 +1451,7 @@ source = { editable = "packages/prime-sandboxes" }
 dependencies = [
     { name = "aiofiles" },
     { name = "certifi" },
-    { name = "connect-python" },
+    { name = "connectrpc" },
     { name = "httpx" },
     { name = "protobuf" },
     { name = "pydantic" },
@@ -1471,7 +1471,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "certifi" },
-    { name = "connect-python", specifier = ">=0.8.0" },
+    { name = "connectrpc", specifier = ">=0.11.1,<0.12" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "protobuf", specifier = ">=6.31.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -1612,6 +1612,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "protobuf-py"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py-ext", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ed/02fd902d9c51b7ff53dfc9a745eb11490722edfd30073af889e171f07b8e/protobuf_py-0.1.1.tar.gz", hash = "sha256:6bd08ac4d8f1661965bbe2685429d79043704cdd1ee720a7a89617331742240b", size = 133525, upload-time = "2026-06-24T19:02:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/00/1b3775aca1c70e3007e06ef5996f6bb9b3a32341eb0cce3ffb6effad8dec/protobuf_py-0.1.1-py3-none-any.whl", hash = "sha256:efc4f50f275ed6dae10a1f30bb81ad1a75368557b3ff22a532b7a472050368f1", size = 181656, upload-time = "2026-06-24T19:01:29.556Z" },
+]
+
+[[package]]
+name = "protobuf-py-ext"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/6dc9ccff1e8159eb9a144e6d3c4acfd2211cd4fcd20c34fe9155d17d6a7f/protobuf_py_ext-0.1.1.tar.gz", hash = "sha256:e85bfdfdb3ed50634db8ccc7429dd9286520109489c735463971a418707b4fef", size = 31912, upload-time = "2026-06-24T19:02:16.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/2b5d62a60a2e0d88ecde1ae98db3132bcd2672fb39c8d581b82b34ac0bd8/protobuf_py_ext-0.1.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:310039e03cb15181781a0b78017419f6d4ee302e988c3c70b87f1facdf05532d", size = 306008, upload-time = "2026-06-24T19:01:31.399Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d6/73c06bb4cac2e04c0adc154965fe8b6520224bd737fd7e73bba405056321/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ec8348d1ba045f79b2fedd14e40cca36f2a41b52f2c4fdf55a60c58add2353", size = 314769, upload-time = "2026-06-24T19:01:32.89Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c5/e4e6bc6096b66d1c82639a1b501147f16ee65d32567304b987d002e2c666/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:182798e4861aba72d05855bd06febe4926aa7265e6f444a1b8af5252beee4f7e", size = 328122, upload-time = "2026-06-24T19:01:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/1d792a40d0f0a0f914f1dfa8bb5e9573ca0ecd5fe5cecf80d77193212abd/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9eb25c3a329c0551cc86b209a5e5d8ecb8d834b9924a3aa019377853a703b6d3", size = 492338, upload-time = "2026-06-24T19:01:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/5ad329223c905e5c530cae38ae24cde3584d8ab7e09457f2a01afce80e60/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aaecbde82bef10c7c40578cbb61b7a19896bf7fa450972050a3bb302acb7d5d6", size = 541578, upload-time = "2026-06-24T19:01:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c7/01bd8a8bfe2df4b07aafac12ccfb7b7ebe2303f65296a9e02fcafa28ff3e/protobuf_py_ext-0.1.1-cp310-abi3-win_amd64.whl", hash = "sha256:6b0c615c48e95acc53cf33e9310eeaff8b30d2d7555bf93e7bca8fb4f40e9a5c", size = 251319, upload-time = "2026-06-24T19:01:38.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/914065538b5db54b6a920b5af38c1ef142252ea1eea711820435fa259fac/protobuf_py_ext-0.1.1-cp310-abi3-win_arm64.whl", hash = "sha256:72956cd0af5dee24b41c6f5ba5e42622d17e6d555002b5efc1634e27a1446de2", size = 241635, upload-time = "2026-06-24T19:01:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/0b5d73cab815fd50615cb87a02e04e8332f9e27380c890aba1459cf7e919/protobuf_py_ext-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6f0cd58620f415a3534d195358338f4999a774e12510f91c592b38d13d37388", size = 304903, upload-time = "2026-06-24T19:01:41.796Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/14c120b9ac36a0e11bb05e482fa6ae322de583a8e1068e4859035c289947/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21572764f625d829604fc4d83635f533f35775f11c6da142345b3f3c8d64bd09", size = 316148, upload-time = "2026-06-24T19:01:43.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7c00a1a9783c3ba74f6b2f5d2f049f09037bbd489c465c09a34f32fb611b/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f14f00c2678bfbe7ad46f057b9f9938c1677bcf39e405e163e272c6f9814b8", size = 326458, upload-time = "2026-06-24T19:01:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/81fa50c0d6c4d664e5be6d0a3c4f2c7edfef87ab12d0bac764abca1f2955/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1610865622e2e27568277ca63d8d2d23dcc55eaa767398865c21539ddf4ce24d", size = 493596, upload-time = "2026-06-24T19:01:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/3183cf6e4de62846c20549654a1d573dae51ca06aaf7fed06accdfab74f6/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8995efba9476e1ea18ef9873306871dba697308994bc2766558fec3387acc3de", size = 539656, upload-time = "2026-06-24T19:01:48.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/6c/09841f3dbe7c3d4b3f2779f8f2832ac23fb96ac8ab71674e91af732cf9ff/protobuf_py_ext-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba61d49dace8f874361583030a7c48139b42eb37c9ffbb1e7e8a227a51576f44", size = 305017, upload-time = "2026-06-24T19:01:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/52/43/e450b5e202f6715274acc9acd9f9769908cbdeab861a53c798fcbd467d35/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a9c2f026096ca4c595c89a297067ef371e241d3ff8e1f6d7c779aa8419cdca7", size = 316215, upload-time = "2026-06-24T19:01:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5c/23e79b35f1b5755b9bdc0c0c9b8cd8abababaef1a1639608d8a96bb61a9d/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf78707a040b9294e5e1ec4a1875f0046acfe52e92150cea27de4e9fc9db39bb", size = 326419, upload-time = "2026-06-24T19:01:52.93Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/de/5493de0ec12920a3b1dd72608ce0c1e8cdb7e0eb9e87accaecc5216df29e/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae4373845cbb85bdade3ef5368cc2f4b5f80bf173383afc1ab063f95644e5599", size = 493734, upload-time = "2026-06-24T19:01:54.301Z" },
+    { url = "https://files.pythonhosted.org/packages/98/89/31da55b414e6332aad11d858e9a86bd36fbb324f52fa3fc6d8f1c57840a9/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2a4cc478eef7a2acc1daaebcde479a3ac2396d47e6bdc7e776ca4c4147ba8b4c", size = 539703, upload-time = "2026-06-24T19:01:55.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
prime-sandboxes declared the legacy connect-python distribution while its command messages use Google's protobuf runtime, so Connect RPC 0.11's default codec could fail locally with a missing to_binary method and wait_for_creation would hide that failure behind a roughly 115-second timeout. This migrates the package to connectrpc 0.11.1, selects its Google protobuf codec for every command RPC, and rejects ambiguous legacy/current installations. Creation waits now retry only transient transport and readiness failures, surface local SDK defects immediately, and report the final gateway error when RUNNING sandboxes stay unreachable. Regression tests and a clean-wheel CI smoke test cover protobuf encoding, transport configuration, dependency resolution, and synchronous and asynchronous timeout behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM command RPC encoding and sandbox creation wait semantics; misconfiguration could break VM commands, though dependency validation and new tests reduce rollout risk.
> 
> **Overview**
> **prime-sandboxes** switches its RPC dependency from legacy `connect-python` to **`connectrpc` 0.11.1** and wires VM command RPCs through the **Google protobuf binary codec**, fixing encoding mismatches that could fail locally (e.g. missing `to_binary`) while creation waits swallowed errors behind long timeouts.
> 
> A new **`_connectrpc`** bootstrap validates installs: it rejects coexisting `connect-python`/`connectrpc`, missing packages, and stale mixed module trees, and exports **`GOOGLE_PROTOBUF_BINARY_CODEC`** for all **`ConnectClient`** / **`ConnectClientSync`** command session paths (with **`send_compression=None`**).
> 
> **Creation and bulk creation waits** no longer treat every reachability failure as silent “not ready”: transient gateway/transport errors retry, **local defects** (`AttributeError`, import/type errors) fail fast, and timeouts after **RUNNING** raise **`GATEWAY_REACHABILITY_TIMEOUT`** with the last error chained. CI adds a **clean-wheel install smoke test** for protobuf round-trip; unit tests cover codec wiring, runtime validation, and sync/async wait behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d6b5bdfae77719ac39838bf742b73f45a998d15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->