### PR TITLE
release: cli 0.6.28

### DIFF
--- a/packages/prime/src/prime_cli/__init__.py
+++ b/packages/prime/src/prime_cli/__init__.py
@@ -21,7 +21,7 @@ from prime_cli.core import (
     Config,
 )
 
-__version__ = "0.6.27"
+__version__ = "0.6.28"
 
 __all__ = [
     "APIClient",


### PR DESCRIPTION
Version bump for the full-FT dispatch changes in #863.

- --full-finetune/--fft flag, [deployment] auto-detect, dead type field warning

https://claude.ai/code/session_011yGRfKqPTj2UHv8j9Fm7Do

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version constant change with no runtime or API behavior in the diff itself.
> 
> **Overview**
> **Bumps** the published Prime CLI package version from `0.6.27` to **`0.6.28`** in `prime_cli.__version__`.
> 
> This diff is only the version tag; it **releases** the full fine-tuning dispatch work from #863 (e.g. `--full-finetune` / `--fft`, `[deployment]` auto-detect, and warnings for legacy `type` fields)—not new logic in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42a8d134593a950c6b25bddeec4178de7cc3ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->