### PR TITLE
fix(prime-sandboxes): stream file transfers

### DIFF
--- a/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
+++ b/packages/prime-sandboxes/src/prime_sandboxes/sandbox.py
@@ -1,6 +1,7 @@
 """Sandbox client implementations."""
 
 import asyncio
+import contextlib
 import functools
 import json
 import os
@@ -8,6 +9,7 @@ import random
 import re
 import shlex
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -187,6 +189,11 @@ MAX_409_RETRIES = 4
 RETRY_409_BASE_DELAY = 0.25  # 250ms, 500ms, 1000ms, 2000ms with exponential backoff
 MAX_GATEWAY_ATTEMPTS = MAX_409_RETRIES + 1
 
+# Keep file transfers bounded in memory. This is deliberately an internal
+# implementation detail: upload_file/download_file continue to accept paths,
+# while upload_bytes/read_file remain available for callers that need bytes.
+GATEWAY_TRANSFER_CHUNK_SIZE = 16 * 1024 * 1024
+
 # Refresh cached gateway auth this many seconds before its reported expiry.
 AUTH_REFRESH_MARGIN_SECONDS = 60
 
@@ -198,6 +205,17 @@ JOB_OUTPUT_TAIL_BYTES = 10 * 1024 * 1024
 # adding a persistent worker to the client lifecycle.
 MAX_STATUS_BATCH_SIZE = 100
 STATUS_BATCH_WINDOW_SECONDS = 0.025
+
+
+def _rewind_upload_files(files: Optional[Dict[str, Any]]) -> None:
+    """Reset multipart file objects before each low-level request retry."""
+    if not files:
+        return
+    for value in files.values():
+        file = value[1] if isinstance(value, tuple) and len(value) > 1 else value
+        if hasattr(file, "seek"):
+            file.seek(0)
+
 
 # Creation status-poll pacing. Sandbox creation is polled with exponential
 # backoff plus jitter rather than at a fixed interval
@@ -902,6 +920,7 @@ class SandboxClient:
         params: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
         """Make a POST request to the gateway with retry on connection errors only."""
+        _rewind_upload_files(files)
         with httpx.Client(timeout=timeout) as client:
             return client.post(url, json=json, files=files, params=params, headers=headers)
 
@@ -919,6 +938,33 @@ class SandboxClient:
         if response.status_code in RETRYABLE_5XX_STATUSES:
             response.raise_for_status()
         return response
+
+    @staticmethod
+    @_gateway_retry
+    def _gateway_stream_to_file(
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any],
+        timeout: float,
+        local_file_path: str,
+    ) -> None:
+        """Stream a gateway response to a temporary file with transient retries."""
+        try:
+            with httpx.Client(timeout=timeout) as client:
+                with client.stream("GET", url, params=params, headers=headers) as response:
+                    # Error responses must be read before raising so callers can
+                    # safely include response.text in their APIError messages.
+                    if response.is_error:
+                        response.read()
+                        response.raise_for_status()
+
+                    with open(local_file_path, "wb") as file:
+                        for chunk in response.iter_bytes(GATEWAY_TRANSFER_CHUNK_SIZE):
+                            file.write(chunk)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(local_file_path)
+            raise
 
     @staticmethod
     @_read_file_retry
@@ -1955,9 +2001,6 @@ class SandboxClient:
 
         effective_timeout = timeout if timeout is not None else 300
 
-        with open(local_file_path, "rb") as f:
-            file_content = f.read()
-
         reauthed = False
         attempt = 0
         for _ in range(MAX_GATEWAY_ATTEMPTS):
@@ -1965,11 +2008,12 @@ class SandboxClient:
             url = f"{auth['gateway_url']}/{auth['user_ns']}/{auth['job_id']}/upload"
             headers = {"Authorization": f"Bearer {auth['token']}"}
             try:
-                files = {"file": (os.path.basename(local_file_path), file_content)}
-                params = {"path": file_path, "sandbox_id": sandbox_id}
-                response = self._gateway_post(
-                    url, headers=headers, timeout=effective_timeout, files=files, params=params
-                )
+                with open(local_file_path, "rb") as file:
+                    files = {"file": (os.path.basename(local_file_path), file)}
+                    params = {"path": file_path, "sandbox_id": sandbox_id}
+                    response = self._gateway_post(
+                        url, headers=headers, timeout=effective_timeout, files=files, params=params
+                    )
                 response.raise_for_status()
                 return FileUploadResponse.model_validate(response.json())
             except httpx.TimeoutException as e:
@@ -2070,22 +2114,32 @@ class SandboxClient:
 
         reauthed = False
         attempt = 0
+        temp_file_path: Optional[str] = None
         for _ in range(MAX_GATEWAY_ATTEMPTS):
