### PR TITLE
release: cli 0.6.26 + sandbox 0.2.39

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/__init__.py
@@ -79,7 +79,7 @@ from .models import (
 from .process import AsyncSandboxProcess
 from .sandbox import AsyncSandboxClient, AsyncTemplateClient, SandboxClient, TemplateClient
 
-__version__ = "0.2.38"
+__version__ = "0.2.39"
 
 # Deprecated alias for backward compatibility
 TimeoutError = APITimeoutError

--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.25"
+__version__ = "0.6.26"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
## Summary

- release `prime-sandboxes` 0.2.39 with typed image listing from #855 and the Connect RPC compatibility and sandbox-reachability fixes from #854
- release Prime CLI 0.6.26 with `prime images list` backed by the typed sandbox SDK API
- publish the already-declared `prime-sandboxes>=0.2.39` CLI dependency floor

This PR changes only the two package version strings. The main release risk comes from the sandbox SDK changes already reviewed in #854: VM command RPC encoding now uses the compatible Google protobuf codec, and creation waits surface local SDK failures instead of hiding them behind readiness timeouts. The image-listing path was validated against the live API for personal scope; the available key did not have permission to validate a successful platform-scope response.

## Testing

- `uv lock --check`
- 87 focused SDK and CLI image-list tests
- 19 Connect RPC, command transport, and creation-reachability tests
- clean-wheel Connect RPC protobuf smoke test
- built `prime==0.6.26` and `prime-sandboxes==0.2.39` artifacts
- Ruff checks passed
