### PR TITLE
fix: render rollout section titles as literal text

### DIFF
--- a/packages/prime/src/prime_lab_app/eval_screen.py
+++ b/packages/prime/src/prime_lab_app/eval_screen.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
-from rich.markup import escape
 from rich.text import Text
 from textual import events, on, work
 from textual.app import ComposeResult
@@ -1291,7 +1290,8 @@ class RolloutViewer(Container):
         )
         return Collapsible(
             *children,
-            title=escape(section.title),
+            # Textual accepts Rich Text titles, but annotates this parameter as str.
+            title=cast(str, Text(section.title)),
             collapsed=collapsed,
             classes=section.classes,
         )

--- a/packages/prime/tests/test_lab_view.py
+++ b/packages/prime/tests/test_lab_view.py
@@ -147,7 +147,7 @@ from prime_lab_app.environment_screen import (
     WorkspaceScreen,
 )
 from prime_lab_app.eval_markdown import MathMarkdown, make_math_parser
-from prime_lab_app.eval_records import LazyRunResults, LocalEvalRun
+from prime_lab_app.eval_records import HistorySectionData, LazyRunResults, LocalEvalRun
 from prime_lab_app.eval_render import compute_run_overview_stats, history_groups
 from prime_lab_app.eval_screen import (
     HostedEvalSamplesScreen,
@@ -1608,6 +1608,17 @@ def test_rollout_viewer_escapes_xml_in_markdown_body() -> None:
     assert [(child.type, child.content) for child in inline.children or []] == [
         ("text", "<answer>hello endpoint</answer>")
     ]
+
+
+def test_rollout_viewer_treats_section_titles_as_literal_text() -> None:
+    title = "tool 2  bash  ... [SUPABASE_URL=http://kong:8000 SUPABASE_ANO..."
+    viewer = RolloutViewer([])
+
+    section = viewer._make_section(
+        HistorySectionData(title=title, body="output", column="completion")
+    )
+
+    assert str(section.title) == title
 
 
 def test_rollout_tool_calls_use_non_error_palette() -> None:


### PR DESCRIPTION
Rollout section titles currently pass through Rich's markup escape function before Textual parses them. The escape function does not handle truncated uppercase bracket sequences such as `[SUPABASE_URL=http://...`, so selecting a rollout with one of these previews raises `MarkupError`.

This change passes titles to Textual as literal Rich Text at the shared section renderer. This protects all dynamic section titles, including nested tool-output previews. A regression test covers the reported truncated Docker environment preview.

Testing:

- `ruff check .`
- `ty check packages/prime/src/`
- `pytest packages/prime/tests/test_lab_view.py -q`
- `pytest packages/prime/tests -q`

Closes #846