+            temp_file_path = None
             auth = self._auth_cache.get_or_refresh(sandbox_id)
             url = f"{auth['gateway_url']}/{auth['user_ns']}/{auth['job_id']}/download"
             headers = {"Authorization": f"Bearer {auth['token']}"}
             try:
-                response = self._gateway_get(
-                    url, headers=headers, params=params, timeout=effective_timeout
-                )
-                response.raise_for_status()
-
                 dir_path = os.path.dirname(local_file_path)
-                if dir_path:
-                    os.makedirs(dir_path, exist_ok=True)
-
-                with open(local_file_path, "wb") as f:
-                    f.write(response.content)
+                os.makedirs(dir_path or ".", exist_ok=True)
+                temp_file = tempfile.NamedTemporaryFile(
+                    mode="wb",
+                    prefix=f".{os.path.basename(local_file_path)}.",
+                    suffix=".tmp",
+                    dir=dir_path or ".",
+                    delete=False,
+                )
+                temp_file_path = temp_file.name
+                temp_file.close()
+                self._gateway_stream_to_file(
+                    url,
+                    headers=headers,
+                    params=params,
+                    timeout=effective_timeout,
+                    local_file_path=temp_file_path,
+                )
+                os.replace(temp_file_path, local_file_path)
                 return
             except httpx.TimeoutException as e:
                 raise DownloadTimeoutError(sandbox_id, file_path, effective_timeout) from e
@@ -2111,6 +2165,10 @@ class SandboxClient:
                 ) from e
             except Exception as e:
                 raise APIError(f"Download failed: {e.__class__.__name__}: {e}") from e
+            finally:
+                if temp_file_path is not None:
+                    with contextlib.suppress(OSError):
+                        os.unlink(temp_file_path)
 
         raise APIError("Download failed after retries")
 
@@ -2306,6 +2364,7 @@ class AsyncSandboxClient:
         params: Optional[Dict[str, Any]] = None,
     ) -> httpx.Response:
         """Make a POST request to the gateway with retry on connection errors only."""
