### PR TITLE
Show dashboard link on FFT run dispatch

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -1105,6 +1105,10 @@ def _dispatch_full_finetune_run(
     # shared shell history/CI logs without buying anything for the user.
     console.print(f"[green]Dispatched[/green] hosted run [bold]{result.run_id}[/bold]")
 
+    dashboard_url = f"{app_config.frontend_url}/dashboard/training/{result.run_id}"
+    console.print("\n[cyan]Monitor run at:[/cyan]")
+    console.print(f"  [link={dashboard_url}]{dashboard_url}[/link]")
+
 
 def load_config(path: str) -> RLConfig:
     """Load config from TOML file."""


### PR DESCRIPTION
## Summary
- Print the dashboard link after a full finetune run is dispatched, matching what the LoRA/regular training path already does.

https://linear.app/primeintellect/issue/ENG-5450/prime-cli-display-dashboard-link-on-fft-run-dispatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX change that prints a public dashboard URL after dispatch; no auth, API, or dispatch-path behavior is modified.
> 
> **Overview**
> After a full-finetune hosted run is dispatched, the CLI now prints a clickable dashboard URL (`/dashboard/training/{run_id}`), matching the existing LoRA/regular training path.
> 
> JSON output is unchanged; the link is only shown in the human-readable dispatch message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e093ed1c7e91b6bf0ccf0ce580d07eae739a302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->