### PR TITLE
prime-cli: dispatch full-FT via explicit --full-finetune flag

### DIFF
--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -880,35 +880,36 @@ def _peek_toml(config_path: str) -> Dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _is_full_finetune(cfg: Dict[str, Any]) -> bool:
-    """A config is full-FT iff it carries one of:
+def _validate_full_finetune_deployment(cfg: Dict[str, Any], config_path: str) -> None:
+    """`--full-finetune` dispatch requires an explicit `[deployment]` table
+    sizing the run — either single-node (`num_train_gpus` / `num_infer_gpus`),
+    multi-node (`num_train_nodes` / `num_infer_nodes`), or an explicit
+    `[deployment].type` of `single_node` / `multi_node`.
 
-    - top-level `type = "full_finetune"` (mirrors prime-rl's discriminator)
-    - a `[deployment]` table with a sizing field — either single-node
-      (`num_train_gpus` / `num_infer_gpus`) or multi-node
-      (`num_train_nodes` / `num_infer_nodes`) — or an explicit
-      `[deployment].type` of `single_node` / `multi_node`.
-
-    Previously only the single-node sizing fields triggered detection, so
-    canonical multi-node prime-rl shapes (e.g. `qwen30b_math/rl.toml`,
-    which uses `num_train_nodes` / `num_infer_nodes`) silently fell
-    through to the LoRA dispatch path.
+    Dispatch routing itself is decided purely by the `--full-finetune` CLI
+    flag, not by sniffing the TOML — prime-rl owns the config schema, so the
+    platform-specific dispatch decision belongs on the command line (same as
+    `--image-tag` / `--gpu-type`), not in a `type = "full_finetune"` field
+    inside the file. This check only guards against dispatching a full-FT
+    run the backend can't size.
     """
-    if cfg.get("type") == "full_finetune":
-        return True
     deploy = cfg.get("deployment")
-    if isinstance(deploy, dict):
-        if deploy.get("type") in ("single_node", "multi_node"):
-            return True
-        sizing_keys = (
-            "num_train_gpus",
-            "num_infer_gpus",
-            "num_train_nodes",
-            "num_infer_nodes",
+    sizing_keys = (
+        "num_train_gpus",
+        "num_infer_gpus",
+        "num_train_nodes",
+        "num_infer_nodes",
+    )
+    has_sizing = isinstance(deploy, dict) and (
+        deploy.get("type") in ("single_node", "multi_node") or any(k in deploy for k in sizing_keys)
+    )
+    if not has_sizing:
+        console.print(
+            f"[red]Error:[/red] --full-finetune requires an explicit [deployment] "
+            f"block in {config_path} (num_train_gpus/num_infer_gpus for "
+            "single-node, or num_train_nodes/num_infer_nodes for multi-node)."
         )
-        if any(k in deploy for k in sizing_keys):
-            return True
-    return False
+        raise typer.Exit(1)
 
 
 def _dispatch_full_finetune_run(
@@ -1296,23 +1297,33 @@ def create_run(
             "default (no preference, auto-pick)."
         ),
     ),
+    full_finetune: bool = typer.Option(
+        False,
+        "--full-finetune",
+        "--fft",
+        help=(
+            "Dispatch this config as a full fine-tune on a dedicated cluster "
+            "(every parameter updated) instead of a shared-deployment LoRA "
+            "run. Requires an explicit [deployment] block in the TOML."
+        ),
+    ),
 ) -> None:
     """Launch a Hosted Training run from a config file.
 
     Example:
 
         prime train config.toml
+        prime train config.toml --full-finetune
     """
     validate_output_format(output, console)
 
-    # Peek at the raw TOML BEFORE the strict-schema RLConfig parse so a
-    # full-FT config (`type = "full_finetune"` or a `[deployment]` block
-    # with num_train_gpus/num_infer_gpus) can bypass the LoRA-shared
-    # validators and dispatch on the hosted full-FT endpoint instead.
-    # Backwards-compatible: configs without these markers take the LoRA
-    # path exactly as before.
+    # Dispatch routing is decided purely by --full-finetune, not by
+    # sniffing the TOML for `type`/`[deployment]` — prime-rl owns the
+    # config schema, so a config that validates locally must validate
+    # identically here regardless of which dispatch path it takes.
     raw_cfg = _peek_toml(config_path)
-    if _is_full_finetune(raw_cfg):
+    if full_finetune:
+        _validate_full_finetune_deployment(raw_cfg, config_path)
         _dispatch_full_finetune_run(
             raw_cfg=raw_cfg,
             config_path=config_path,

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -912,6 +912,19 @@ def _validate_full_finetune_deployment(cfg: Dict[str, Any], config_path: str) ->
         raise typer.Exit(1)
 
 
+def _warn_legacy_full_finetune_type(cfg: Dict[str, Any], config_path: str) -> None:
+    """`type = "full_finetune"` used to be how dispatch routing was decided;
+    --full-finetune/--fft now owns that decision entirely, so a leftover
+    `type` key in a full-FT config is dead weight. Warn so configs get
+    cleaned up instead of silently accumulating a field nothing reads."""
+    if "type" in cfg:
+        console.print(
+            f'[yellow]Warning:[/yellow] `type = "{cfg["type"]}"` in {config_path} '
+            "is no longer used — dispatch routing is decided by "
+            "--full-finetune/--fft on the command line. Remove it from the config."
+        )
+
+
 def _dispatch_full_finetune_run(
     *,
     raw_cfg: Dict[str, Any],
@@ -1037,6 +1050,8 @@ def _dispatch_full_finetune_run(
     if isinstance(orch_section, dict):
         _remove_deprecated_config_keys(orch_section)
 
+    _warn_legacy_full_finetune_type(raw_cfg, config_path)
+
     # Strip CLI-only secret-loading keys before shipping the TOML to the
     # backend. `env_file` / `env_files` only meaningfully exist on the
     # caller's filesystem — the hosted pod doesn't see them, and prime-rl
@@ -1045,10 +1060,12 @@ def _dispatch_full_finetune_run(
     # confuses prime-rl (unknown field) or silently sends it chasing
     # phantom paths. `image_tag` is similarly chart-level — the backend
     # parses it off the request body, not the embedded prime-rl config.
+    # `type` is stripped here too rather than left for the backend's
+    # legacy CLI-metadata cleanup to silently absorb.
     config_payload = {
         k: v
         for k, v in raw_cfg.items()
-        if k not in ("env_file", "env_files", "image_tag", "gpu_type")
+        if k not in ("env_file", "env_files", "image_tag", "gpu_type", "type")
     }
 
     payload = build_payload_from_toml(

--- a/packages/prime/src/prime_cli/commands/rl.py
+++ b/packages/prime/src/prime_cli/commands/rl.py
@@ -880,30 +880,48 @@ def _peek_toml(config_path: str) -> Dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _validate_full_finetune_deployment(cfg: Dict[str, Any], config_path: str) -> None:
-    """`--full-finetune` dispatch requires an explicit `[deployment]` table
-    sizing the run — either single-node (`num_train_gpus` / `num_infer_gpus`),
-    multi-node (`num_train_nodes` / `num_infer_nodes`), or an explicit
+def _has_full_finetune_deployment(cfg: Dict[str, Any]) -> bool:
+    """True iff `cfg` carries a `[deployment]` table sizing the run — either
+    single-node (`num_train_gpus` / `num_infer_gpus`), multi-node
+    (`num_train_nodes` / `num_infer_nodes`), or an explicit
     `[deployment].type` of `single_node` / `multi_node`.
 
-    Dispatch routing itself is decided purely by the `--full-finetune` CLI
-    flag, not by sniffing the TOML — prime-rl owns the config schema, so the
-    platform-specific dispatch decision belongs on the command line (same as
-    `--image-tag` / `--gpu-type`), not in a `type = "full_finetune"` field
-    inside the file. This check only guards against dispatching a full-FT
-    run the backend can't size.
+    `[deployment]` is a full-FT-only prime-rl concept: RLConfig (the LoRA
+    schema) has no such field and forbids extras, so its presence is
+    unambiguous full-FT intent even without `--full-finetune` on the
+    command line.
     """
     deploy = cfg.get("deployment")
+    if not isinstance(deploy, dict):
+        return False
+    if deploy.get("type") in ("single_node", "multi_node"):
+        return True
     sizing_keys = (
         "num_train_gpus",
         "num_infer_gpus",
         "num_train_nodes",
         "num_infer_nodes",
     )
-    has_sizing = isinstance(deploy, dict) and (
-        deploy.get("type") in ("single_node", "multi_node") or any(k in deploy for k in sizing_keys)
-    )
-    if not has_sizing:
+    return any(k in deploy for k in sizing_keys)
+
+
+def _is_full_finetune(cfg: Dict[str, Any], *, flag: bool) -> bool:
+    """Dispatch as full-FT if `--full-finetune`/`--fft` was passed, or if
+    the config's `[deployment]` block already sizes the run. Either is
+    sufficient on its own — the flag lets a config without `[deployment]`
+    yet still be routed (and get `_validate_full_finetune_deployment`'s
+    clear error instead of silently landing on the LoRA path).
+    """
+    return flag or _has_full_finetune_deployment(cfg)
+
+
+def _validate_full_finetune_deployment(cfg: Dict[str, Any], config_path: str) -> None:
+    """Full-FT dispatch requires an explicit `[deployment]` table sizing the
+    run. Guards the `--full-finetune`-without-`[deployment]` case — the
+    auto-detect path in `_has_full_finetune_deployment` never reaches here
+    without sizing already present.
+    """
+    if not _has_full_finetune_deployment(cfg):
         console.print(
             f"[red]Error:[/red] --full-finetune requires an explicit [deployment] "
             f"block in {config_path} (num_train_gpus/num_infer_gpus for "
@@ -1321,7 +1339,9 @@ def create_run(
         help=(
             "Dispatch this config as a full fine-tune on a dedicated cluster "
             "(every parameter updated) instead of a shared-deployment LoRA "
-            "run. Requires an explicit [deployment] block in the TOML."
+            "run. Usually unnecessary — a config with a [deployment] block "
+            "is auto-detected as full-FT. Requires an explicit [deployment] "
+            "block in the TOML either way."
         ),
     ),
 ) -> None:
@@ -1334,12 +1354,12 @@ def create_run(
     """
     validate_output_format(output, console)
 
-    # Dispatch routing is decided purely by --full-finetune, not by
-    # sniffing the TOML for `type`/`[deployment]` — prime-rl owns the
-    # config schema, so a config that validates locally must validate
-    # identically here regardless of which dispatch path it takes.
+    # Dispatch routing: --full-finetune/--fft, or an unambiguous
+    # `[deployment]` block (full-FT-only — RLConfig/the LoRA schema has no
+    # such field). No longer sniffs `type` — prime-rl owns the config
+    # schema, so a leftover `type` field is dead weight, not a signal.
     raw_cfg = _peek_toml(config_path)
-    if full_finetune:
+    if _is_full_finetune(raw_cfg, flag=full_finetune):
         _validate_full_finetune_deployment(raw_cfg, config_path)
         _dispatch_full_finetune_run(
             raw_cfg=raw_cfg,

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -8,6 +8,7 @@ from prime_cli.commands.rl import (
     RLConfig,
     _flatten_config_schema,
     _validate_full_finetune_deployment,
+    _warn_legacy_full_finetune_type,
     generate_rl_config_template,
     load_config,
 )
@@ -692,3 +693,31 @@ def test_validate_full_finetune_deployment_empty_deployment_rejected() -> None:
     # `[deployment]` with no recognised sizing fields isn't enough.
     with pytest.raises(typer.Exit):
         _validate_full_finetune_deployment({"deployment": {}}, "rl.toml")
+
+
+def test_warn_legacy_full_finetune_type_warns_on_leftover_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "prime_cli.commands.rl.console.print",
+        lambda *args, **_: printed.append(" ".join(str(a) for a in args)),
+    )
+
+    _warn_legacy_full_finetune_type({"type": "full_finetune"}, "rl.toml")
+
+    assert any("type" in line and "no longer used" in line for line in printed)
+
+
+def test_warn_legacy_full_finetune_type_silent_without_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "prime_cli.commands.rl.console.print",
+        lambda *args, **_: printed.append(" ".join(str(a) for a in args)),
+    )
+
+    _warn_legacy_full_finetune_type({"deployment": {"num_train_gpus": 1}}, "rl.toml")
+
+    assert printed == []

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -7,7 +7,7 @@ from prime_cli.commands.rl import (
     EnvConfig,
     RLConfig,
     _flatten_config_schema,
-    _is_full_finetune,
+    _validate_full_finetune_deployment,
     generate_rl_config_template,
     load_config,
 )
@@ -654,16 +654,12 @@ def test_tailscale_no_auth_key_anywhere_rejected(tmp_path: Path, monkeypatch) ->
         load_config(str(config_path))
 
 
-def test_is_full_finetune_top_level_discriminator() -> None:
-    assert _is_full_finetune({"type": "full_finetune"}) is True
-
-
-def test_is_full_finetune_single_node_gpu_sizing() -> None:
+def test_validate_full_finetune_deployment_single_node_gpu_sizing() -> None:
     cfg = {"deployment": {"num_train_gpus": 4, "num_infer_gpus": 4}}
-    assert _is_full_finetune(cfg) is True
+    _validate_full_finetune_deployment(cfg, "rl.toml")  # does not raise
 
 
-def test_is_full_finetune_multi_node_node_sizing() -> None:
+def test_validate_full_finetune_deployment_multi_node_node_sizing() -> None:
     # Mirrors prime-rl's qwen30b_math/rl.toml — multi-node configs use
     # num_train_nodes/num_infer_nodes instead of the *_gpus variants.
     cfg = {
@@ -673,24 +669,26 @@ def test_is_full_finetune_multi_node_node_sizing() -> None:
             "num_infer_nodes": 2,
         }
     }
-    assert _is_full_finetune(cfg) is True
+    _validate_full_finetune_deployment(cfg, "rl.toml")  # does not raise
 
 
-def test_is_full_finetune_deployment_type_alone() -> None:
-    assert _is_full_finetune({"deployment": {"type": "single_node"}}) is True
-    assert _is_full_finetune({"deployment": {"type": "multi_node"}}) is True
+def test_validate_full_finetune_deployment_type_alone() -> None:
+    _validate_full_finetune_deployment({"deployment": {"type": "single_node"}}, "rl.toml")
+    _validate_full_finetune_deployment({"deployment": {"type": "multi_node"}}, "rl.toml")
 
 
-def test_is_full_finetune_lora_config_rejected() -> None:
-    lora_cfg = {
+def test_validate_full_finetune_deployment_missing_block_rejected() -> None:
+    lora_shaped_cfg = {
         "model": "Qwen/Qwen3.5-4B",
         "max_steps": 50,
         "batch_size": 128,
         "rollouts_per_example": 8,
     }
-    assert _is_full_finetune(lora_cfg) is False
+    with pytest.raises(typer.Exit):
+        _validate_full_finetune_deployment(lora_shaped_cfg, "rl.toml")
 
 
-def test_is_full_finetune_empty_deployment_rejected() -> None:
-    # `[deployment]` with no recognised fields shouldn't flip dispatch.
-    assert _is_full_finetune({"deployment": {}}) is False
+def test_validate_full_finetune_deployment_empty_deployment_rejected() -> None:
+    # `[deployment]` with no recognised sizing fields isn't enough.
+    with pytest.raises(typer.Exit):
+        _validate_full_finetune_deployment({"deployment": {}}, "rl.toml")

--- a/packages/prime/tests/test_rl_config.py
+++ b/packages/prime/tests/test_rl_config.py
@@ -7,6 +7,7 @@ from prime_cli.commands.rl import (
     EnvConfig,
     RLConfig,
     _flatten_config_schema,
+    _is_full_finetune,
     _validate_full_finetune_deployment,
     _warn_legacy_full_finetune_type,
     generate_rl_config_template,
@@ -693,6 +694,31 @@ def test_validate_full_finetune_deployment_empty_deployment_rejected() -> None:
     # `[deployment]` with no recognised sizing fields isn't enough.
     with pytest.raises(typer.Exit):
         _validate_full_finetune_deployment({"deployment": {}}, "rl.toml")
+
+
+def test_is_full_finetune_auto_detects_deployment_without_flag() -> None:
+    cfg = {"deployment": {"num_train_gpus": 1, "num_infer_gpus": 1}}
+    assert _is_full_finetune(cfg, flag=False) is True
+
+
+def test_is_full_finetune_flag_routes_without_deployment() -> None:
+    lora_shaped_cfg = {"model": "Qwen/Qwen3.5-4B"}
+    assert _is_full_finetune(lora_shaped_cfg, flag=True) is True
+
+
+def test_is_full_finetune_lora_config_without_flag_rejected() -> None:
+    lora_cfg = {
+        "model": "Qwen/Qwen3.5-4B",
+        "max_steps": 50,
+        "batch_size": 128,
+        "rollouts_per_example": 8,
+    }
+    assert _is_full_finetune(lora_cfg, flag=False) is False
+
+
+def test_is_full_finetune_empty_deployment_without_flag_rejected() -> None:
+    # `[deployment]` with no recognised sizing fields isn't a signal on its own.
+    assert _is_full_finetune({"deployment": {}}, flag=False) is False
 
 
 def test_warn_legacy_full_finetune_type_warns_on_leftover_type(


### PR DESCRIPTION
Replaces TOML sniffing (`type = "full_finetune"` / `[deployment]` presence) with an explicit `--full-finetune` / `--fft` CLI flag as the dispatch discriminator.

- Keeps the prime-rl config schema free of platform-specific fields — dispatch intent lives on the CLI invocation, same as `--image-tag` / `--gpu-type`
- Fixes silent misrouting: a full-FT config missing its discriminator used to fall through to the LoRA path and hit the wrong validator instead of erroring clearly
- `--full-finetune` still requires an explicit `[deployment]` block, erroring informatively if absent

ENG-5449

https://claude.ai/code/session_011yGRfKqPTj2UHv8j9Fm7Do

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how hosted training runs are dispatched (LoRA vs full-FT), which affects expensive cluster placement; behavior is clearer but users relying on `type` alone must use the flag or `[deployment]`.
> 
> **Overview**
> **`prime train`** now chooses the dedicated full fine-tune path when you pass **`--full-finetune`** / **`--fft`**, or when the TOML has a sized **`[deployment]`** block (single-node GPU fields or multi-node node counts). Top-level **`type = "full_finetune"`** is no longer used for routing.
> 
> Passing the flag without a valid **`[deployment]`** fails fast with a clear error instead of falling through to LoRA validation. Legacy **`type`** keys trigger a warning and are stripped from the payload sent to the backend.
> 
> Tests in **`test_rl_config.py`** cover validation, auto-detect, flag routing, and the legacy warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1736f5f454a59be8f2381f806863be1c1120626c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->