+        _rewind_upload_files(files)
         gateway_client = self._get_gateway_client()
         return await gateway_client.post(
             url, json=json, files=files, params=params, headers=headers, timeout=timeout
@@ -2325,6 +2384,35 @@ class AsyncSandboxClient:
         if response.status_code in RETRYABLE_5XX_STATUSES:
             response.raise_for_status()
         return response
+
+    @_gateway_retry
+    async def _gateway_stream_to_file(
+        self,
+        url: str,
+        headers: Dict[str, str],
+        params: Dict[str, Any],
+        timeout: float,
+        local_file_path: str,
+    ) -> None:
+        """Stream a gateway response to a temporary file with transient retries."""
+        try:
+            gateway_client = self._get_gateway_client()
+            async with gateway_client.stream(
+                "GET", url, params=params, headers=headers, timeout=timeout
+            ) as response:
+                # Error responses must be read before raising so callers can
+                # safely include response.text in their APIError messages.
+                if response.is_error:
+                    await response.aread()
+                    response.raise_for_status()
+
+                async with aiofiles.open(local_file_path, "wb") as file:
+                    async for chunk in response.aiter_bytes(GATEWAY_TRANSFER_CHUNK_SIZE):
+                        await file.write(chunk)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(local_file_path)
+            raise
 
     @_read_file_retry
     async def _gateway_read_file_get(
@@ -3486,8 +3574,8 @@ class AsyncSandboxClient:
     ) -> FileUploadResponse:
         """Upload a file to a sandbox via gateway (async)
 
-        Uses aiofiles for non-blocking file I/O, then passes content to httpx.
-        File content is loaded into memory, suitable for typical sandbox files.
+        Streams a file object through httpx so file size does not determine
+        client memory usage.
 
         Args:
             sandbox_id: The sandbox ID
@@ -3502,10 +3590,6 @@ class AsyncSandboxClient:
 
         effective_timeout = timeout if timeout is not None else 300
 
-        # Read file asynchronously (non-blocking I/O)
-        async with aiofiles.open(local_file_path, "rb") as f:
-            file_content = await f.read()
-
         reauthed = False
         attempt = 0
         for _ in range(MAX_GATEWAY_ATTEMPTS):
@@ -3514,10 +3598,11 @@ class AsyncSandboxClient:
             url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/upload"
             headers = {"Authorization": f"Bearer {auth['token']}"}
             try:
-                files = {"file": (os.path.basename(local_file_path), file_content)}
-                response = await self._gateway_post(
-                    url, headers=headers, timeout=effective_timeout, files=files, params=params
-                )
+                with open(local_file_path, "rb") as file:
+                    files = {"file": (os.path.basename(local_file_path), file)}
+                    response = await self._gateway_post(
+                        url, headers=headers, timeout=effective_timeout, files=files, params=params
+                    )
                 response.raise_for_status()
                 return FileUploadResponse.model_validate(response.json())
             except httpx.TimeoutException as e:
@@ -3621,25 +3706,34 @@ class AsyncSandboxClient:
 
         reauthed = False
         attempt = 0
+        temp_file_path: Optional[str] = None
         for _ in range(MAX_GATEWAY_ATTEMPTS):
+            temp_file_path = None
             auth = await self._auth_cache.get_or_refresh(sandbox_id)
             gateway_url = auth["gateway_url"].rstrip("/")
             url = f"{gateway_url}/{auth['user_ns']}/{auth['job_id']}/download"
             headers = {"Authorization": f"Bearer {auth['token']}"}
             try:
-                response = await self._gateway_get(
-                    url, headers=headers, params=params, timeout=effective_timeout
-                )
-                response.raise_for_status()
-                content = response.content
-
                 dir_path = os.path.dirname(local_file_path)
-                if dir_path:
-                    await asyncio.to_thread(os.makedirs, dir_path, exist_ok=True)
-
-                # Write file asynchronously (non-blocking I/O)
-                async with aiofiles.open(local_file_path, "wb") as f:
-                    await f.write(content)
+                await asyncio.to_thread(os.makedirs, dir_path or ".", exist_ok=True)
+                temp_file = await asyncio.to_thread(
+                    tempfile.NamedTemporaryFile,
+                    mode="wb",
+                    prefix=f".{os.path.basename(local_file_path)}.",
+                    suffix=".tmp",
+                    dir=dir_path or ".",
+                    delete=False,
+                )
+                temp_file_path = temp_file.name
+                temp_file.close()
+                await self._gateway_stream_to_file(
+                    url,
+                    headers=headers,
+                    params=params,
+                    timeout=effective_timeout,
+                    local_file_path=temp_file_path,
+                )
+                await asyncio.to_thread(os.replace, temp_file_path, local_file_path)
                 return
             except httpx.TimeoutException as e:
                 raise DownloadTimeoutError(sandbox_id, file_path, effective_timeout) from e
@@ -3667,6 +3761,10 @@ class AsyncSandboxClient:
                 ) from e
             except Exception as e:
                 raise APIError(f"Download failed: {e.__class__.__name__}: {e}") from e
+            finally:
+                if temp_file_path is not None:
+                    with contextlib.suppress(OSError):
+                        os.unlink(temp_file_path)
 
         raise APIError("Download failed after retries")
 

--- a/packages/prime-sandboxes/tests/test_streaming_file_operations.py
+++ b/packages/prime-sandboxes/tests/test_streaming_file_operations.py
@@ -1,0 +1,169 @@
+"""Unit tests for bounded-memory gateway file transfers."""
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from prime_sandboxes import APIClient, AsyncSandboxClient, SandboxClient
+from prime_sandboxes import sandbox as sandbox_module
+
+AUTH = {
+    "gateway_url": "https://gateway.example.com",
+    "user_ns": "ns",
+    "job_id": "job",
+    "token": "tok",
+}
+
+
+class _SyncAuthCache:
+    def get_or_refresh(self, _sandbox_id: str):
+        return AUTH
+
+
+class _AsyncAuthCache:
+    async def get_or_refresh(self, _sandbox_id: str):
+        return AUTH
+
+
+class _ChunkedSyncStream(httpx.SyncByteStream):
+    def __iter__(self):
+        yield b"first chunk\n"
+        yield b"second chunk\n"
+
+
+class _ChunkedAsyncStream(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        yield b"first chunk\n"
+        yield b"second chunk\n"
+
+
+def _upload_response() -> httpx.Response:
+    request = httpx.Request("POST", "https://gateway.example.com/upload")
+    return httpx.Response(
+        200,
+        request=request,
+        json={
+            "success": True,
+            "path": "/tmp/uploaded.txt",
+            "size": 12,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+
+def test_sync_upload_passes_file_object_without_reading_into_memory(tmp_path, monkeypatch):
+    local_path = tmp_path / "upload.txt"
+    local_path.write_bytes(b"upload contents")
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client._auth_cache = _SyncAuthCache()
+    captured = {}
+
+    def fake_post(_url, **kwargs):
+        file_object = kwargs["files"]["file"][1]
+        captured["is_bytes"] = isinstance(file_object, bytes)
+        captured["content"] = file_object.read()
+        return _upload_response()
+
+    monkeypatch.setattr(client, "_gateway_post", fake_post)
+
+    result = client.upload_file("sandbox-1", "/tmp/uploaded.txt", str(local_path))
+
+    assert result.success is True
+    assert captured == {"is_bytes": False, "content": b"upload contents"}
+
+
+@pytest.mark.asyncio
+async def test_async_upload_passes_file_object_without_reading_into_memory(tmp_path, monkeypatch):
+    local_path = tmp_path / "upload.txt"
+    local_path.write_bytes(b"upload contents")
+    client = AsyncSandboxClient(api_key="test-key")
+    client._auth_cache = _AsyncAuthCache()
+    captured = {}
+
+    async def fake_post(_url, **kwargs):
+        file_object = kwargs["files"]["file"][1]
+        captured["is_bytes"] = isinstance(file_object, bytes)
+        captured["content"] = file_object.read()
+        return _upload_response()
+
+    monkeypatch.setattr(client, "_gateway_post", fake_post)
+
+    result = await client.upload_file("sandbox-1", "/tmp/uploaded.txt", str(local_path))
+
+    assert result.success is True
+    assert captured == {"is_bytes": False, "content": b"upload contents"}
+    await client.aclose()
+
+
+def test_sync_download_streams_and_replaces_destination_atomically(tmp_path, monkeypatch):
+    destination = tmp_path / "nested" / "download.txt"
+    destination.parent.mkdir()
+    destination.write_bytes(b"old contents")
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, request=request, stream=_ChunkedSyncStream())
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.Client
+
+    def client_factory(*args, **kwargs):
+        return original_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(sandbox_module.httpx, "Client", client_factory)
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client._auth_cache = _SyncAuthCache()
+
+    client.download_file("sandbox-1", "/tmp/remote.txt", str(destination))
+
+    assert destination.read_bytes() == b"first chunk\nsecond chunk\n"
+    assert len(requests) == 1
+    assert list(tmp_path.rglob("*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_async_download_streams_and_replaces_destination_atomically(tmp_path):
+    destination = tmp_path / "nested" / "download.txt"
+    destination.parent.mkdir()
+    destination.write_bytes(b"old contents")
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, request=request, stream=_ChunkedAsyncStream())
+
+    client = AsyncSandboxClient(api_key="test-key")
+    client._auth_cache = _AsyncAuthCache()
+    client._gateway_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    await client.download_file("sandbox-1", "/tmp/remote.txt", str(destination))
+
+    assert destination.read_bytes() == b"first chunk\nsecond chunk\n"
+    assert len(requests) == 1
+    assert list(tmp_path.rglob("*.tmp")) == []
+    await client.aclose()
+
+
+def test_sync_download_keeps_existing_destination_when_gateway_fails(tmp_path, monkeypatch):
+    destination = tmp_path / "download.txt"
+    destination.write_bytes(b"old contents")
+
+    def handler(request):
+        return httpx.Response(404, request=request, text="missing")
+
+    transport = httpx.MockTransport(handler)
+    original_client = httpx.Client
+
+    def client_factory(*args, **kwargs):
+        return original_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(sandbox_module.httpx, "Client", client_factory)
+    client = SandboxClient(APIClient(api_key="test-key"))
+    client._auth_cache = _SyncAuthCache()
+
+    with pytest.raises(sandbox_module.APIError, match="HTTP 404"):
+        client.download_file("sandbox-1", "/tmp/missing.txt", str(destination))
+
+    assert destination.read_bytes() == b"old contents"
+    assert list(tmp_path.rglob("*.tmp")) == []


### PR DESCRIPTION
## Summary

- Stream path-based uploads through open file objects instead of reading the entire file into memory.
- Stream downloads in bounded chunks into a same-directory temporary file, then atomically replace the destination only after the transfer succeeds.
- Rewind multipart file objects before low-level connection retries so a retry always starts at byte zero.
- Add sync and async unit coverage for streaming, atomic replacement, failure cleanup, and file-object uploads.

Fixes #824

## Validation

- `python -m pytest packages/prime-sandboxes/tests -q --ignore=packages/prime-sandboxes/tests/test_file_operations.py --ignore=packages/prime-sandboxes/tests/test_cmd_timeout.py --ignore=packages/prime-sandboxes/tests/test_command_execution.py --ignore=packages/prime-sandboxes/tests/test_sandbox_operations.py` (212 passed)
- `ruff check --config packages/prime-sandboxes/pyproject.toml --select E,F,I ...` (passed)
- `ruff format --config packages/prime-sandboxes/pyproject.toml --check ...` (passed)
- `python -m compileall -q packages/prime-sandboxes/src packages/prime-sandboxes/tests` (passed)

Live sandbox integration tests were not run because they provision resources and require an API key.
